### PR TITLE
Automated Changelog Entry for 0.1.0a13 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a13
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a12...d2a4c4dec8a087f9f106aafaf510808c974dcb59))
+
+### Enhancements made
+
+- Add a plugin to share links to files [#384](https://github.com/jupyterlite/jupyterlite/pull/384) ([@jtpio](https://github.com/jtpio))
+- Open file via URL params in JupyterLab [#380](https://github.com/jupyterlite/jupyterlite/pull/380) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Update to the latest RetroLab [#387](https://github.com/jupyterlite/jupyterlite/pull/387) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- Mention GitHub releases in the release docs [#377](https://github.com/jupyterlite/jupyterlite/pull/377) ([@jtpio](https://github.com/jtpio))
+- Add docs for developing server extensions [#376](https://github.com/jupyterlite/jupyterlite/pull/376) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-04&to=2021-10-12&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-10-04..2021-10-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-04..2021-10-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-04..2021-10-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a12
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a11...db972e31732d8ef41d95d8ecbe0d8afce77b89d3))
@@ -23,8 +49,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-02&to=2021-10-04&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-02..2021-10-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-02..2021-10-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a11
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a13 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.13
@jupyterlite/app-retro: 0.1.0-alpha.13
@jupyterlite/app-lab: 0.1.0-alpha.13
@jupyterlite/pyolite-kernel: 0.1.0-alpha.13
@jupyterlite/retro-application-extension: 0.1.0-alpha.13
@jupyterlite/session: 0.1.0-alpha.13
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.13
@jupyterlite/javascript-kernel: 0.1.0-alpha.13
@jupyterlite/translation: 0.1.0-alpha.13
@jupyterlite/iframe-extension: 0.1.0-alpha.13
@jupyterlite/settings: 0.1.0-alpha.13
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.13
@jupyterlite/kernel: 0.1.0-alpha.13
@jupyterlite/metapackage: 0.1.0-alpha.13
@jupyterlite/contents: 0.1.0-alpha.13
@jupyterlite/server-extension: 0.1.0-alpha.13
@jupyterlite/ui-components: 0.1.0-alpha.13
@jupyterlite/server: 0.1.0-alpha.13
@jupyterlite/application-extension: 0.1.0-alpha.13
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a12 |