### PR TITLE
Buffers are already bytes

### DIFF
--- a/packages/pyolite-kernel/py/ipykernel/ipykernel/comm.py
+++ b/packages/pyolite-kernel/py/ipykernel/ipykernel/comm.py
@@ -40,10 +40,8 @@ class Comm:
         data = {} if data is None else data
         metadata = {} if metadata is None else metadata
         content = dict(data=data, comm_id=self.comm_id, **keys)
-        if ((buffers is not None) and
-            (len(buffers) > 0) and
-            hasattr(buffers[0], "tobytes")):
-            buffers = [b.tobytes() for b in buffers]
+        if buffers is not None:
+            buffers = [(b.tobytes() if hasattr(b, "tobytes") else b) for b in buffers]
 
         self.kernel.interpreter.send_comm(
             msg_type,

--- a/packages/pyolite-kernel/py/ipykernel/ipykernel/comm.py
+++ b/packages/pyolite-kernel/py/ipykernel/ipykernel/comm.py
@@ -40,7 +40,10 @@ class Comm:
         data = {} if data is None else data
         metadata = {} if metadata is None else metadata
         content = dict(data=data, comm_id=self.comm_id, **keys)
-        buffers = None if buffers is None else [b.tobytes() for b in buffers]
+        if ((buffers is not None) and
+            (len(buffers) > 0) and
+            hasattr(buffers[0], "tobytes")):
+            buffers = [b.tobytes() for b in buffers]
 
         self.kernel.interpreter.send_comm(
             msg_type,


### PR DESCRIPTION
I see that at some point in the past (and maybe for some situations today) the buffers had to be converted to bytes. In my situation (using ipywidgets.Image and setting the bytes from Python) they are already bytes. The changes in this PR preserve the previous fix, but doesn't apply when not necessary.