### PR TITLE
Handle 404s when getting contents

### DIFF
--- a/packages/contents/package.json
+++ b/packages/contents/package.json
@@ -45,7 +45,6 @@
     "@jupyterlab/nbformat": "~3.2.0",
     "@jupyterlab/services": "~6.2.0",
     "@lumino/coreutils": "^1.8.0",
-    "@lumino/signaling": "^1.7.0",
     "localforage": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -54,6 +54,9 @@ export class Contents implements IContents {
     const basename = PathExt.basename(path);
     const extname = PathExt.extname(path);
     const item = await this.get(dirname);
+
+    // handle the case of "Save As", where the path points to the new file
+    // to create, e.g. subfolder/example-copy.ipynb
     let name = '';
     if (path && !extname && item) {
       // directory

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -49,9 +49,16 @@ export class Contents implements IContents {
     const path = options?.path ?? '';
     const type = options?.type ?? 'notebook';
     const created = new Date().toISOString();
-    const dirname = PathExt.dirname(path);
-    const basename = PathExt.basename(path);
-    const prefix = path && dirname ? `${path}/` : '';
+    let basename = PathExt.basename(path);
+    let dirname = PathExt.dirname(path);
+    const item = await this.get(path);
+    // if it exists (directory)
+    if (path && item) {
+      dirname = `${path}/`;
+      basename = '';
+    } else if (path) {
+      dirname = `${dirname}/`;
+    }
 
     let file: ServerContents.IModel;
     let name = '';
@@ -61,7 +68,7 @@ export class Contents implements IContents {
         name += `Untitled Folder${counter || ''}`;
         file = {
           name,
-          path: `${prefix}${name}`,
+          path: `${dirname}${name}`,
           last_modified: created,
           created,
           format: 'text',
@@ -79,7 +86,7 @@ export class Contents implements IContents {
         name += basename || `untitled${counter || ''}${ext}`;
         file = {
           name,
-          path: `${prefix}${name}`,
+          path: `${dirname}${name}`,
           last_modified: created,
           created,
           format: 'text',
@@ -97,7 +104,7 @@ export class Contents implements IContents {
         name += basename || `Untitled${counter || ''}.ipynb`;
         file = {
           name,
-          path: `${prefix}${name}`,
+          path: `${dirname}${name}`,
           last_modified: created,
           created,
           format: 'json',
@@ -111,7 +118,7 @@ export class Contents implements IContents {
       }
     }
 
-    const key = `${prefix}${name}`;
+    const key = file.path;
     await this._storage.setItem(key, file);
     return file;
   }

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -360,6 +360,7 @@ export class Contents implements IContents {
    *   checkpoint is created.
    */
   async createCheckpoint(path: string): Promise<ServerContents.ICheckpointModel> {
+    path = decodeURIComponent(path);
     const item = await this.get(path, { content: true });
     if (!item) {
       throw Error(`Could not find file with path ${path}`);
@@ -410,6 +411,7 @@ export class Contents implements IContents {
    * @returns A promise which resolves when the checkpoint is restored.
    */
   async restoreCheckpoint(path: string, checkpointID: string): Promise<void> {
+    path = decodeURIComponent(path);
     const copies = ((await this._checkpoints.getItem(path)) ||
       []) as ServerContents.IModel[];
     const id = parseInt(checkpointID);
@@ -426,6 +428,7 @@ export class Contents implements IContents {
    * @returns A promise which resolves when the checkpoint is deleted.
    */
   async deleteCheckpoint(path: string, checkpointID: string): Promise<void> {
+    path = decodeURIComponent(path);
     const copies = ((await this._checkpoints.getItem(path)) ||
       []) as ServerContents.IModel[];
     const id = parseInt(checkpointID);

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -49,8 +49,9 @@ export class Contents implements IContents {
     const path = options?.path ?? '';
     const type = options?.type ?? 'notebook';
     const created = new Date().toISOString();
-    let basename = PathExt.basename(path);
+
     let dirname = PathExt.dirname(path);
+    const basename = PathExt.basename(path);
     const extname = PathExt.extname(path);
     const item = await this.get(dirname);
     let name = '';

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -51,21 +51,28 @@ export class Contents implements IContents {
     const created = new Date().toISOString();
     let basename = PathExt.basename(path);
     let dirname = PathExt.dirname(path);
-    const item = await this.get(path);
-    // if it exists (directory)
-    if (path && item) {
+    const extname = PathExt.extname(path);
+    const item = await this.get(dirname);
+    let name = '';
+    if (path && !extname && item) {
+      // directory
       dirname = `${path}/`;
-      basename = '';
-    } else if (path) {
+      name = '';
+    } else if (dirname && basename) {
+      // file in a subfolder
       dirname = `${dirname}/`;
+      name = basename;
+    } else {
+      // file at the top level
+      dirname = '';
+      name = path;
     }
 
     let file: ServerContents.IModel;
-    let name = '';
     switch (type) {
       case 'directory': {
         const counter = await this._incrementCounter('directory');
-        name += `Untitled Folder${counter || ''}`;
+        name = `Untitled Folder${counter || ''}`;
         file = {
           name,
           path: `${dirname}${name}`,
@@ -83,7 +90,7 @@ export class Contents implements IContents {
       case 'file': {
         const ext = options?.ext ?? '.txt';
         const counter = await this._incrementCounter('file');
-        name += basename || `untitled${counter || ''}${ext}`;
+        name = name || `untitled${counter || ''}${ext}`;
         file = {
           name,
           path: `${dirname}${name}`,
@@ -101,7 +108,7 @@ export class Contents implements IContents {
       }
       default: {
         const counter = await this._incrementCounter('notebook');
-        name += basename || `Untitled${counter || ''}.ipynb`;
+        name = name || `Untitled${counter || ''}.ipynb`;
         file = {
           name,
           path: `${dirname}${name}`,

--- a/packages/contents/src/tokens.ts
+++ b/packages/contents/src/tokens.ts
@@ -18,7 +18,9 @@ export interface IContents {
    *
    * @returns A promise which resolves with the created file content when the file is created.
    */
-  newUntitled(options?: ServerContents.ICreateOptions): Promise<ServerContents.IModel>;
+  newUntitled(
+    options?: ServerContents.ICreateOptions
+  ): Promise<ServerContents.IModel | null>;
 
   /**
    * Copy a file into a given directory.
@@ -68,7 +70,7 @@ export interface IContents {
   save(
     path: string,
     options?: Partial<ServerContents.IModel>
-  ): Promise<ServerContents.IModel>;
+  ): Promise<ServerContents.IModel | null>;
 
   /**
    * Delete a file.

--- a/packages/contents/src/tokens.ts
+++ b/packages/contents/src/tokens.ts
@@ -1,4 +1,4 @@
-import { Contents } from '@jupyterlab/services';
+import { Contents as ServerContents } from '@jupyterlab/services';
 
 import { Token } from '@lumino/coreutils';
 
@@ -10,4 +10,110 @@ export const IContents = new Token<IContents>('@jupyterlite/contents:IContents')
 /**
  * The interface for the contents service.
  */
-export interface IContents extends Contents.IManager {}
+export interface IContents {
+  /**
+   * Create a new untitled file or directory in the specified directory path.
+   *
+   * @param options: The options used to create the file.
+   *
+   * @returns A promise which resolves with the created file content when the file is created.
+   */
+  newUntitled(options?: ServerContents.ICreateOptions): Promise<ServerContents.IModel>;
+
+  /**
+   * Copy a file into a given directory.
+   *
+   * @param path - The original file path.
+   * @param toDir - The destination directory path.
+   *
+   * @returns A promise which resolves with the new contents model when the
+   *  file is copied.
+   *
+   * #### Notes
+   * The server will select the name of the copied file.
+   */
+  copy(path: string, toDir: string): Promise<ServerContents.IModel>;
+
+  /**
+   * Get a file or directory.
+   *
+   * @param path: The path to the file.
+   * @param options: The options used to fetch the file.
+   *
+   * @returns A promise which resolves with the file content.
+   */
+  get(
+    path: string,
+    options?: ServerContents.IFetchOptions
+  ): Promise<ServerContents.IModel | null>;
+
+  /**
+   * Rename a file or directory.
+   *
+   * @param oldLocalPath - The original file path.
+   * @param newLocalPath - The new file path.
+   *
+   * @returns A promise which resolves with the new file content model when the file is renamed.
+   */
+  rename(oldLocalPath: string, newLocalPath: string): Promise<ServerContents.IModel>;
+
+  /**
+   * Save a file.
+   *
+   * @param path - The desired file path.
+   * @param options - Optional overrides to the model.
+   *
+   * @returns A promise which resolves with the file content model when the file is saved.
+   */
+  save(
+    path: string,
+    options?: Partial<ServerContents.IModel>
+  ): Promise<ServerContents.IModel>;
+
+  /**
+   * Delete a file.
+   *
+   * @param path - The path to the file.
+   */
+  delete(path: string): Promise<void>;
+
+  /**
+   * Create a checkpoint for a file.
+   *
+   * @param path - The path of the file.
+   *
+   * @returns A promise which resolves with the new checkpoint model when the
+   *   checkpoint is created.
+   */
+  createCheckpoint(path: string): Promise<ServerContents.ICheckpointModel>;
+
+  /**
+   * List available checkpoints for a file.
+   *
+   * @param path - The path of the file.
+   *
+   * @returns A promise which resolves with a list of checkpoint models for
+   *    the file.
+   */
+  listCheckpoints(path: string): Promise<ServerContents.ICheckpointModel[]>;
+
+  /**
+   * Restore a file to a known checkpoint state.
+   *
+   * @param path - The path of the file.
+   * @param checkpointID - The id of the checkpoint to restore.
+   *
+   * @returns A promise which resolves when the checkpoint is restored.
+   */
+  restoreCheckpoint(path: string, checkpointID: string): Promise<void>;
+
+  /**
+   * Delete a checkpoint for a file.
+   *
+   * @param path - The path of the file.
+   * @param checkpointID - The id of the checkpoint to delete.
+   *
+   * @returns A promise which resolves when the checkpoint is deleted.
+   */
+  deleteCheckpoint(path: string, checkpointID: string): Promise<void>;
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -109,9 +109,9 @@ export class JupyterServer {
         file = await this._contents.copy(copyFrom, path);
       } else {
         file = await this._contents.newUntitled(options);
-        if (!file) {
-          return new Response(null, { status: 400 });
-        }
+      }
+      if (!file) {
+        return new Response(null, { status: 400 });
       }
       return new Response(JSON.stringify(file), { status: 201 });
     });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -104,11 +104,14 @@ export class JupyterServer {
     app.post('/api/contents(.*)', async (req: Router.IRequest, path: string) => {
       const options = req.body;
       const copyFrom = options?.copy_from as string;
-      let file: ServerContents.IModel;
+      let file: ServerContents.IModel | null;
       if (copyFrom) {
         file = await this._contents.copy(copyFrom, path);
       } else {
         file = await this._contents.newUntitled(options);
+        if (!file) {
+          return new Response(null, { status: 400 });
+        }
       }
       return new Response(JSON.stringify(file), { status: 201 });
     });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -94,6 +94,9 @@ export class JupyterServer {
         content: req.query?.content === '1'
       };
       const nb = await this._contents.get(filename, options);
+      if (!nb) {
+        return new Response(null, { status: 404 });
+      }
       return new Response(JSON.stringify(nb));
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #370 

## Code changes

Slight rework of the server contents manager to:

- not implement the frontend `Contents.IManager`
- return 404 on missing file, so it can correctly be handled on the frontend
- make some methods private (fetching server files)

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should fix the "Save As" as described in #370.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

The interface of the server contents manager changes (narrower).

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
