### PR TITLE
Automated Changelog Entry for 0.1.0a8 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a8
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a7...ac985ec59fd56cb5df85e59023a643fcf557b91c))
+
+### Bugs fixed
+
+- Fix display of XML files [#330](https://github.com/jupyterlite/jupyterlite/pull/330) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Add `CHANGELOG.md` to `.prettierignore`, fix `appVersion` [#329](https://github.com/jupyterlite/jupyterlite/pull/329) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-14&to=2021-09-15&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-14..2021-09-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a7
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a6...b1a72bf6bd47aa9f801338b0b55c8932ea068905))
@@ -73,8 +93,6 @@
 [@nv2k3](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Anv2k3+updated%3A2021-07-24..2021-09-14&type=Issues)
 |
 [@seidlr](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Aseidlr+updated%3A2021-07-24..2021-09-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v0.1.0a6
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a8 on main
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.8
@jupyterlite/app-lab: 0.1.0-alpha.8
@jupyterlite/app-retro: 0.1.0-alpha.8
@jupyterlite/settings: 0.1.0-alpha.8
@jupyterlite/retro-application-extension: 0.1.0-alpha.8
@jupyterlite/p5-kernel-extension: 0.1.0-alpha.8
@jupyterlite/kernel: 0.1.0-alpha.8
@jupyterlite/p5-kernel: 0.1.0-alpha.8
@jupyterlite/metapackage: 0.1.0-alpha.8
@jupyterlite/pyolite-kernel: 0.1.0-alpha.8
@jupyterlite/javascript-kernel: 0.1.0-alpha.8
@jupyterlite/application-extension: 0.1.0-alpha.8
@jupyterlite/server-extension: 0.1.0-alpha.8
@jupyterlite/contents: 0.1.0-alpha.8
@jupyterlite/session: 0.1.0-alpha.8
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.8
@jupyterlite/ui-components: 0.1.0-alpha.8
@jupyterlite/iframe-extension: 0.1.0-alpha.8
@jupyterlite/server: 0.1.0-alpha.8
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.8

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a7 |