### PR TITLE
Automated Changelog Entry for 0.1.0a9 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a9
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a8...012dde52ff2d31521dfeab94af891e454273c07b))
+
+### New features added
+
+- Add support for localization [#336](https://github.com/jupyterlite/jupyterlite/pull/336) ([@jtpio](https://github.com/jtpio))
+
+### Enhancements made
+
+- Buffers are already bytes [#335](https://github.com/jupyterlite/jupyterlite/pull/335) ([@dsblank](https://github.com/dsblank))
+
+### Bugs fixed
+
+- fixed typo in logging call [#334](https://github.com/jupyterlite/jupyterlite/pull/334) ([@stevejpurves](https://github.com/stevejpurves))
+
+### Maintenance and upkeep improvements
+
+- Sync the demo site environment [#344](https://github.com/jupyterlite/jupyterlite/pull/344) ([@jtpio](https://github.com/jtpio))
+- Bump the pyolite version [#343](https://github.com/jupyterlite/jupyterlite/pull/343) ([@jtpio](https://github.com/jtpio))
+- Update to Pyodide 0.18.1 [#338](https://github.com/jupyterlite/jupyterlite/pull/338) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Update release instructions [#337](https://github.com/jupyterlite/jupyterlite/pull/337) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-15&to=2021-09-27&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-09-15..2021-09-27&type=Issues) | [@dsblank](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Adsblank+updated%3A2021-09-15..2021-09-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-15..2021-09-27&type=Issues) | [@stevejpurves](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Astevejpurves+updated%3A2021-09-15..2021-09-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a8
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a7...ac985ec59fd56cb5df85e59023a643fcf557b91c))
@@ -19,8 +53,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-14&to=2021-09-15&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-14..2021-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a7
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a9 on main
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.9
@jupyterlite/app-retro: 0.1.0-alpha.9
@jupyterlite/app-lab: 0.1.0-alpha.9
@jupyterlite/contents: 0.1.0-alpha.9
@jupyterlite/session: 0.1.0-alpha.9
@jupyterlite/application-extension: 0.1.0-alpha.9
@jupyterlite/pyolite-kernel: 0.1.0-alpha.9
@jupyterlite/p5-kernel-extension: 0.1.0-alpha.9
@jupyterlite/server: 0.1.0-alpha.9
@jupyterlite/metapackage: 0.1.0-alpha.9
@jupyterlite/translation: 0.1.0-alpha.9
@jupyterlite/javascript-kernel: 0.1.0-alpha.9
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.9
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.9
@jupyterlite/server-extension: 0.1.0-alpha.9
@jupyterlite/p5-kernel: 0.1.0-alpha.9
@jupyterlite/retro-application-extension: 0.1.0-alpha.9
@jupyterlite/kernel: 0.1.0-alpha.9
@jupyterlite/iframe-extension: 0.1.0-alpha.9
@jupyterlite/ui-components: 0.1.0-alpha.9
@jupyterlite/settings: 0.1.0-alpha.9

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a8 |