### PR TITLE
Automated Changelog Entry for 0.1.0a12 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a12
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a11...db972e31732d8ef41d95d8ecbe0d8afce77b89d3))
+
+### New features added
+
+- Add `htmlviewer-extension` [#365](https://github.com/jupyterlite/jupyterlite/pull/365) ([@jtpio](https://github.com/jtpio))
+
+### Bugs fixed
+
+- `disabledExtension` for base retro extensions [#366](https://github.com/jupyterlite/jupyterlite/pull/366) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Add docs to deploy to Vercel [#364](https://github.com/jupyterlite/jupyterlite/pull/364) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-02&to=2021-10-04&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-02..2021-10-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-02..2021-10-04&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a11
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a10...ecccffa1f8989e50a24736a74d32f4a1ee1e1256))
@@ -23,8 +47,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-01&to=2021-10-02&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-01..2021-10-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-01..2021-10-02&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a10
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a12 on main
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.12
@jupyterlite/app-retro: 0.1.0-alpha.12
@jupyterlite/app-lab: 0.1.0-alpha.12
@jupyterlite/contents: 0.1.0-alpha.12
@jupyterlite/session: 0.1.0-alpha.12
@jupyterlite/application-extension: 0.1.0-alpha.12
@jupyterlite/pyolite-kernel: 0.1.0-alpha.12
@jupyterlite/server: 0.1.0-alpha.12
@jupyterlite/metapackage: 0.1.0-alpha.12
@jupyterlite/translation: 0.1.0-alpha.12
@jupyterlite/javascript-kernel: 0.1.0-alpha.12
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.12
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.12
@jupyterlite/server-extension: 0.1.0-alpha.12
@jupyterlite/retro-application-extension: 0.1.0-alpha.12
@jupyterlite/kernel: 0.1.0-alpha.12
@jupyterlite/iframe-extension: 0.1.0-alpha.12
@jupyterlite/ui-components: 0.1.0-alpha.12
@jupyterlite/settings: 0.1.0-alpha.12

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a11 |