### PR TITLE
Remove duplicate download entry in the main and context menus

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -239,7 +239,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/application-extension:download',
   autoStart: true,
   requires: [ITranslator, IDocumentManager],
-  optional: [ICommandPalette, IFileBrowserFactory, IMainMenu],
+  optional: [ICommandPalette, IFileBrowserFactory],
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Since we use the same command id as in JupyterLab, the command was already added via the menu as settings options system.

## Code changes

Do not explicit add the download command to the `IMainMenu`.

## User-facing changes

### Before

![image](https://user-images.githubusercontent.com/591645/136375970-aa4ce252-ec24-4161-b7c2-9f8a19b5ce1c.png)

### After

![image](https://user-images.githubusercontent.com/591645/136376519-a36babde-a65a-4e13-8fa4-37b4bd3d7994.png)


## Backwards-incompatible changes

None
