### PR TITLE
Fix handling of disabled extensions

### DIFF
--- a/app/lab/index.template.js
+++ b/app/lab/index.template.js
@@ -18,7 +18,6 @@ const serverExtensions = [
 
 // custom list of disabled plugins
 const disabled = [
-  ...JSON.parse(PageConfig.getOption('disabledExtensions') || '[]'),
   '@jupyterlab/apputils-extension:workspaces',
   '@jupyterlab/application-extension:logo',
   '@jupyterlab/application-extension:main',
@@ -95,8 +94,8 @@ async function main() {
 
     let plugins = Array.isArray(exports) ? exports : [exports];
     for (let plugin of plugins) {
-      // skip the plugin (or extension) if disabled
       if (
+        PageConfig.Extension.isDisabled(plugin.id) ||
         disabled.includes(plugin.id) ||
         disabled.includes(plugin.id.split(':')[0])
       ) {
@@ -159,6 +158,14 @@ async function main() {
     }
   });
 
+  // Add the base serverlite extensions
+  const baseServerExtensions = await Promise.all(serverExtensions);
+  baseServerExtensions.forEach(p => {
+    for (let plugin of activePlugins(p)) {
+      litePluginsToRegister.push(plugin);
+    }
+  })
+
   // Add the serverlite federated extensions.
   const federatedLiteExtensions = await Promise.allSettled(liteExtensionPromises);
   federatedLiteExtensions.forEach(p => {
@@ -178,8 +185,7 @@ async function main() {
 
   // create the in-browser JupyterLite Server
   const jupyterLiteServer = new JupyterLiteServer({});
-  const allServerExtensions = (await Promise.all(serverExtensions)).concat(litePluginsToRegister);
-  jupyterLiteServer.registerPluginModules(allServerExtensions);
+  jupyterLiteServer.registerPluginModules(litePluginsToRegister);
   // start the server
   await jupyterLiteServer.start();
 
@@ -189,7 +195,8 @@ async function main() {
   // create a full-blown JupyterLab frontend
   const lab = new JupyterLab({
     mimeExtensions,
-    serviceManager
+    serviceManager,
+    disabled
   });
   lab.name = 'JupyterLite';
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #352 

So we can also disable serverlite extensions in both lab and retro.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update to the startup logic to handle disabled extensions.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Deployers can for example specify:

```json
"disabledExtensions": [
  "@jupyterlite/pyolite-kernel-extension"
]
```

In `jupyter-lite.json` to disable the Python kernel:

![image](https://user-images.githubusercontent.com/591645/135689894-4b69750d-d36f-44a9-8cff-8d4a814faff3.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
