### PR TITLE
Automated Changelog Entry for 0.1.0a11 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a11
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a10...ecccffa1f8989e50a24736a74d32f4a1ee1e1256))
+
+### Enhancements made
+
+-  Add support for `python -m jupyterlite`  [#362](https://github.com/jupyterlite/jupyterlite/pull/362) ([@jtpio](https://github.com/jtpio))
+
+### Bugs fixed
+
+- Fix handling of disabled extensions [#361](https://github.com/jupyterlite/jupyterlite/pull/361) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Fix token name for IKernelSpecs [#360](https://github.com/jupyterlite/jupyterlite/pull/360) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-01&to=2021-10-02&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-01..2021-10-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-01..2021-10-02&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a10
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a9...e6da8c5abdb4101c6208e554ea8b2215e4d8d411))
@@ -28,8 +52,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-09-27&to=2021-10-01&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-09-27..2021-10-01&type=Issues) | [@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3ADerThorsten+updated%3A2021-09-27..2021-10-01&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-09-27..2021-10-01&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a9
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a11 on main
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.11
@jupyterlite/app-retro: 0.1.0-alpha.11
@jupyterlite/app-lab: 0.1.0-alpha.11
@jupyterlite/contents: 0.1.0-alpha.11
@jupyterlite/session: 0.1.0-alpha.11
@jupyterlite/application-extension: 0.1.0-alpha.11
@jupyterlite/pyolite-kernel: 0.1.0-alpha.11
@jupyterlite/server: 0.1.0-alpha.11
@jupyterlite/metapackage: 0.1.0-alpha.11
@jupyterlite/translation: 0.1.0-alpha.11
@jupyterlite/javascript-kernel: 0.1.0-alpha.11
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.11
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.11
@jupyterlite/server-extension: 0.1.0-alpha.11
@jupyterlite/retro-application-extension: 0.1.0-alpha.11
@jupyterlite/kernel: 0.1.0-alpha.11
@jupyterlite/iframe-extension: 0.1.0-alpha.11
@jupyterlite/ui-components: 0.1.0-alpha.11
@jupyterlite/settings: 0.1.0-alpha.11

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a10 |