### PR TITLE
add input_request message protocol

### DIFF
--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -201,9 +201,9 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputReply(
-    content: KernelMessage.IInputReplyMsg['content']
-  ): Promise<KernelMessage.IInputRequestMsg['content']> {
+  async inputRequest(
+    content: KernelMessage.IInputRequestMsg['content']
+  ): Promise<KernelMessage.IInputReplyMsg['content']> {
     throw new Error('Not implemented');
   }
 

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -201,7 +201,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void> {
+  inputReply(content: KernelMessage.IInputReplyMsg['content']): void {
     throw new Error('Not implemented');
   }
 

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -197,9 +197,9 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
   }
 
   /**
-   * Send an `input_request` message.
+   * Send an `input_reply` message.
    *
-   * @param content - The content of the request.
+   * @param content - The content of the reply.
    */
   inputReply(content: KernelMessage.IInputReplyMsg['content']): void {
     throw new Error('Not implemented');

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -201,9 +201,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']> {
+  async inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void> {
     throw new Error('Not implemented');
   }
 

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -203,7 +203,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    */
   async inputRequest(
     content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<void> {
+  ): Promise<KernelMessage.IInputReplyMsg['content']> {
     throw new Error('Not implemented');
   }
 

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -201,9 +201,9 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']> {
+  async inputReply(
+    content: KernelMessage.IInputReplyMsg['content']
+  ): Promise<KernelMessage.IInputRequestMsg['content']> {
     throw new Error('Not implemented');
   }
 

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -195,9 +195,9 @@ export abstract class BaseKernel implements IKernel {
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']>;
 
   /**
-   * Send an `input_request` message.
+   * Send an `input_reply` message.
    *
-   * @param content - The content of the request.
+   * @param content - The content of the reply.
    */
   abstract inputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -196,7 +196,7 @@ export abstract class BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  abstract inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void>;
+  abstract inputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 
   /**
    * Send an `comm_open` message.
@@ -259,14 +259,7 @@ export abstract class BaseKernel implements IKernel {
    *
    * @param content The input_request content.
    */
-  protected inputRequest(
-    content: KernelMessage.IInputRequestMsg['content'],
-    parentHeader: any
-  ): void {
-    console.log('parent header from worker');
-    console.log(parentHeader);
-    console.log('this parent header');
-    console.log(this._parentHeader);
+  protected inputRequest(content: KernelMessage.IInputRequestMsg['content']): void {
     const message = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
       channel: 'stdin',
       msgType: 'input_request',

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -259,13 +259,16 @@ export abstract class BaseKernel implements IKernel {
    *
    * @param content The input_request content.
    */
-  protected _inputRequest(content: KernelMessage.IInputRequestMsg['content']): void {
+  protected inputRequest(
+    content: KernelMessage.IInputRequestMsg['content'],
+    parentHeader: any
+  ): void {
     const message = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
       channel: 'stdin',
       msgType: 'input_request',
       // TODO: better handle this
-      session: this._parentHeader?.session ?? '',
-      parentHeader: this._parentHeader,
+      session: parentHeader?.session ?? '',
+      parentHeader,
       content
     });
     this._sendMessage(message);

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -263,12 +263,16 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IInputRequestMsg['content'],
     parentHeader: any
   ): void {
+    console.log('parent header from worker');
+    console.log(parentHeader);
+    console.log('this parent header');
+    console.log(this._parentHeader);
     const message = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
       channel: 'stdin',
       msgType: 'input_request',
       // TODO: better handle this
-      session: parentHeader?.session ?? '',
-      parentHeader,
+      session: this._parentHeader?.session ?? '',
+      parentHeader: this._parentHeader,
       content
     });
     this._sendMessage(message);

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -105,8 +105,8 @@ export abstract class BaseKernel implements IKernel {
       case 'execute_request':
         await this._execute(msg);
         break;
-      case 'input_request':
-        await this._inputRequest(msg);
+      case 'input_reply':
+        await this._inputReply(msg);
         break;
       case 'inspect_request':
         await this._inspect(msg);
@@ -199,9 +199,9 @@ export abstract class BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  abstract inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']>;
+  abstract inputReply(
+    content: KernelMessage.IInputReplyMsg['content']
+  ): Promise<KernelMessage.IInputRequestMsg['content']>;
 
   /**
    * Send an `comm_open` message.
@@ -538,15 +538,15 @@ export abstract class BaseKernel implements IKernel {
   }
 
   /**
-   * Handle an input_request message
+   * Handle an input_reply message
    *
    * @param msg The parent message.
    */
-  private async _inputRequest(msg: KernelMessage.IMessage): Promise<void> {
-    const inputMsg = msg as KernelMessage.IInputRequestMsg;
-    const content = await this.inputRequest(inputMsg.content);
-    const message = KernelMessage.createMessage<KernelMessage.IInputReplyMsg>({
-      msgType: 'input_reply',
+  private async _inputReply(msg: KernelMessage.IMessage): Promise<void> {
+    const inputMsg = msg as KernelMessage.IInputReplyMsg;
+    const content = await this.inputReply(inputMsg.content);
+    const message = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
+      msgType: 'input_request',
       parentHeader: inputMsg.header,
       channel: 'stdin',
       session: msg.header.session,

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -105,8 +105,8 @@ export abstract class BaseKernel implements IKernel {
       case 'execute_request':
         await this._execute(msg);
         break;
-      case 'input_reply':
-        await this._inputReply(msg);
+      case 'input_request':
+        await this._inputRequest(msg);
         break;
       case 'inspect_request':
         await this._inspect(msg);
@@ -199,9 +199,9 @@ export abstract class BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  abstract inputReply(
-    content: KernelMessage.IInputReplyMsg['content']
-  ): Promise<KernelMessage.IInputRequestMsg['content']>;
+  abstract inputRequest(
+    content: KernelMessage.IInputRequestMsg['content']
+  ): Promise<KernelMessage.IInputReplyMsg['content']>;
 
   /**
    * Send an `comm_open` message.
@@ -538,15 +538,15 @@ export abstract class BaseKernel implements IKernel {
   }
 
   /**
-   * Handle an input_reply message
+   * Handle an input_request message
    *
    * @param msg The parent message.
    */
-  private async _inputReply(msg: KernelMessage.IMessage): Promise<void> {
-    const inputMsg = msg as KernelMessage.IInputReplyMsg;
-    const content = await this.inputReply(inputMsg.content);
-    const message = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
-      msgType: 'input_request',
+  private async _inputRequest(msg: KernelMessage.IMessage): Promise<void> {
+    const inputMsg = msg as KernelMessage.IInputRequestMsg;
+    const content = await this.inputRequest(inputMsg.content);
+    const message = KernelMessage.createMessage<KernelMessage.IInputReplyMsg>({
+      msgType: 'input_reply',
       parentHeader: inputMsg.header,
       channel: 'stdin',
       session: msg.header.session,

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -105,6 +105,9 @@ export abstract class BaseKernel implements IKernel {
       case 'execute_request':
         await this._execute(msg);
         break;
+      case 'input_reply':
+        this.inputReply(msg.content as KernelMessage.IInputReplyMsg['content']);
+        break;
       case 'inspect_request':
         await this._inspect(msg);
         break;

--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -77,7 +77,7 @@ export class Kernels implements IKernels {
           }
 
           // TODO Find a better solution for this?
-          // input-reply is asynchrone, must not be processed like other messages
+          // input-reply is asynchronous, must not be processed like other messages
           if (msg.header.msg_type === 'input_reply') {
             kernel.handleMessage(msg);
           } else {

--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -75,7 +75,14 @@ export class Kernels implements IKernels {
           } else {
             return;
           }
-          void processMsg(msg);
+
+          // TODO Find a better solution for this?
+          // input-reply is asynchrone, must not be processed like other messages
+          if (msg.header.msg_type === 'input_reply') {
+            kernel.handleMessage(msg);
+          } else {
+            void processMsg(msg);
+          }
         }
       );
 

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -124,9 +124,9 @@ export interface IKernel extends IObservableDisposable {
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']>;
 
   /**
-   * Send an `input_request` message.
+   * Send an `input_reply` message.
    *
-   * @param content - The content of the request.
+   * @param content - The content of the reply.
    */
   inputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 }

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -128,9 +128,9 @@ export interface IKernel extends IObservableDisposable {
    *
    * @param content - The content of the request.
    */
-  inputReply(
-    content: KernelMessage.IInputReplyMsg['content']
-  ): Promise<KernelMessage.IInputRequestMsg['content']>;
+  inputRequest(
+    content: KernelMessage.IInputRequestMsg['content']
+  ): Promise<KernelMessage.IInputReplyMsg['content']>;
 }
 
 /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -128,7 +128,9 @@ export interface IKernel extends IObservableDisposable {
    *
    * @param content - The content of the request.
    */
-  inputRequest(content: KernelMessage.IInputRequestMsg['content']): Promise<void>;
+  inputRequest(
+    content: KernelMessage.IInputRequestMsg['content']
+  ): Promise<KernelMessage.IInputReplyMsg['content']>;
 }
 
 /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -128,9 +128,7 @@ export interface IKernel extends IObservableDisposable {
    *
    * @param content - The content of the request.
    */
-  inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']>;
+  inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void>;
 }
 
 /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -128,9 +128,9 @@ export interface IKernel extends IObservableDisposable {
    *
    * @param content - The content of the request.
    */
-  inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']>;
+  inputReply(
+    content: KernelMessage.IInputReplyMsg['content']
+  ): Promise<KernelMessage.IInputRequestMsg['content']>;
 }
 
 /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -128,7 +128,7 @@ export interface IKernel extends IObservableDisposable {
    *
    * @param content - The content of the request.
    */
-  inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void>;
+  inputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 }
 
 /**

--- a/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
@@ -22,6 +22,7 @@ class Interpreter(InteractiveShell):
         super(Interpreter, self).__init__(*args, **kwargs)
         self.kernel = Pyolite(interpreter=self)
         self._last_traceback = None
+        self.input_request = None
 
     def init_history(self):
         self.history_manager = CustomHistoryManager(shell=self, parent=self)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 
 from IPython.core.application import BaseIPythonApplication
@@ -22,7 +23,16 @@ class Interpreter(InteractiveShell):
         super(Interpreter, self).__init__(*args, **kwargs)
         self.kernel = Pyolite(interpreter=self)
         self._last_traceback = None
-        self.input_request = None
+        self._input = None
+
+    @property
+    def input_request(self):
+        return self._input
+
+    @input_request.setter
+    def input_request(self, value):
+        self._input = value
+        builtins.input = self._input
 
     def init_history(self):
         self.history_manager = CustomHistoryManager(shell=self, parent=self)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/interpreter.py
@@ -1,4 +1,5 @@
 import builtins
+import getpass
 import sys
 
 from IPython.core.application import BaseIPythonApplication
@@ -24,15 +25,25 @@ class Interpreter(InteractiveShell):
         self.kernel = Pyolite(interpreter=self)
         self._last_traceback = None
         self._input = None
+        self._getpass = None
 
     @property
-    def input_request(self):
+    def input(self):
         return self._input
 
-    @input_request.setter
-    def input_request(self, value):
+    @input.setter
+    def input(self, value):
         self._input = value
         builtins.input = self._input
+
+    @property
+    def getpass(self):
+        return self._getpass
+
+    @getpass.setter
+    def getpass(self, value):
+        self._getpass = value
+        getpass.getpass = self._getpass
 
     def init_history(self):
         self.history_manager = CustomHistoryManager(shell=self, parent=self)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -27,14 +27,11 @@ class Pyolite:
     def input_request(self, prompt, password):
         prompt = "" if prompt is None else prompt
         password = False if password is None else password
-        self.interpreter.input_request(
-            prompt,
-            password
-        )
-    
+        self.interpreter.input_request(prompt, password)
+
     def getpass(self, prompt):
         self.input_request(prompt, password=True)
-    
+
     def raw_input(self, prompt):
         self.input_request(prompt, password=False)
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -24,17 +24,6 @@ class Pyolite:
 
         return comms
 
-    def input_request(self, prompt, password):
-        prompt = "" if prompt is None else prompt
-        password = False if password is None else password
-        self.interpreter.input_request(prompt, password)
-
-    def getpass(self, prompt):
-        self.input_request(prompt, password=True)
-
-    def raw_input(self, prompt):
-        self.input_request(prompt, password=False)
-
     def inspect(self, code, cursor_pos, detail_level):
         found = False
         name = token_at_cursor(code, cursor_pos)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -23,7 +23,7 @@ class Pyolite:
                 comms[comm_id] = dict(target_name=comm.target_name)
 
         return comms
-    
+
     def input_request(self, prompt, password):
         pass
 

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -25,7 +25,18 @@ class Pyolite:
         return comms
 
     def input_request(self, prompt, password):
-        pass
+        prompt = "" if prompt is None else prompt
+        password = False if password is None else password
+        self.interpreter.input_request(
+            prompt,
+            password
+        )
+    
+    def getpass(self, prompt):
+        self.input_request(prompt, password=True)
+    
+    def raw_input(self, prompt):
+        self.input_request(prompt, password=False)
 
     def inspect(self, code, cursor_pos, detail_level):
         found = False

--- a/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/kernel.py
@@ -23,6 +23,9 @@ class Pyolite:
                 comms[comm_id] = dict(target_name=comm.target_name)
 
         return comms
+    
+    def input_request(self, prompt, password):
+        pass
 
     def inspect(self, code, cursor_pos, detail_level):
         found = False

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -245,8 +245,8 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    */
   async inputRequest(
     content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<void> {
-    throw new Error('Not implemented');
+  ): Promise<KernelMessage.IInputReplyMsg['content']> {
+    return await this._sendWorkerMessage('input-request', content);
   }
 
   /**

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -288,6 +288,8 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    */
   private async _sendWorkerMessage(type: string, data: any): Promise<any> {
     this._executeDelegate = new PromiseDelegate<any>();
+    console.log('sending parent header to worker');
+    console.log(this.parent);
     this._worker.postMessage({ type, data, parent: this.parent });
     return await this._executeDelegate.promise;
   }

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -243,10 +243,10 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputReply(
-    content: KernelMessage.IInputReplyMsg['content']
-  ): Promise<KernelMessage.IInputRequestMsg['content']> {
-    return await this._sendWorkerMessage('input-reply', content);
+  async inputRequest(
+    content: KernelMessage.IInputRequestMsg['content']
+  ): Promise<KernelMessage.IInputReplyMsg['content']> {
+    return await this._sendWorkerMessage('input-request', content);
   }
 
   /**

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -95,6 +95,11 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
         this.stream(bundle);
         break;
       }
+      case 'input_request': {
+        const bundle = msg.content ?? { prompt: '', password: false };
+        this._inputRequest(bundle);
+        break;
+      }
       case 'reply': {
         const bundle = msg.results;
         this._executeDelegate.resolve(bundle);
@@ -239,14 +244,12 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   }
 
   /**
-   * Send an `input_request` message.
+   * Send an `input_reply` message.
    *
-   * @param content - The content of the request.
+   * @param content - The content of the reply.
    */
-  async inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']> {
-    return await this._sendWorkerMessage('input-request', content);
+  async inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void> {
+    return await this._sendWorkerMessage('input-reply', content);
   }
 
   /**

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -97,8 +97,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
       }
       case 'input_request': {
         const bundle = msg.content ?? { prompt: '', password: false };
-        const parentHeader = msg.parentHeader;
-        this.inputRequest(bundle, parentHeader);
+        this.inputRequest(bundle);
         break;
       }
       case 'reply': {
@@ -249,8 +248,12 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the reply.
    */
-  async inputReply(content: KernelMessage.IInputReplyMsg['content']): Promise<void> {
-    return await this._sendWorkerMessage('input-reply', content);
+  inputReply(content: KernelMessage.IInputReplyMsg['content']): void {
+    this._worker.postMessage({
+      type: 'input-reply',
+      data: content,
+      parent: this.parent
+    });
   }
 
   /**
@@ -288,8 +291,6 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    */
   private async _sendWorkerMessage(type: string, data: any): Promise<any> {
     this._executeDelegate = new PromiseDelegate<any>();
-    console.log('sending parent header to worker');
-    console.log(this.parent);
     this._worker.postMessage({ type, data, parent: this.parent });
     return await this._executeDelegate.promise;
   }

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -185,7 +185,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   async executeRequest(
     content: KernelMessage.IExecuteRequestMsg['content']
   ): Promise<KernelMessage.IExecuteReplyMsg['content']> {
-    const result = await this._sendWorkerMessage('execute-request', content);
+    const result = await this._sendRequestMessageToWorker('execute-request', content);
 
     return {
       execution_count: this.executionCount,
@@ -201,7 +201,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   async completeRequest(
     content: KernelMessage.ICompleteRequestMsg['content']
   ): Promise<KernelMessage.ICompleteReplyMsg['content']> {
-    return await this._sendWorkerMessage('complete-request', content);
+    return await this._sendRequestMessageToWorker('complete-request', content);
   }
 
   /**
@@ -214,7 +214,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   async inspectRequest(
     content: KernelMessage.IInspectRequestMsg['content']
   ): Promise<KernelMessage.IInspectReplyMsg['content']> {
-    return await this._sendWorkerMessage('inspect-request', content);
+    return await this._sendRequestMessageToWorker('inspect-request', content);
   }
 
   /**
@@ -227,7 +227,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   async isCompleteRequest(
     content: KernelMessage.IIsCompleteRequestMsg['content']
   ): Promise<KernelMessage.IIsCompleteReplyMsg['content']> {
-    return await this._sendWorkerMessage('is-complete-request', content);
+    return await this._sendRequestMessageToWorker('is-complete-request', content);
   }
 
   /**
@@ -240,7 +240,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   async commInfoRequest(
     content: KernelMessage.ICommInfoRequestMsg['content']
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']> {
-    return await this._sendWorkerMessage('comm-info-request', content);
+    return await this._sendRequestMessageToWorker('comm-info-request', content);
   }
 
   /**
@@ -262,7 +262,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    * @param msg - The comm_open message.
    */
   async commOpen(msg: KernelMessage.ICommOpenMsg): Promise<void> {
-    return await this._sendWorkerMessage('comm-open', msg);
+    return await this._sendRequestMessageToWorker('comm-open', msg);
   }
 
   /**
@@ -271,7 +271,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    * @param msg - The comm_msg message.
    */
   async commMsg(msg: KernelMessage.ICommMsgMsg): Promise<void> {
-    return await this._sendWorkerMessage('comm-msg', msg);
+    return await this._sendRequestMessageToWorker('comm-msg', msg);
   }
 
   /**
@@ -280,7 +280,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    * @param close - The comm_close message.
    */
   async commClose(msg: KernelMessage.ICommCloseMsg): Promise<void> {
-    return await this._sendWorkerMessage('comm-close', msg);
+    return await this._sendRequestMessageToWorker('comm-close', msg);
   }
 
   /**
@@ -289,7 +289,7 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    * @param type The message type to send to the worker.
    * @param data The message to send to the worker.
    */
-  private async _sendWorkerMessage(type: string, data: any): Promise<any> {
+  private async _sendRequestMessageToWorker(type: string, data: any): Promise<any> {
     this._executeDelegate = new PromiseDelegate<any>();
     this._worker.postMessage({ type, data, parent: this.parent });
     return await this._executeDelegate.promise;

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -243,10 +243,10 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
    *
    * @param content - The content of the request.
    */
-  async inputRequest(
-    content: KernelMessage.IInputRequestMsg['content']
-  ): Promise<KernelMessage.IInputReplyMsg['content']> {
-    return await this._sendWorkerMessage('input-request', content);
+  async inputReply(
+    content: KernelMessage.IInputReplyMsg['content']
+  ): Promise<KernelMessage.IInputRequestMsg['content']> {
+    return await this._sendWorkerMessage('input-reply', content);
   }
 
   /**

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -97,7 +97,8 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
       }
       case 'input_request': {
         const bundle = msg.content ?? { prompt: '', password: false };
-        this._inputRequest(bundle);
+        const parentHeader = msg.parentHeader;
+        this.inputRequest(bundle, parentHeader);
         break;
       }
       case 'reply': {

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -249,11 +249,11 @@ function inspect(content: { code: string; cursor_pos: number; detail_level: 0 | 
 /**
  * Deal with Inputs
  *
- * @param content The incoming message with the input value.
+ * @param content The incoming message with the input prompt.
  */
-function inputRep(content: { value: string }) {
+function inputReq(content: { prompt: string; password: boolean }) {
   console.log(content);
-  const res = kernel.input_reply(content.value);
+  const res = kernel.input_request(content.prompt, content.password);
   console.log(res);
   const results = formatResult(res);
   console.log(results);
@@ -342,8 +342,8 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
       results = await execute(messageContent);
       break;
 
-    case 'input-reply':
-      results = inputRep(messageContent);
+    case 'input-request':
+      results = inputReq(messageContent);
       break;
 
     case 'inspect-request':

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -109,8 +109,8 @@ async function getpass(prompt: string) {
   const replyPromise = new Promise(resolve => {
     resolveInputReply = resolve;
   });
-  const result = await replyPromise;
-  return result;
+  const result: any = await replyPromise;
+  return result['value'];
 }
 
 async function input(prompt: string) {
@@ -119,8 +119,8 @@ async function input(prompt: string) {
   const replyPromise = new Promise(resolve => {
     resolveInputReply = resolve;
   });
-  const result = await replyPromise;
-  return result;
+  const result: any = await replyPromise;
+  return result['value'];
 }
 
 /**

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -13,6 +13,9 @@ let stdout_stream: any;
 // eslint-disable-next-line
 // @ts-ignore: breaks typedoc
 let stderr_stream: any;
+// eslint-disable-next-line
+// @ts-ignore: breaks typedoc
+let resolveInputReply: any;
 /**
  * Load Pyodided and initialize the interpreter.
  */
@@ -101,7 +104,6 @@ async function sendComm(
   });
 }
 
-let resolveInputReply: any;
 async function input(prompt: string, passwd: boolean) {
   await sendInputRequest(prompt, passwd);
   const replyPromise = new Promise(resolve => {

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -42,7 +42,6 @@ async function loadPyodideAndPackages() {
   stderr_stream = pyodide.globals.get('pyolite').stderr_stream;
   interpreter = kernel.interpreter;
   interpreter.send_comm = sendComm;
-  interpreter.input_request = input;
   const version = pyodide.globals.get('pyolite').__version__;
   console.log('Pyolite kernel initialized, version', version);
 }
@@ -226,6 +225,7 @@ async function execute(content: any) {
   interpreter.display_pub.display_data_callback = displayDataCallback;
   interpreter.display_pub.update_display_data_callback = updateDisplayDataCallback;
   interpreter.displayhook.publish_execution_result = publishExecutionResult;
+  interpreter.input_request = input;
 
   const res = await kernel.run(content.code);
   const results = formatResult(res);
@@ -342,7 +342,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
 
     case 'input-reply':
       resolveInputReply(messageContent);
-      break;
+      return;
 
     case 'inspect-request':
       results = inspect(messageContent);

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -123,6 +123,11 @@ async function sendInputRequest(prompt: string, password: boolean) {
     prompt,
     password
   };
+  console.log('sending parent header from worker');
+  console.log('without formatResult');
+  console.log(kernel._parent_header['header']);
+  console.log('with formatResult');
+  console.log(formatResult(kernel._parent_header['header']));
   postMessage({
     type: 'input_request',
     parentHeader: formatResult(kernel._parent_header['header']),
@@ -333,6 +338,9 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   const messageType = data.type;
   const messageContent = data.data;
   kernel._parent_header = pyodide.toPy(data.parent);
+  console.log('worker receives this');
+  console.log(data.parent);
+  console.log(kernel._parent_header);
 
   switch (messageType) {
     case 'execute-request':

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -123,11 +123,6 @@ async function sendInputRequest(prompt: string, password: boolean) {
     prompt,
     password
   };
-  console.log('sending parent header from worker');
-  console.log('without formatResult');
-  console.log(kernel._parent_header['header']);
-  console.log('with formatResult');
-  console.log(formatResult(kernel._parent_header['header']));
   postMessage({
     type: 'input_request',
     parentHeader: formatResult(kernel._parent_header['header']),
@@ -338,9 +333,6 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   const messageType = data.type;
   const messageContent = data.data;
   kernel._parent_header = pyodide.toPy(data.parent);
-  console.log('worker receives this');
-  console.log(data.parent);
-  console.log(kernel._parent_header);
 
   switch (messageType) {
     case 'execute-request':

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -103,9 +103,19 @@ async function sendComm(
   });
 }
 
-async function input(prompt: string, passwd: boolean) {
+async function getpass(prompt: string) {
   prompt = typeof prompt === 'undefined' ? '' : prompt;
-  await sendInputRequest(prompt, passwd);
+  await sendInputRequest(prompt, true);
+  const replyPromise = new Promise(resolve => {
+    resolveInputReply = resolve;
+  });
+  const result = await replyPromise;
+  return result;
+}
+
+async function input(prompt: string) {
+  prompt = typeof prompt === 'undefined' ? '' : prompt;
+  await sendInputRequest(prompt, false);
   const replyPromise = new Promise(resolve => {
     resolveInputReply = resolve;
   });
@@ -226,7 +236,8 @@ async function execute(content: any) {
   interpreter.display_pub.display_data_callback = displayDataCallback;
   interpreter.display_pub.update_display_data_callback = updateDisplayDataCallback;
   interpreter.displayhook.publish_execution_result = publishExecutionResult;
-  interpreter.input_request = input;
+  interpreter.input = input;
+  interpreter.getpass = getpass;
 
   const res = await kernel.run(content.code);
   const results = formatResult(res);

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -228,6 +228,17 @@ function inspect(content: { code: string; cursor_pos: number; detail_level: 0 | 
 }
 
 /**
+ * Deal with Inputs
+ *
+ * @param content The incoming message with the input prompt.
+ */
+function inputReq(content: { prompt: string; password: boolean }) {
+  const res = kernel.input_request(content.prompt, content.password);
+  const results = formatResult(res);
+  return results;
+}
+
+/**
  * Check code for completeness submitted by a user.
  *
  * @param content The incoming message with the code to check.
@@ -307,6 +318,10 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
     case 'execute-request':
       console.log('Perform execution inside worker', data);
       results = await execute(messageContent);
+      break;
+
+    case 'input-request':
+      results = inputReq(messageContent);
       break;
 
     case 'inspect-request':

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -104,6 +104,7 @@ async function sendComm(
 }
 
 async function input(prompt: string, passwd: boolean) {
+  prompt = typeof prompt === 'undefined' ? '' : prompt;
   await sendInputRequest(prompt, passwd);
   const replyPromise = new Promise(resolve => {
     resolveInputReply = resolve;


### PR DESCRIPTION
This is not done yet, I need some sense of direction as to how to proceed further. Maybe links to some reference implementations?

Also, I changed the return type to `Promise<KernelMessage.IInputReplyMsg['content']>` instead of `Promise<void>`. I hope this is the way to go according to here: https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-stdin-router-dealer-channel

When this is done, it should allow us to use:
```
a = input()
```
in JupyterLite. (cc: @jtpio @martinRenou)