### PR TITLE
Use importhook for patches

### DIFF
--- a/packages/pyolite-kernel/py/pyolite/pyolite/__init__.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/__init__.py
@@ -19,12 +19,7 @@ sys.modules["resource"] = types.ModuleType("resource")
 # This is needed for some Matplotlib backends (webagg, ipympl)
 sys.modules["tornado"] = types.ModuleType("tornados")
 
-from .patches import ensure_matplotlib_patch, ensure_pil_patch
-
-# apply patches for available modules
-ensure_matplotlib_patch()
-ensure_pil_patch()
-
+from .patches import register_patches
 from .display import LiteStream
 from .interpreter import LitePythonShellApp
 
@@ -38,3 +33,5 @@ kernel_instance = ipython_shell.kernel
 
 sys.stdout = stdout_stream
 sys.stderr = stderr_stream
+
+register_patches()

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -21,7 +21,7 @@ def register_patch(module_name, path, method_name, function):
             for item in path.split("."):
                 obj = getattr(obj, item)
         original = getattr(obj, method_name)
-        setattr(obj, "__wrapped__", original)
+        setattr(obj, "__wrapped__", types.MethodType(original, obj))
         setattr(obj, method_name, types.MethodType(function, obj))
         return new_module
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -1,6 +1,7 @@
 import base64
 import os
 from io import BytesIO
+import types
 
 os.environ["MPLBACKEND"] = "AGG"
 
@@ -18,13 +19,10 @@ def register_patch(module_name, path, method_name, function):
         obj = new_module
         if path:
             for item in path.split("."):
-                if hasattr(obj, item):
-                    obj = getattr(obj, item)
-                else:
-                    return None
+                obj = getattr(obj, item)
         original = getattr(obj, method_name)
         setattr(obj, "__wrapped__", original)
-        setattr(obj, method_name, classmethod(function))
+        setattr(obj, method_name, types.MethodType(function, obj))
         return new_module
 
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -8,10 +8,6 @@ from IPython.display import display
 
 from .display import Image
 
-import micropip
-
-await micropip.install("importhook")
-
 import importhook
 
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -14,7 +14,7 @@ import importhook
 
 def register_patch(module_name, path, method_name, function):
     @importhook.on_import(module_name)
-    def on_pil_import(module):
+    def on_import(module):
         new_module = importhook.copy_module(module)
         obj = new_module
         if path:
@@ -22,7 +22,10 @@ def register_patch(module_name, path, method_name, function):
                 obj = getattr(obj, item)
         original = getattr(obj, method_name)
         # Save the original, in case we need it
-        setattr(function, "__wrapped__", original)
+        try:
+            setattr(function, "__wrapped__", original)
+        except Exception:
+            pass
         # Set the new function/method:
         if isinstance(original, types.FunctionType):
             setattr(obj, method_name, function)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -22,6 +22,8 @@ def register_patch(module_name, path, method_name, function):
         obj = new_module
         for item in path.split("."):
             obj = getattr(obj, item)
+        original = getattr(obj, method_name)
+        setattr(obj, "__wrapped__", original)
         setattr(obj, method_name, function)
         return new_module
 
@@ -35,7 +37,7 @@ def matplotlib_show(self):
 
 
 def image_repr_png(self):
-    byte = _old_repr_png(self)
+    byte = self.__wrapped__()
     return base64.b64encode(byte).decode("utf-8")
 
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -9,9 +9,11 @@ from IPython.display import display
 from .display import Image
 
 import micropip
+
 await micropip.install("importhook")
 
 import importhook
+
 
 def register_patch(module_name, path, method_name, function):
     @importhook.on_import(module_name)
@@ -38,5 +40,5 @@ def image_repr_png(self):
 
 
 def register_patches():
-    register_patch('PIL.Image', "Image", "_repr_png_", image_repr_png)
-    register_patch('matplotlib', "pyplot", "show", matplotlib_show)
+    register_patch("PIL.Image", "Image", "_repr_png_", image_repr_png)
+    register_patch("matplotlib", "pyplot", "show", matplotlib_show)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -16,8 +16,9 @@ def register_patch(module_name, path, method_name, function):
     def on_pil_import(module):
         new_module = importhook.copy_module(module)
         obj = new_module
-        for item in path.split("."):
-            obj = getattr(obj, item)
+        if path:
+            for item in path.split("."):
+                obj = getattr(obj, item)
         original = getattr(obj, method_name)
         setattr(obj, "__wrapped__", original)
         setattr(obj, method_name, function)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -18,7 +18,10 @@ def register_patch(module_name, path, method_name, function):
         obj = new_module
         if path:
             for item in path.split("."):
-                obj = getattr(obj, item)
+                if hasattr(obj, item):
+                    obj = getattr(obj, item)
+                else:
+                    return None
         original = getattr(obj, method_name)
         setattr(obj, "__wrapped__", original)
         setattr(obj, method_name, function)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -21,21 +21,28 @@ def register_patch(module_name, path, method_name, function):
             for item in path.split("."):
                 obj = getattr(obj, item)
         original = getattr(obj, method_name)
-        setattr(obj, "__wrapped__", types.MethodType(original, obj))
-        setattr(obj, method_name, types.MethodType(function, obj))
+        # Save the original, in case we need it
+        setattr(function, "__wrapped__", original)
+        # Set the new function/method:
+        if isinstance(original, types.FunctionType):
+            setattr(obj, method_name, function)
+        else:
+            setattr(obj, method_name, types.MethodType(function, obj))
         return new_module
 
 
-def matplotlib_show(self):
+def matplotlib_show(*args, **kwargs):
+    from matplotlib import pyplot
+
     buf = BytesIO()
-    self.savefig(buf, format="png")
+    pyplot.savefig(buf, format="png")
     buf.seek(0)
     display(Image(buf.read()))
-    self.clf()
+    pyplot.clf()
 
 
 def image_repr_png(self):
-    byte = self.__wrapped__()
+    byte = image_repr_png.__wrapped__(self)
     return base64.b64encode(byte).decode("utf-8")
 
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -24,7 +24,7 @@ def register_patch(module_name, path, method_name, function):
                     return None
         original = getattr(obj, method_name)
         setattr(obj, "__wrapped__", original)
-        setattr(obj, method_name, function)
+        setattr(obj, method_name, classmethod(function))
         return new_module
 
 
@@ -43,4 +43,4 @@ def image_repr_png(self):
 
 def register_patches():
     register_patch("PIL.Image", "Image", "_repr_png_", image_repr_png)
-    register_patch("matplotlib", "pyplot", "show", matplotlib_show)
+    register_patch("matplotlib.pyplot", "", "show", matplotlib_show)

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -24,6 +24,7 @@ async function loadPyodideAndPackages() {
     import micropip
     await micropip.install([
       'traitlets',
+      'importhook',
       '${_widgetsnbextensionWheelUrl}',
       '${_nbformatWheelUrl}',
       '${_ipykernelWheelUrl}'


### PR DESCRIPTION
Use importhook to lazily patch needed tweaks.

## References

Possible fix for #235 

## Code changes

Instead of import and patch, use importhook for setting patch on import.

## User-facing changes

No longer need to load all of matplotlib (and all dependencies) on first execution.

## Backwards-incompatible changes

None.