### PR TITLE
Add `exposeAppInBrowser` to the docs app

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -3,6 +3,7 @@
   "jupyter-config-data": {
     "appName": "JupyterLite Examples",
     "collaborative": true,
+    "exposeAppInBrowser": true,
     "disabledExtensions": [
       "@jupyterlab/server-proxy",
       "jupyterlab-server-proxy",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

So `window.jupyterlab` / `window.jupyterapp` becomes available on the RTD website.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Config change for the docs app.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Folks can tinker with `window.jupyterlab` (`window.jupyterapp` in retro) with the JavaScript display, `%%javascript` magic, or by opening the dev tools.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
