### PR TITLE
add index.html to serve message

### DIFF
--- a/py/jupyterlite/src/jupyterlite/addons/serve.py
+++ b/py/jupyterlite/src/jupyterlite/addons/serve.py
@@ -87,7 +87,7 @@ class ServeAddon(BaseAddon):
         Serving JupyterLite from:
             {path}
         on:
-            {self.url}
+            {self.url}index.html
 
         *** Press Ctrl+C to exit **
         """


### PR DESCRIPTION
## References

- for https://github.com/jupyterlite/jupyterlite/issues/67#issuecomment-880170234

## Code changes

appends `index.html` to avoid redirect problems.

## User-facing changes

- `jupyter lite serve` will suggest a page that exists.

## Backwards-incompatible changes

- n/a