### PR TITLE
Add ipycytoscape to the example federated extensions

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -3,6 +3,7 @@
     "federated_extensions": [
       "https://github.com/conda-forge/releases/releases/download/noarch/bqplot-0.12.29-pyhd8ed1ab_0.tar.bz2/bqplot-0.12.29-pyhd8ed1ab_0.tar.bz2",
       "https://github.com/conda-forge/releases/releases/download/noarch/ipycanvas-0.9.0-pyhd8ed1ab_0.tar.bz2/ipycanvas-0.9.0-pyhd8ed1ab_0.tar.bz2",
+      "https://github.com/conda-forge/releases/releases/download/noarch/ipycytoscape-1.2.2-pyhd8ed1ab_0.tar.bz2/ipycytoscape-1.2.2-pyhd8ed1ab_0.tar.bz2",
       "https://github.com/conda-forge/releases/releases/download/noarch/ipyleaflet-0.14.0-pyhd8ed1ab_1.tar.bz2/ipyleaflet-0.14.0-pyhd8ed1ab_1.tar.bz2",
       "https://github.com/conda-forge/releases/releases/download/noarch/ipympl-0.7.0-pyhd8ed1ab_0.tar.bz2/ipympl-0.7.0-pyhd8ed1ab_0.tar.bz2",
       "https://github.com/conda-forge/releases/releases/download/noarch/jupyterlab-drawio-0.9.0-pyhd8ed1ab_0.tar.bz2/jupyterlab-drawio-0.9.0-pyhd8ed1ab_0.tar.bz2",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #238 

## Code changes

Examples change.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should enable the `ipycytoscape` example notebook back:

![image](https://user-images.githubusercontent.com/591645/125498133-0093c47c-3d00-4485-9336-336662eec6e2.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
