### PR TITLE
Automated Changelog Entry for 0.1.0a15 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a15
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a14...5981e991a428be1d5c0fd789a22b1875f9939f97))
+
+### Enhancements made
+
+- Add `@jupyterlab/javascript-extension` [#397](https://github.com/jupyterlite/jupyterlite/pull/397) ([@jtpio](https://github.com/jtpio))
+
+### Bugs fixed
+
+- Handle 404s when getting contents [#404](https://github.com/jupyterlite/jupyterlite/pull/404) ([@jtpio](https://github.com/jtpio))
+- Escape file path before saving [#399](https://github.com/jupyterlite/jupyterlite/pull/399) ([@jtpio](https://github.com/jtpio))
+- Better handle text files [#396](https://github.com/jupyterlite/jupyterlite/pull/396) ([@jtpio](https://github.com/jtpio))
+- Improve handling of IFrame elements [#394](https://github.com/jupyterlite/jupyterlite/pull/394) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Pass version spec as an input for check release [#401](https://github.com/jupyterlite/jupyterlite/pull/401) ([@jtpio](https://github.com/jtpio))
+
+### API and Breaking Changes
+
+- Handle 404s when getting contents [#404](https://github.com/jupyterlite/jupyterlite/pull/404) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-14&to=2021-11-03&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-10-14..2021-11-03&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-14..2021-11-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-14..2021-11-03&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a14
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a13...5d46a724d2518325e8ccdc88a9264bd99c99c358))
@@ -19,8 +50,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-12&to=2021-10-14&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-10-12..2021-10-14&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-12..2021-10-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-12..2021-10-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a13
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a15 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.15
@jupyterlite/app-retro: 0.1.0-alpha.15
@jupyterlite/app-lab: 0.1.0-alpha.15
@jupyterlite/pyolite-kernel: 0.1.0-alpha.15
@jupyterlite/iframe-extension: 0.1.0-alpha.15
@jupyterlite/application-extension: 0.1.0-alpha.15
@jupyterlite/retro-application-extension: 0.1.0-alpha.15
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.15
@jupyterlite/session: 0.1.0-alpha.15
@jupyterlite/translation: 0.1.0-alpha.15
@jupyterlite/ui-components: 0.1.0-alpha.15
@jupyterlite/server-extension: 0.1.0-alpha.15
@jupyterlite/settings: 0.1.0-alpha.15
@jupyterlite/kernel: 0.1.0-alpha.15
@jupyterlite/javascript-kernel: 0.1.0-alpha.15
@jupyterlite/metapackage: 0.1.0-alpha.15
@jupyterlite/server: 0.1.0-alpha.15
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.15
@jupyterlite/contents: 0.1.0-alpha.15
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a14 |