### PR TITLE
Fix token name for IKernelSpecs

### DIFF
--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -99,9 +99,7 @@ export namespace IKernel {
 /**
  * The token for the kernel spec service.
  */
-export const IKernelSpecs = new Token<IKernelSpecs>(
-  '@jupyterlite/kernelspec:IKernelSpecs'
-);
+export const IKernelSpecs = new Token<IKernelSpecs>('@jupyterlite/kernel:IKernelSpecs');
 
 /**
  * The interface for the kernel specs service.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Since `IKernelSpecs` lives in the `@jupyterlite/kernel` package, we can update the name of the token to `@jupyterlite/kernel` instead `@jupyterlite/kernelspec` for consistency.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update token name.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

We might have to rebuild and publish downstream kernels:

- https://github.com/jupyterlite/p5-kernel
- https://github.com/jupyterlite/echo-kernel

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
