### PR TITLE
Basic support for renaming the RTC session

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -61,15 +61,6 @@ class WebRtcProvider extends WebrtcProvider implements IDocumentProvider {
     }
     this._room = options.room;
     this._path = options.path;
-
-    this.on('rename', (args: any) => {
-      const path = args.path;
-      if (path !== this._path) {
-        this._path = path;
-        console.log('new path', path);
-        this._reconnect(path);
-      }
-    });
   }
 
   private _reconnect(path: string): void {
@@ -85,7 +76,6 @@ class WebRtcProvider extends WebrtcProvider implements IDocumentProvider {
       return;
     }
     this._path = newPath;
-    this.emit('rename', [{ path: this._path }]);
     this._reconnect(newPath);
   }
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -59,10 +59,34 @@ class WebRtcProvider extends WebrtcProvider implements IDocumentProvider {
         color
       });
     }
+    this._room = options.room;
+    this._path = options.path;
+
+    this.on('rename', (args: any) => {
+      const path = args.path;
+      if (path !== this._path) {
+        this._path = path;
+        console.log('new path', path);
+        this._reconnect(path);
+      }
+    });
   }
 
-  setPath() {
-    // TODO: this seems super useful
+  private _reconnect(path: string): void {
+    this.roomName = `${this._room}${path}`;
+    if (this.room) {
+      this.room.name = this.roomName;
+    }
+    this.connect();
+  }
+
+  setPath(newPath: string): void {
+    if (newPath === this._path) {
+      return;
+    }
+    this._path = newPath;
+    this.emit('rename', [{ path: this._path }]);
+    this._reconnect(newPath);
   }
 
   requestInitialContent(): Promise<boolean> {
@@ -99,6 +123,8 @@ class WebRtcProvider extends WebrtcProvider implements IDocumentProvider {
   }
 
   private _initialRequest: PromiseDelegate<boolean> | null = null;
+  private _path: string;
+  private _room: string;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #267 

## Code changes

Implement simple logic to rename a file, and continue the RTC session seamlessly.

## User-facing changes

Users should be able to rename a file. However since the files are distributed (everyone has a copy in indexeddb), users must explicitly save the notebook to get a copy.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
