### PR TITLE
Automated Changelog Entry for 0.1.0a10 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a10
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/@jupyterlite/app-lab@0.1.0-alpha.9...e6da8c5abdb4101c6208e554ea8b2215e4d8d411))
+
+### New features added
+
+- Scaffolding for loading serverlite extensions [#352](https://github.com/jupyterlite/jupyterlite/pull/352) ([@jtpio](https://github.com/jtpio))
+
+### Enhancements made
+
+- removed not needed methods from kernel interface [#355](https://github.com/jupyterlite/jupyterlite/pull/355) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Bugs fixed
+
+- Translation fixes [#354](https://github.com/jupyterlite/jupyterlite/pull/354) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Fix RTD Preview workflow [#357](https://github.com/jupyterlite/jupyterlite/pull/357) ([@jtpio](https://github.com/jtpio))
+- Add workflow to post the RTD link as a PR comment [#356](https://github.com/jupyterlite/jupyterlite/pull/356) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-27&to=2021-10-01&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-09-27..2021-10-01&type=Issues) | [@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3ADerThorsten+updated%3A2021-09-27..2021-10-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-27..2021-10-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a9
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a8...012dde52ff2d31521dfeab94af891e454273c07b))
@@ -33,8 +62,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-15&to=2021-09-27&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-09-15..2021-09-27&type=Issues) | [@dsblank](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Adsblank+updated%3A2021-09-15..2021-09-27&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-15..2021-09-27&type=Issues) | [@stevejpurves](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Astevejpurves+updated%3A2021-09-15..2021-09-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a8
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a10 on main
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.10
@jupyterlite/app-retro: 0.1.0-alpha.10
@jupyterlite/app-lab: 0.1.0-alpha.10
@jupyterlite/contents: 0.1.0-alpha.10
@jupyterlite/session: 0.1.0-alpha.10
@jupyterlite/application-extension: 0.1.0-alpha.10
@jupyterlite/pyolite-kernel: 0.1.0-alpha.10
@jupyterlite/server: 0.1.0-alpha.10
@jupyterlite/metapackage: 0.1.0-alpha.10
@jupyterlite/translation: 0.1.0-alpha.10
@jupyterlite/javascript-kernel: 0.1.0-alpha.10
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.10
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.10
@jupyterlite/server-extension: 0.1.0-alpha.10
@jupyterlite/retro-application-extension: 0.1.0-alpha.10
@jupyterlite/kernel: 0.1.0-alpha.10
@jupyterlite/iframe-extension: 0.1.0-alpha.10
@jupyterlite/ui-components: 0.1.0-alpha.10
@jupyterlite/settings: 0.1.0-alpha.10

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | @jupyterlite/app-lab@0.1.0-alpha.9 |