### PR TITLE
Provide `IStateDB` in retro

### DIFF
--- a/app/retro/index.template.js
+++ b/app/retro/index.template.js
@@ -75,6 +75,7 @@ async function main() {
       [
         '@jupyterlab/apputils-extension:palette',
         '@jupyterlab/apputils-extension:settings',
+        '@jupyterlab/apputils-extension:state',
         '@jupyterlab/apputils-extension:themes',
         '@jupyterlab/apputils-extension:themes-palette-menu'
       ].includes(id)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

To address the `jupyterlab-tour` part of https://github.com/jupyterlite/jupyterlite/issues/286

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add `@jupyterlab/apputils-extension:settings` to the retro app.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users should be able to take tours with RetroLab if the `jupyterlab-tour` extension is installed and tour exists.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
