### PR TITLE
ipython refactor

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -72,7 +72,7 @@ export abstract class BaseKernel implements IKernel {
   /**
    * Get the last parent message (mimick ipykernel's get_parent)
    */
-  get parent(): KernelMessage.IMessage {
+  get parent(): KernelMessage.IMessage | undefined {
     return this._parent;
   }
 
@@ -500,5 +500,5 @@ export abstract class BaseKernel implements IKernel {
   private _parentHeader:
     | KernelMessage.IHeader<KernelMessage.MessageType>
     | undefined = undefined;
-  private _parent: KernelMessage.IMessage;
+  private _parent: KernelMessage.IMessage | undefined = undefined;
 }

--- a/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
@@ -4,8 +4,6 @@ from IPython.core.application import BaseIPythonApplication
 from IPython.core.history import HistoryManager
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.shellapp import InteractiveShellApp
-from IPython.utils.tokenutil import line_at_cursor
-from pyodide_js import loadPackagesFromImports as _load_packages_from_imports
 
 from .display import LiteDisplayHook, LiteDisplayPublisher
 from .kernel import Pyolite
@@ -39,31 +37,6 @@ class Interpreter(InteractiveShell):
             "evalue": str(evalue),
             "traceback": stb,
         }
-
-    def do_complete(self, code, cursor_pos):
-        if cursor_pos is None:
-            cursor_pos = len(code)
-        line, offset = line_at_cursor(code, cursor_pos)
-        line_cursor = cursor_pos - offset
-
-        txt, matches = self.complete("", line, line_cursor)
-        return {
-            "matches": matches,
-            "cursor_end": cursor_pos,
-            "cursor_start": cursor_pos - len(txt),
-            "metadata": {},
-            "status": "ok",
-        }
-
-    async def run(self, code):
-        self._last_traceback = None
-        exec_code = self.transform_cell(code)
-        await _load_packages_from_imports(exec_code)
-        if self.should_run_async(code):
-            self.result = await self.run_cell_async(code, store_history=True)
-        else:
-            self.result = self.run_cell(code, store_history=True)
-        return self.result
 
 
 class LitePythonShellApp(BaseIPythonApplication, InteractiveShellApp):

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -27,15 +27,11 @@ class Pyolite:
 
         txt, matches = self.interpreter.complete("", line, line_cursor)
         return {
-            "parentheader": self._parent_header,
-            "type": "reply",
-            "results": {
-                "matches": matches,
-                "cursor_end": cursor_pos,
-                "cursor_start": cursor_pos - len(txt),
-                "metadata": {},
-                "status": "ok",
-            },
+            "matches": matches,
+            "cursor_end": cursor_pos,
+            "cursor_start": cursor_pos - len(txt),
+            "metadata": {},
+            "status": "ok"
         }
 
     async def run(self, code):
@@ -62,8 +58,4 @@ class Pyolite:
             results["evalue"] = last_traceback["evalue"]
             results["traceback"] = last_traceback["traceback"]
 
-        return {
-            "parentheader": self._parent_header,
-            "type": "reply",
-            "results": results,
-        }
+        return results

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -34,7 +34,7 @@ class Pyolite:
         }
 
     async def run(self, code):
-        self._last_traceback = None
+        self.interpreter._last_traceback = None
         exec_code = self.interpreter.transform_cell(code)
         await _load_packages_from_imports(exec_code)
         if self.interpreter.should_run_async(code):

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -31,7 +31,7 @@ class Pyolite:
             "cursor_end": cursor_pos,
             "cursor_start": cursor_pos - len(txt),
             "metadata": {},
-            "status": "ok"
+            "status": "ok",
         }
 
     async def run(self, code):

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -53,7 +53,7 @@ class Pyolite:
         results["payload"] = self.interpreter.payload_manager.read_payload()
         self.interpreter.payload_manager.clear_payload()
 
-        if self.interpreter._last_traceback is not None:
+        if self.interpreter._last_traceback is None:
             results["status"] = "ok"
         else:
             last_traceback = self.interpreter._last_traceback

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -284,7 +284,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    */
   private async _sendWorkerMessage(type: string, data: any): Promise<any> {
     this._executeDelegate = new PromiseDelegate<any>();
-    this._worker.postMessage({ type, data });
+    this._worker.postMessage({ type, data, parentHeader: this.parentHeader });
     return await this._executeDelegate.promise;
   }
 

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -203,13 +203,7 @@ async function execute(content: any) {
     publishExecutionError(results['ename'], results['evalue'], results['traceback']);
   }
 
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results
-  };
-
-  return reply;
+  return results;
 }
 /**
  * Complete the code submitted by a user.
@@ -219,12 +213,7 @@ async function execute(content: any) {
 function complete(content: any) {
   const res = kernel.complete(content.code, content.cursor_pos);
   const results = formatResult(res);
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results
-  };
-  return reply;
+  return results;
 }
 
 /**
@@ -236,16 +225,10 @@ function commInfo(content: any) {
   const res = kernel.comm_info(content.target_name);
   const results = formatResult(res);
 
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results: {
-      comms: results,
-      status: 'ok'
-    }
+  return {
+    comms: results,
+    status: 'ok'
   };
-
-  return reply;
 }
 
 /**
@@ -257,13 +240,7 @@ function commOpen(content: any) {
   const res = kernel.comm_manager.comm_open(pyodide.toPy(content));
   const results = formatResult(res);
 
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results
-  };
-
-  return reply;
+  return results;
 }
 
 /**
@@ -275,13 +252,7 @@ function commMsg(content: any) {
   const res = kernel.comm_manager.comm_msg(pyodide.toPy(content));
   const results = formatResult(res);
 
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results
-  };
-
-  return reply;
+  return results;
 }
 
 /**
@@ -293,13 +264,7 @@ function commClose(content: any) {
   const res = kernel.comm_manager.comm_close(pyodide.toPy(content));
   const results = formatResult(res);
 
-  const reply = {
-    parentHeader: kernel._parent_header,
-    type: 'reply',
-    results
-  };
-
-  return reply;
+  return results;
 }
 
 /**
@@ -311,7 +276,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   await pyodideReadyPromise;
   const data = event.data;
 
-  let reply;
+  let results;
   const messageType = data.type;
   const messageContent = data.data;
   kernel._parent_header = data.parentHeader;
@@ -319,31 +284,38 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   switch (messageType) {
     case 'execute-request':
       console.log('Perform execution inside worker', data);
-      reply = execute(messageContent);
+      results = execute(messageContent);
       break;
 
     case 'complete-request':
-      reply = complete(messageContent);
+      results = complete(messageContent);
       break;
 
     case 'comm-info-request':
-      reply = commInfo(messageContent);
+      results = commInfo(messageContent);
       break;
 
     case 'comm-open':
-      reply = commOpen(messageContent);
+      results = commOpen(messageContent);
       break;
 
     case 'comm-msg':
-      reply = commMsg(messageContent);
+      results = commMsg(messageContent);
       break;
 
     case 'comm-close':
-      reply = commClose(messageContent);
+      results = commClose(messageContent);
       break;
 
     default:
-      postMessage(reply);
       break;
   }
+
+  const reply = {
+    parentHeader: kernel._parent_header,
+    type: 'reply',
+    results
+  };
+
+  postMessage(reply);
 };

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -197,15 +197,17 @@ async function execute(content: any) {
   interpreter.displayhook.publish_execution_result = publishExecutionResult;
 
   const res = await kernel.run(content.code);
-  const reply = formatResult(res);
+  const results = formatResult(res);
 
-  if (reply['results']['status'] === 'error') {
-    publishExecutionError(
-      reply['results']['ename'],
-      reply['results']['evalue'],
-      reply['results']['traceback']
-    );
+  if (results['status'] === 'error') {
+    publishExecutionError(results['ename'], results['evalue'], results['traceback']);
   }
+
+  const reply = {
+    parentHeader: kernel._parent_header,
+    type: 'reply',
+    results
+  };
 
   return reply;
 }
@@ -216,7 +218,12 @@ async function execute(content: any) {
  */
 function complete(content: any) {
   const res = kernel.complete(content.code, content.cursor_pos);
-  const reply = formatResult(res);
+  const results = formatResult(res);
+  const reply = {
+    parentHeader: kernel._parent_header,
+    type: 'reply',
+    results
+  };
   return reply;
 }
 

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -196,7 +196,7 @@ async function execute(content: any) {
   interpreter.display_pub.update_display_data_callback = updateDisplayDataCallback;
   interpreter.displayhook.publish_execution_result = publishExecutionResult;
 
-  await interpreter.run(content.code);
+  await kernel.run(content.code);
   const results: any = {};
 
   results['payload'] = formatResult(interpreter.payload_manager.read_payload());
@@ -230,7 +230,7 @@ async function execute(content: any) {
  * @param content The incoming message with the code to complete.
  */
 function complete(content: any) {
-  const res = interpreter.do_complete(content.code, content.cursor_pos);
+  const res = kernel.do_complete(content.code, content.cursor_pos);
   const results = formatResult(res);
   const reply = {
     parentheader: content.parentheader,

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -284,7 +284,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   switch (messageType) {
     case 'execute-request':
       console.log('Perform execution inside worker', data);
-      results = execute(messageContent);
+      results = await execute(messageContent);
       break;
 
     case 'complete-request':

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -117,7 +117,7 @@ async function execute(content: any) {
       metadata: formatResult(metadata)
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'execute_result'
     });
@@ -130,7 +130,7 @@ async function execute(content: any) {
       traceback: traceback
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'execute_error'
     });
@@ -141,7 +141,7 @@ async function execute(content: any) {
       wait: formatResult(wait)
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'clear_output'
     });
@@ -154,7 +154,7 @@ async function execute(content: any) {
       transient: formatResult(transient)
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'display_data'
     });
@@ -171,7 +171,7 @@ async function execute(content: any) {
       transient: formatResult(transient)
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'update_display_data'
     });
@@ -183,7 +183,7 @@ async function execute(content: any) {
       text: formatResult(text)
     };
     postMessage({
-      parentHeader: kernel._parent_header,
+      parentHeader: formatResult(kernel._parent_header),
       bundle,
       type: 'stream'
     });
@@ -279,7 +279,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   let results;
   const messageType = data.type;
   const messageContent = data.data;
-  kernel._parent_header = data.parentHeader;
+  kernel._parent_header = pyodide.toPy(data.parentHeader);
 
   switch (messageType) {
     case 'execute-request':
@@ -312,7 +312,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   }
 
   const reply = {
-    parentHeader: kernel._parent_header,
+    parentHeader: data.parentHeader,
     type: 'reply',
     results
   };


### PR DESCRIPTION
1. `run` and `complete` methods are now a part of `Pyolite` class / kernel.
2. reply is now constructed at the end for all messages of type `reply` (except for callbacks inside `execute`)
3. `get_parent` is implemented to access parent headers which enables the use of `Output` widget.