### PR TITLE
Automated Changelog Entry for 0.1.0a19 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a19
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a18...6c23eaf30b567bfc2f4a7f3b1b0b2b75f0f54e38))
+
+### Enhancements made
+
+- Update to pyodide 0.19.0 [#433](https://github.com/jupyterlite/jupyterlite/pull/433) ([@bollwyvl](https://github.com/bollwyvl))
+
+### Maintenance and upkeep improvements
+
+- Update to JupyerLab 3.2.6 and RetroLab 0.3.16 [#441](https://github.com/jupyterlite/jupyterlite/pull/441) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-12-06&to=2022-01-12&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-12-06..2022-01-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-12-06..2022-01-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-12-06..2022-01-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a18
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a17...31d33608863e34105ae65d66b86537a8e631391a))
@@ -21,8 +41,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-11-26&to=2021-12-06&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-11-26..2021-12-06&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-11-26..2021-12-06&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-11-26..2021-12-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a17
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a19 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.19
@jupyterlite/app-lab: 0.1.0-alpha.19
@jupyterlite/app-retro: 0.1.0-alpha.19
@jupyterlite/metapackage: 0.1.0-alpha.19
@jupyterlite/application-extension: 0.1.0-alpha.19
@jupyterlite/contents: 0.1.0-alpha.19
@jupyterlite/iframe-extension: 0.1.0-alpha.19
@jupyterlite/javascript-kernel: 0.1.0-alpha.19
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.19
@jupyterlite/kernel: 0.1.0-alpha.19
@jupyterlite/pyolite-kernel: 0.1.0-alpha.19
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.19
@jupyterlite/retro-application-extension: 0.1.0-alpha.19
@jupyterlite/server: 0.1.0-alpha.19
@jupyterlite/server-extension: 0.1.0-alpha.19
@jupyterlite/session: 0.1.0-alpha.19
@jupyterlite/settings: 0.1.0-alpha.19
@jupyterlite/translation: 0.1.0-alpha.19
@jupyterlite/ui-components: 0.1.0-alpha.19
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a18 |