### PR TITLE
Fix display of XML files

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -364,7 +364,7 @@ export class Contents implements IContents {
             mimetype: model.mimetype || 'application/json'
           };
           // TODO: this is not great, need a better oracle
-        } else if (mimetype === 'image/svg+xml' || mimetype.indexOf('text') !== -1) {
+        } else if (mimetype.indexOf('xml') !== -1 || mimetype.indexOf('text') !== -1) {
           model = {
             ...model,
             content: await response.text(),


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #308 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Not the best fix but should cover one more case. The `TODO` on the line above is still relevant.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Server deployed xml files should now be readable.

![image](https://user-images.githubusercontent.com/591645/133317356-9874ae49-3c35-4c9d-816f-d906bc3b27c7.png)

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
