### PR TITLE
Add `CHANGELOG.md` to `.prettierignore`, fix `appVersion`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ app/lab/extensions/
 # JS templating
 bootstrap.js
 index.template.js
+
+# The changelog is updated by the releaser
+CHANGELOG.md

--- a/app/jupyter-lite.json
+++ b/app/jupyter-lite.json
@@ -2,7 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite",
-    "appVersion": "0.1.0-alpha.6",
+    "appVersion": "0.1.0-alpha.7",
     "baseUrl": "./",
     "appUrl": "./lab",
     "faviconUrl": "./lab/favicon.ico",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ skip = ["build-python", "check-links", "check-manifest"]
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyter_releaser -r requirements-build.txt -r requirements-lint.txt"]
+after-bump-version = ["doit lint"]
 before-build-npm = ["doit build"]
 after-check-npm = ["doit dist"]
 before-draft-release = ["rm dist/jupyterlite-app-*.tgz"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ skip = ["build-python", "check-links", "check-manifest"]
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install bump2version jupyter_releaser -r requirements-build.txt -r requirements-lint.txt"]
 before-build-npm = ["doit build"]
-after-build-changelog = ["yarn lint", "yarn lint:check", "git add CHANGELOG.md"]
 after-check-npm = ["doit dist"]
 before-draft-release = ["rm dist/jupyterlite-app-*.tgz"]
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -19,12 +19,18 @@ ENC = dict(encoding="utf-8")
 ROOT = Path(__file__).parent.parent
 ROOT_PACKAGE_JSON = ROOT / "package.json"
 APP_PACKAGE_JSON = ROOT / "app" / "package.json"
+APP_JUPYTERLITE_JSON = ROOT / "app" / "jupyter-lite.json"
 
 
 def postbump():
     # read the new app version
     app_json = json.loads(APP_PACKAGE_JSON.read_text(**ENC))
     new_version = app_json["version"]
+
+    # save the new version to the app jupyter-lite.json
+    jupyterlite_json = json.loads(APP_JUPYTERLITE_JSON.read_text(**ENC))
+    jupyterlite_json["version"] = new_version
+    APP_JUPYTERLITE_JSON.write_text(json.dumps(jupyterlite_json, indent=2), **ENC)
 
     # save the new version to the top-level package.json
     py_version = new_version.replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -30,10 +30,14 @@ def postbump():
     # save the new version to the app jupyter-lite.json
     jupyterlite_json = json.loads(APP_JUPYTERLITE_JSON.read_text(**ENC))
     jupyterlite_json["jupyter-config-data"]["appVersion"] = new_version
-    APP_JUPYTERLITE_JSON.write_text(json.dumps(jupyterlite_json, indent=2), **ENC)
+    APP_JUPYTERLITE_JSON.write_text(
+        json.dumps(jupyterlite_json, indent=2) + "\n", **ENC
+    )
 
     # save the new version to the top-level package.json
-    py_version = new_version.replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")
+    py_version = (
+        new_version.replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")
+    )
     root_json = json.loads(ROOT_PACKAGE_JSON.read_text(**ENC))
     root_json["version"] = py_version
     ROOT_PACKAGE_JSON.write_text(json.dumps(root_json, indent=2), **ENC)

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -29,7 +29,7 @@ def postbump():
 
     # save the new version to the app jupyter-lite.json
     jupyterlite_json = json.loads(APP_JUPYTERLITE_JSON.read_text(**ENC))
-    jupyterlite_json["version"] = new_version
+    jupyterlite_json["appVersion"] = new_version
     APP_JUPYTERLITE_JSON.write_text(json.dumps(jupyterlite_json, indent=2), **ENC)
 
     # save the new version to the top-level package.json

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -29,7 +29,7 @@ def postbump():
 
     # save the new version to the app jupyter-lite.json
     jupyterlite_json = json.loads(APP_JUPYTERLITE_JSON.read_text(**ENC))
-    jupyterlite_json["appVersion"] = new_version
+    jupyterlite_json["jupyter-config-data"]["appVersion"] = new_version
     APP_JUPYTERLITE_JSON.write_text(json.dumps(jupyterlite_json, indent=2), **ENC)
 
     # save the new version to the top-level package.json


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #319 and #327 

The simplest for now would be to not lint the changelog since it's automatically updated by the releaser.

And it doesn't render nicely on the GiHub Release page:

![image](https://user-images.githubusercontent.com/591645/133303239-e0f73e55-34fe-4e42-bb21-6cb3a24b5182.png)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Config changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
