### PR TITLE
Fix false positive for non-prebuilt extensions in wheels, MathJax check

### DIFF
--- a/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
+++ b/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
@@ -35,7 +35,7 @@ class FederatedExtensionAddon(BaseAddon):
                 *root.glob(f"*/{PACKAGE_JSON}"),
                 *root.glob(f"@*/*/{PACKAGE_JSON}"),
             ]
-            if self.is_prebuilt(json.loads(p).read_text(**UTF8))
+            if self.is_prebuilt(json.loads(p.read_text(**UTF8)))
         ]
 
     @property
@@ -154,7 +154,7 @@ class FederatedExtensionAddon(BaseAddon):
 
                     try:
                         is_prebuilt = self.is_prebuilt(
-                            json.loads(zf.extractfile(info).read().decode("utf-8"))
+                            json.loads(zf.read(info).decode("utf-8"))
                         )
                     except Exception as err:
                         print(f"... skipping {info}: {err}")
@@ -190,7 +190,7 @@ class FederatedExtensionAddon(BaseAddon):
             actions=[_extract],
         )
 
-    def is_prebuilt(pkg_json):
+    def is_prebuilt(self, pkg_json):
         """verify this is an actual pre-built extension, containing load information"""
         return pkg_json.get("jupyterlab", {}).get("_build", {}).get("load") is not None
 

--- a/py/jupyterlite/src/jupyterlite/addons/mathjax.py
+++ b/py/jupyterlite/src/jupyterlite/addons/mathjax.py
@@ -143,10 +143,10 @@ class MathjaxAddon(BaseAddon):
         if not mathjax_url or not mathjax_url.startswith("./"):
             return
 
-        mathjax_path = Path(self.manager.output_dir / mathjax_url)
-        assert mathjax_path.exists(), f"{mathjax_url} not found"
+        mathjax_path = Path(self.manager.output_dir / mathjax_url).parent
+        assert mathjax_path.exists(), f"{mathjax_path} not found"
         mathjax_js = mathjax_path / MATHJAX_JS
-        assert mathjax_js.exists(), f"{MATHJAX_JS} not found"
+        assert mathjax_js.exists(), f"{mathjax_js} not found"
 
         for config in config.get(MATHJAX_CONFIG, "").split(","):
             config_js = mathjax_path / "config/{config}.js"

--- a/py/jupyterlite/src/jupyterlite/addons/static.py
+++ b/py/jupyterlite/src/jupyterlite/addons/static.py
@@ -31,6 +31,8 @@ class StaticAddon(BaseAddon):
             actions=[
                 lambda: print(
                     f"""    tarball:  {self.app_archive.name} {int(self.app_archive.stat().st_size / (1024 * 1024))}MB"""
+                    if self.app_archive.exists()
+                    else "    tarball:  none"
                 ),
                 lambda: print(f"""    output:   {self.manager.output_dir}"""),
                 lambda: print(f"""    lite dir: {self.manager.lite_dir}"""),

--- a/py/jupyterlite/src/jupyterlite/tests/test_federated.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_federated.py
@@ -9,7 +9,12 @@ from .conftest import CONDA_PKGS, WHEELS
 
 @mark.parametrize(
     "remote,kind",
-    [[True, "wheel"], [True, "conda"], [False, "wheel"], [False, "conda"]],
+    [
+        [True, "wheel"],
+        [True, "conda"],
+        [False, "wheel"],
+        [False, "conda"],
+    ],
 )
 def test_federated_extensions(
     an_empty_lite_dir, script_runner, remote, kind, a_fixture_server


### PR DESCRIPTION
## References

- fixes #422
- additionally addresses problems in new checks from #419
- both noticed while trying to adopt some of these new features in https://github.com/deathbeds/ipydrawio/pull/74

## Code changes

- [x] checks `package.json` files to see if they are actually federated extensions in wheels and conda packages
- [ ] fix path for mathjax check (was getting extra `MathJax.js` appended)

## User-facing changes

- extra `package.json` will not trigger extra copies
- custom MathJax URLs will pass `check`

## Backwards-incompatible changes

- n/a