### PR TITLE
Add docs to deploy to Vercel

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -246,7 +246,60 @@ You might also want to specify the `--debug` flag to get extra log messages:
 
 ### Vercel
 
-> TBD
+Just like Netlify, [Vercel](https://vercel.com) can connect to an existing git
+repository and seamlessly deploy static files on push and PR events (previews).
+
+Unfortunately, their build image only includes Python 3.6 and JupyterLite requires
+Python 3.7+.
+
+Fortunately it is possible to run arbitrary bash scripts, which provides a convenient
+escape hatch.
+
+Specify the Python packages in a `requirements-deploy.txt` file with additional
+dependencies if needed:
+
+```
+jupyterlab~=3.1.0
+jupyterlite
+```
+
+Then create a new `deploy.sh` file with the following content:
+
+```bash
+#!/bin/bash
+
+yum install wget
+
+wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+
+./bin/micromamba shell init -s bash -p ~/micromamba
+source ~/.bashrc
+
+# activate the environment and install a new version of Python
+micromamba activate
+micromamba install python=3.9 -c conda-forge -y
+
+# install the dependencies
+python -m pip install -r requirements-deploy.txt
+
+# build the JupyterLite site
+jupyter lite --version
+jupyter lite build
+```
+
+[Micromamba](https://github.com/mamba-org/mamba#micromamba) creates a new self-contained
+environment, which makes it very convenient to install any required package without
+being limited by the build image.
+
+Then configure the build command and output directory on Vercel:
+
+![image](https://user-images.githubusercontent.com/591645/135725426-1dc0d9d1-e661-477d-810c-1c06400a0f6a.png)
+
+You might also want to specify the `--debug` flag to get extra log messages:
+
+```bash
+jupyter lite build --debug
+```
 
 ### GitHub Pages
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -284,7 +284,7 @@ python -m pip install -r requirements-deploy.txt
 
 # build the JupyterLite site
 jupyter lite --version
-jupyter lite build
+jupyter lite build --output-dir dist
 ```
 
 [Micromamba](https://github.com/mamba-org/mamba#micromamba) creates a new self-contained
@@ -293,7 +293,7 @@ being limited by the build image.
 
 Then configure the build command and output directory on Vercel:
 
-![image](https://user-images.githubusercontent.com/591645/135725426-1dc0d9d1-e661-477d-810c-1c06400a0f6a.png)
+![image](https://user-images.githubusercontent.com/591645/135726080-93ca6930-19de-4371-ad13-78f5716b7299.png)
 
 You might also want to specify the `--debug` flag to get extra log messages:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #228 but to document Vercel

Related to #67 

We can use the `micromamba` "trick" to easily bypass the Python 3.6 limitation and have full control on the dependencies :rocket: 

Currently using this approach for https://github.com/jtpio/p5-notebook

## Code changes

Documentation

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Docs:

![image](https://user-images.githubusercontent.com/591645/135725793-91929d42-16d7-4881-9368-3b44390cba59.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
