### PR TITLE
Bump Python packages with `tbump`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 **/_output
 **/lib
 **/node_modules
-**/package.json
 **/static
 
 .yarn-packages

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,6 @@ _pypi.ts
 
 # The changelog is updated by the releaser
 CHANGELOG.md
+
+# UI tests
+ui-tests/ui-tests-app

--- a/package.json
+++ b/package.json
@@ -1,1 +1,79 @@
-{"name": "@jupyterlite/root", "version": "0.1.0a17", "private": true, "homepage": "https://github.com/jupyterlite/jupyterlite", "bugs": {"url": "https://github.com/jupyterlite/jupyterlite/issues"}, "repository": {"type": "git", "url": "https://github.com/jupyterlite/jupyterlite"}, "license": "BSD-3-Clause", "author": "JupyterLite Contributors", "workspaces": {"packages": ["app", "app/*", "packages/*"]}, "scripts": {"bootstrap": "yarn && yarn clean && yarn build && yarn lint && yarn test", "build": "yarn build:lib && yarn build:app", "build:app": "lerna run build --stream --parallel --scope \"@jupyterlite/app-*\"", "build:lib": "lerna run build --scope @jupyterlite/metapackage", "build:prod": "lerna run build:prod", "build:python": "lerna run build:python", "build:test": "lerna run build:test", "clean": "lerna run clean", "docs": "typedoc", "eslint:fix": "eslint . --ext .ts,.tsx --fix --cache", "eslint:check": "eslint . --ext .ts,.tsx --cache", "install": "lerna bootstrap", "lint": "yarn prettier:fix && yarn eslint:fix", "lint:check": "yarn prettier:check && yarn eslint:check", "prettier:fix": "prettier --list-different --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml,.html}\"", "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml,.html}\"", "publish": "yarn clean && yarn build && lerna publish", "serve": "node scripts/serve.js", "serve:py": "cd app && python -m http.server -b 127.0.0.1", "test": "lerna run test", "update:dependency": "node ./node_modules/@jupyterlab/buildutils/lib/update-dependency.js --lerna", "watch": "run-p watch:lib watch:app", "watch:app": "lerna exec --stream --stream --parallel --scope \"@jupyterlite/app-*\" yarn watch", "watch:lib": "lerna exec --stream --scope @jupyterlite/metapackage yarn watch"}, "husky": {"hooks": {"pre-commit": "lint-staged"}}, "devDependencies": {"@jupyterlab/buildutils": "~3.2.0", "@typescript-eslint/eslint-plugin": "^4.28.2", "@typescript-eslint/parser": "^4.28.2", "eslint": "^7.30.0", "eslint-config-prettier": "^8.3.0", "eslint-plugin-jest": "^24.3.6", "eslint-plugin-prettier": "^3.4.0", "eslint-plugin-react": "^7.24.0", "extra-watch-webpack-plugin": "^1.0.3", "husky": "^3", "jest": "^26.4.2", "jest-junit": "^11.1.0", "jest-raw-loader": "^1.0.1", "jest-summary-reporter": "^0.0.2", "lerna": "^3.22.1", "lint-staged": "^10.4.0", "npm-run-all": "^4.1.5", "prettier": "^1.19.0", "rimraf": "^3.0.2", "shell-quote": "^1.7.2", "svgo": "^2.3.0", "typedoc": "^0.20.36", "typedoc-plugin-markdown": "~3.9.0", "typescript": "~4.2.3"}}
+{
+  "name": "@jupyterlite/root",
+  "version": "0.1.0a17",
+  "private": true,
+  "homepage": "https://github.com/jupyterlite/jupyterlite",
+  "bugs": {
+    "url": "https://github.com/jupyterlite/jupyterlite/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlite/jupyterlite"
+  },
+  "license": "BSD-3-Clause",
+  "author": "JupyterLite Contributors",
+  "workspaces": {
+    "packages": [
+      "app",
+      "app/*",
+      "packages/*"
+    ]
+  },
+  "scripts": {
+    "bootstrap": "yarn && yarn clean && yarn build && yarn lint && yarn test",
+    "build": "yarn build:lib && yarn build:app",
+    "build:app": "lerna run build --stream --parallel --scope \"@jupyterlite/app-*\"",
+    "build:lib": "lerna run build --scope @jupyterlite/metapackage",
+    "build:prod": "lerna run build:prod",
+    "build:python": "lerna run build:python",
+    "build:test": "lerna run build:test",
+    "clean": "lerna run clean",
+    "docs": "typedoc",
+    "eslint:fix": "eslint . --ext .ts,.tsx --fix --cache",
+    "eslint:check": "eslint . --ext .ts,.tsx --cache",
+    "install": "lerna bootstrap",
+    "lint": "yarn prettier:fix && yarn eslint:fix",
+    "lint:check": "yarn prettier:check && yarn eslint:check",
+    "prettier:fix": "prettier --list-different --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml,.html}\"",
+    "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml,.html}\"",
+    "publish": "yarn clean && yarn build && lerna publish",
+    "serve": "node scripts/serve.js",
+    "serve:py": "cd app && python -m http.server -b 127.0.0.1",
+    "test": "lerna run test",
+    "update:dependency": "node ./node_modules/@jupyterlab/buildutils/lib/update-dependency.js --lerna",
+    "watch": "run-p watch:lib watch:app",
+    "watch:app": "lerna exec --stream --stream --parallel --scope \"@jupyterlite/app-*\" yarn watch",
+    "watch:lib": "lerna exec --stream --scope @jupyterlite/metapackage yarn watch"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "devDependencies": {
+    "@jupyterlab/buildutils": "~3.2.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
+    "@typescript-eslint/parser": "^4.28.2",
+    "eslint": "^7.30.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jest": "^24.3.6",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-react": "^7.24.0",
+    "extra-watch-webpack-plugin": "^1.0.3",
+    "husky": "^3",
+    "jest": "^26.4.2",
+    "jest-junit": "^11.1.0",
+    "jest-raw-loader": "^1.0.1",
+    "jest-summary-reporter": "^0.0.2",
+    "lerna": "^3.22.1",
+    "lint-staged": "^10.4.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^1.19.0",
+    "rimraf": "^3.0.2",
+    "shell-quote": "^1.7.2",
+    "svgo": "^2.3.0",
+    "typedoc": "^0.20.36",
+    "typedoc-plugin-markdown": "~3.9.0",
+    "typescript": "~4.2.3"
+  }
+}

--- a/packages/pyolite-kernel/package.json
+++ b/packages/pyolite-kernel/package.json
@@ -1,1 +1,76 @@
-{"name": "@jupyterlite/pyolite-kernel", "version": "0.1.0-alpha.17", "description": "JupyterLite - Pyolite Kernel", "homepage": "https://github.com/jupyterlite/jupyterlite", "bugs": {"url": "https://github.com/jupyterlite/jupyterlite/issues"}, "repository": {"type": "git", "url": "https://github.com/jupyterlite/jupyterlite.git"}, "license": "BSD-3-Clause", "author": "JupyterLite Contributors", "sideEffects": ["style/*.css", "style/index.js"], "main": "lib/index.js", "types": "lib/index.d.ts", "style": "style/index.css", "directories": {"lib": "lib/", "py": "py/"}, "files": ["lib/*.d.ts", "lib/*.js.map", "lib/*.js", "style/*.css", "style/index.js", "pypi/*.{json,whl}"], "scripts": {"build": "yarn run build:lib", "build:lib": "tsc -b", "build:python": "python -m pip install build && cd py && python -m build -w", "build:test": "tsc --build tsconfig.test.json", "clean": "yarn run clean:lib && yarn run clean:python", "clean:lib": "rimraf lib && rimraf tsconfig.tsbuildinfo", "clean:python": "rimraf py/**/dist", "docs": "typedoc src", "prepublishOnly": "npm run build", "test": "jest", "test:cov": "jest --collect-coverage", "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand", "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch", "watch": "tsc -b --watch"}, "dependencies": {"@jupyterlite/kernel": "^0.1.0-alpha.17"}, "devDependencies": {"@babel/core": "^7.11.6", "@babel/preset-env": "^7.12.1", "@jupyterlab/testutils": "~3.2.0", "@types/jest": "^26.0.10", "jest": "^26.4.2", "rimraf": "~3.0.0", "ts-jest": "^26.3.0", "typescript": "~4.2.3"}, "publishConfig": {"access": "public"}, "pyolite": {"packages": {"py/pyolite": "0.1.0a17", "py/piplite": "0.1.0a17", "py/ipykernel": "5.5.5", "py/nbformat": "4.2.0", "py/widgetsnbextension": "3.5.0"}}, "styleModule": "style/index.js"}
+{
+  "name": "@jupyterlite/pyolite-kernel",
+  "version": "0.1.0-alpha.17",
+  "description": "JupyterLite - Pyolite Kernel",
+  "homepage": "https://github.com/jupyterlite/jupyterlite",
+  "bugs": {
+    "url": "https://github.com/jupyterlite/jupyterlite/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlite/jupyterlite.git"
+  },
+  "license": "BSD-3-Clause",
+  "author": "JupyterLite Contributors",
+  "sideEffects": [
+    "style/*.css",
+    "style/index.js"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "style": "style/index.css",
+  "directories": {
+    "lib": "lib/",
+    "py": "py/"
+  },
+  "files": [
+    "lib/*.d.ts",
+    "lib/*.js.map",
+    "lib/*.js",
+    "style/*.css",
+    "style/index.js",
+    "pypi/*.{json,whl}"
+  ],
+  "scripts": {
+    "build": "yarn run build:lib",
+    "build:lib": "tsc -b",
+    "build:python": "python -m pip install build && cd py && python -m build -w",
+    "build:test": "tsc --build tsconfig.test.json",
+    "clean": "yarn run clean:lib && yarn run clean:python",
+    "clean:lib": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "clean:python": "rimraf py/**/dist",
+    "docs": "typedoc src",
+    "prepublishOnly": "npm run build",
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "watch": "tsc -b --watch"
+  },
+  "dependencies": {
+    "@jupyterlite/kernel": "^0.1.0-alpha.17"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.12.1",
+    "@jupyterlab/testutils": "~3.2.0",
+    "@types/jest": "^26.0.10",
+    "jest": "^26.4.2",
+    "rimraf": "~3.0.0",
+    "ts-jest": "^26.3.0",
+    "typescript": "~4.2.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "pyolite": {
+    "packages": {
+      "py/pyolite": "0.1.0a17",
+      "py/piplite": "0.1.0a17",
+      "py/ipykernel": "5.5.5",
+      "py/nbformat": "4.2.0",
+      "py/widgetsnbextension": "3.5.0"
+    }
+  },
+  "styleModule": "style/index.js"
+}

--- a/packages/pyolite-kernel/py/piplite/pyproject.toml
+++ b/packages/pyolite-kernel/py/piplite/pyproject.toml
@@ -15,8 +15,12 @@ regex = '''
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
 '''
 
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
 [[tool.tbump.file]]
-src = "piplite/_version.py"
+src = "piplite/__init__.py"
 
 [[tool.tbump.field]]
 name = "channel"

--- a/packages/pyolite-kernel/py/piplite/pyproject.toml
+++ b/packages/pyolite-kernel/py/piplite/pyproject.toml
@@ -7,3 +7,21 @@ module = "piplite"
 author = "JupyterLite Contributors"
 home-page = "https://github.com/jupyterlite/jupyterlite"
 requires-python = ">=3.6"
+
+[tool.tbump.version]
+current = "0.1.0a17"
+regex = '''
+  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
+'''
+
+[[tool.tbump.file]]
+src = "piplite/_version.py"
+
+[[tool.tbump.field]]
+name = "channel"
+default = ""
+
+[[tool.tbump.field]]
+name = "release"
+default = ""

--- a/packages/pyolite-kernel/py/pyolite/pyproject.toml
+++ b/packages/pyolite-kernel/py/pyolite/pyproject.toml
@@ -7,3 +7,21 @@ module = "pyolite"
 author = "JupyterLite Contributors"
 home-page = "https://github.com/jupyterlite/jupyterlite"
 requires-python = ">=3.6"
+
+[tool.tbump.version]
+current = "0.1.0a17"
+regex = '''
+  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+  ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
+'''
+
+[[tool.tbump.file]]
+src = "pyolite/_version.py"
+
+[[tool.tbump.field]]
+name = "channel"
+default = ""
+
+[[tool.tbump.field]]
+name = "release"
+default = ""

--- a/packages/pyolite-kernel/py/pyolite/pyproject.toml
+++ b/packages/pyolite-kernel/py/pyolite/pyproject.toml
@@ -15,8 +15,12 @@ regex = '''
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?
 '''
 
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
 [[tool.tbump.file]]
-src = "pyolite/_version.py"
+src = "pyolite/__init__.py"
 
 [[tool.tbump.field]]
 name = "channel"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -23,16 +23,9 @@ APP_JUPYTERLITE_JSON = ROOT / "app" / "jupyter-lite.json"
 
 PYOLITE_PACKAGE = ROOT / "packages" / "pyolite-kernel"
 PYOLITE_PACKAGE_JSON = PYOLITE_PACKAGE / "package.json"
-PYOLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "pyolite" / "pyolite" / "__init__.py"
-PIPLITE_INIT_PY = PYOLITE_PACKAGE / "py" / "piplite" / "piplite" / "__init__.py"
-
-
-def replace_in_file(path, pattern, replacement):
-    source = path.read_text(**ENC)
-    replaced = re.sub(pattern, replacement, source)
-    if replaced == source:
-        raise ValueError("pattern not found")
-    path.write_text(replaced, **ENC)
+PYOLITE_PY_PACKAGE = PYOLITE_PACKAGE / "py" / "pyolite"
+PIPLITE_PY_PACKAGE = PYOLITE_PACKAGE / "py" / "piplite"
+TBUMP_CMD = "tbump --non-interactive --only-patch"
 
 
 def postbump():
@@ -43,15 +36,11 @@ def postbump():
         new_version.replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")
     )
 
-    # bump pyolite wheel import
-    replace_in_file(
-        PYOLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
-    )
-    replace_in_file(
-        PIPLITE_INIT_PY, "__version__ = (.*)", f'__version__ = "{py_version}"'
-    )
+    # bump pyolite and piplite py versions
+    run(f"{TBUMP_CMD} {py_version}", cwd=PYOLITE_PY_PACKAGE)
+    run(f"{TBUMP_CMD} {py_version}", cwd=PIPLITE_PY_PACKAGE)
 
-    # bump pyolite version
+    # bump pyolite js version
     pyolite_json = json.loads(PYOLITE_PACKAGE_JSON.read_text(**ENC))
     pyolite_json["pyolite"]["packages"]["py/pyolite"] = py_version
     pyolite_json["pyolite"]["packages"]["py/piplite"] = py_version

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -7,7 +7,6 @@
 # - https://github.com/voila-dashboards/voila/blob/master/scripts/bump-version.py
 
 import json
-import re
 from pathlib import Path
 
 import click


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #421, so the bump is less brittle.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Bump `pyolite` and `piplite` with `tbump`
- [x] Fixes `package.json` files not being formatted by prettier
- [x] Reformat existing `packages.json` with prettier

Keeping `bump2version` for now to handle `patch`, `minor`, ... specs easily, and derive the other versions from the main `jupyterlite` version.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
