### PR TITLE
Automated Changelog Entry for 0.1.0a16 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a16
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a15...2e6a6cb7c0ef4474b45168db30dd405afcfe69a1))
+
+### Bugs fixed
+
+- Fix handling of existing folders on the server [#409](https://github.com/jupyterlite/jupyterlite/pull/409) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-11-03&to=2021-11-03&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-11-03..2021-11-03&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a15
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a14...5981e991a428be1d5c0fd789a22b1875f9939f97))
@@ -30,8 +46,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-10-14&to=2021-11-03&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-10-14..2021-11-03&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-10-14..2021-11-03&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-10-14..2021-11-03&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a14
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a16 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.16
@jupyterlite/app-retro: 0.1.0-alpha.16
@jupyterlite/app-lab: 0.1.0-alpha.16
@jupyterlite/pyolite-kernel: 0.1.0-alpha.16
@jupyterlite/iframe-extension: 0.1.0-alpha.16
@jupyterlite/application-extension: 0.1.0-alpha.16
@jupyterlite/retro-application-extension: 0.1.0-alpha.16
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.16
@jupyterlite/session: 0.1.0-alpha.16
@jupyterlite/translation: 0.1.0-alpha.16
@jupyterlite/ui-components: 0.1.0-alpha.16
@jupyterlite/server-extension: 0.1.0-alpha.16
@jupyterlite/settings: 0.1.0-alpha.16
@jupyterlite/kernel: 0.1.0-alpha.16
@jupyterlite/javascript-kernel: 0.1.0-alpha.16
@jupyterlite/metapackage: 0.1.0-alpha.16
@jupyterlite/server: 0.1.0-alpha.16
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.16
@jupyterlite/contents: 0.1.0-alpha.16
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a15 |