### PR TITLE
Add RTC colors and usernames

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -16,7 +16,9 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import {
   IDocumentProvider,
   IDocumentProviderFactory,
-  ProviderMock
+  ProviderMock,
+  getAnonymousUserName,
+  getRandomColor
 } from '@jupyterlab/docprovider';
 
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
@@ -47,6 +49,16 @@ class WebRtcProvider extends WebrtcProvider implements IDocumentProvider {
   constructor(options: IDocumentProviderFactory.IOptions & { room: string }) {
     super(`${options.room}${options.path}`, options.ymodel.ydoc);
     this.awareness = options.ymodel.awareness;
+    const color = `#${getParam('--usercolor', getRandomColor().slice(1))}`;
+    const name = getParam('--username', getAnonymousUserName());
+    const currState = this.awareness.getLocalState();
+    // only set if this was not already set by another plugin
+    if (currState && !currState.name) {
+      this.awareness.setLocalStateField('user', {
+        name,
+        color
+      });
+    }
   }
 
   setPath() {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #207 

Similar to the implementation in JupyterLab: 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Handle username and colors in the custom RTC provider plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Nicer usernames and colors, that can also be set via query string parameters.

![image](https://user-images.githubusercontent.com/591645/125747439-c0fdbda8-1e6a-4b63-8113-e88f31551577.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
