### PR TITLE
Version piplite with the `bump-version` script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,12 +3,12 @@ current_version = 0, 1, 0, "alpha", 16
 commit = False
 tag = False
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \"(?P<release>\S+)\"\,\ (?P<build>\d+)
-serialize = 
+serialize =
 	{major}, {minor}, {patch}, "{release}", {build}
 
 [bumpversion:part:release]
 optional_value = final
-values = 
+values =
 	alpha
 	beta
 	candidate

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -25,6 +25,7 @@ PYOLITE_PACKAGE = ROOT / "packages" / "pyolite-kernel"
 PYOLITE_PACKAGE_JSON = PYOLITE_PACKAGE / "package.json"
 PYOLITE_KERNEL_SOURCE = PYOLITE_PACKAGE / "src" / "kernel.ts"
 PYOLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "pyolite" / "pyolite" / "__init__.py"
+PIPITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
 
 
 def replace_in_file(path, pattern, replacement):
@@ -50,10 +51,14 @@ def postbump():
     replace_in_file(
         PYOLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
     )
+    replace_in_file(
+        PIPITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
+    )
 
     # bump pyolite version
     pyolite_json = json.loads(PYOLITE_PACKAGE_JSON.read_text(**ENC))
     pyolite_json["pyolite"]["packages"]["py/pyolite"] = py_version
+    pyolite_json["pyolite"]["packages"]["py/piplite"] = py_version
     PYOLITE_PACKAGE_JSON.write_text(json.dumps(pyolite_json), **ENC)
     run(f"yarn prettier --write {PYOLITE_PACKAGE_JSON}")
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -23,9 +23,8 @@ APP_JUPYTERLITE_JSON = ROOT / "app" / "jupyter-lite.json"
 
 PYOLITE_PACKAGE = ROOT / "packages" / "pyolite-kernel"
 PYOLITE_PACKAGE_JSON = PYOLITE_PACKAGE / "package.json"
-PYPI_SOURCE = PYOLITE_PACKAGE / "src" / "_pypi.ts"
 PYOLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "pyolite" / "pyolite" / "__init__.py"
-PIPITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
+PIPLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
 
 
 def replace_in_file(path, pattern, replacement):
@@ -44,20 +43,10 @@ def postbump():
 
     # bump pyolite wheel import
     replace_in_file(
-        PYPI_SOURCE,
-        "pyolite-(.*)-py3-none-any.whl",
-        f"pyolite-{py_version}-py3-none-any.whl",
-    )
-    replace_in_file(
-        PYPI_SOURCE,
-        "piplite-(.*)-py3-none-any.whl",
-        f"piplite-{py_version}-py3-none-any.whl",
-    )
-    replace_in_file(
         PYOLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
     )
     replace_in_file(
-        PIPITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
+        PIPLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
     )
 
     # bump pyolite version

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -30,6 +30,8 @@ PIPLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
 def replace_in_file(path, pattern, replacement):
     source = path.read_text(**ENC)
     replaced = re.sub(pattern, replacement, source)
+    if replaced == source:
+        raise ValueError("pattern not found")
     path.write_text(replaced, **ENC)
 
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -23,7 +23,7 @@ APP_JUPYTERLITE_JSON = ROOT / "app" / "jupyter-lite.json"
 
 PYOLITE_PACKAGE = ROOT / "packages" / "pyolite-kernel"
 PYOLITE_PACKAGE_JSON = PYOLITE_PACKAGE / "package.json"
-PYOLITE_KERNEL_SOURCE = PYOLITE_PACKAGE / "src" / "kernel.ts"
+PYPI_SOURCE = PYOLITE_PACKAGE / "src" / "_pypi.ts"
 PYOLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "pyolite" / "pyolite" / "__init__.py"
 PIPITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
 
@@ -44,9 +44,14 @@ def postbump():
 
     # bump pyolite wheel import
     replace_in_file(
-        PYOLITE_KERNEL_SOURCE,
+        PYPI_SOURCE,
         "pyolite-(.*)-py3-none-any.whl",
         f"pyolite-{py_version}-py3-none-any.whl",
+    )
+    replace_in_file(
+        PYPI_SOURCE,
+        "piplite-(.*)-py3-none-any.whl",
+        f"piplite-{py_version}-py3-none-any.whl",
     )
     replace_in_file(
         PYOLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #420 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the `bump-version.py` script to version the packages, as a follow-up to #310.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

So the following code snippet:

```python
import piplite
piplite.__version__
```

Gives a consistent version.

## Backwards-incompatible changes

None