### PR TITLE
Lint changelog in `after-build-changelog`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ skip = ["build-python", "check-links", "check-manifest"]
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyter_releaser -r requirements-build.txt -r requirements-lint.txt"]
 before-build-npm = ["doit build"]
-after-build-changelog = ["yarn lint", "yarn lint:check"]
+after-build-changelog = ["yarn lint", "yarn lint:check", "git add CHANGELOG.md"]
 after-check-npm = ["doit dist"]
 before-draft-release = ["rm dist/jupyterlite-app-*.tgz"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ skip = ["build-python", "check-links", "check-manifest"]
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyter_releaser -r requirements-build.txt -r requirements-lint.txt"]
 before-build-npm = ["doit build"]
-after-draft-changelog = ["yarn lint", "yarn lint:check"]
+after-build-changelog = ["yarn lint", "yarn lint:check"]
 after-check-npm = ["doit dist"]
 before-draft-release = ["rm dist/jupyterlite-app-*.tgz"]
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #319 

In #325 we notice the changelog is not linted and the CI check fails.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Releaser config.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
