### PR TITLE
Improve handling of IFrame elements

### DIFF
--- a/packages/iframe-extension/src/index.ts
+++ b/packages/iframe-extension/src/index.ts
@@ -46,22 +46,20 @@ export class RenderedIFrame extends Widget implements IRenderMime.IRenderer {
       this._iframe.parentNode.removeChild(this._iframe);
     }
 
+    const ready = new PromiseDelegate<void>();
     this._iframe = document.createElement('iframe');
-    // Provide default dimensions
-    this._iframe.width = '100%';
-    this._iframe.height = '400px';
     this._iframe.onload = () => {
-      this._ready.resolve(void 0);
+      ready.resolve(void 0);
     };
     this.node.appendChild(this._iframe);
-    await this._ready.promise;
+    await ready.promise;
     const data = model.data[MIME_TYPE] as string | undefined;
     if (!data || !this._iframe.contentWindow) {
       return;
     }
     const metadata = model.metadata[MIME_TYPE] as IIFrameMetadata | undefined;
-    this._iframe.width = metadata?.width ?? this._iframe.width;
-    this._iframe.height = metadata?.height ?? this._iframe.height;
+    this._iframe.width = metadata?.width ?? '100%';
+    this._iframe.height = metadata?.height ?? '400px';
     this._iframe.contentWindow.document.write(data);
   }
 
@@ -74,7 +72,6 @@ export class RenderedIFrame extends Widget implements IRenderMime.IRenderer {
   }
 
   private _iframe: HTMLIFrameElement;
-  private _ready = new PromiseDelegate<void>();
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

To be able to handle the model being re-rendered, for example in the case of the `p5-kernel`: https://github.com/jupyterlite/p5-kernel

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Recreate the IFrame when the model is re-rendered. This is mostly useful to the p5 kernel for now and might need some more tweaks later.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
