### PR TITLE
Automated Changelog Entry for 0.1.0a20 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a20
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a19...18d3bf5dd04e88c320c3ad95a9c6e77695280d1b))
+
+### Enhancements made
+
+- Allow contents and settings storage names to be configured [#449](https://github.com/jupyterlite/jupyterlite/pull/449) ([@bollwyvl](https://github.com/bollwyvl))
+
+### Bugs fixed
+
+- Update to `jupyterlab-fasta==3.2.0` in docs app [#453](https://github.com/jupyterlite/jupyterlite/pull/453) ([@jtpio](https://github.com/jtpio))
+- Disable jedi to fix tab completion issue [#448](https://github.com/jupyterlite/jupyterlite/pull/448) ([@qqdaiyu55](https://github.com/qqdaiyu55))
+
+### Documentation improvements
+
+- [DOCS] Adding introductory documentation to the launch buttons [#432](https://github.com/jupyterlite/jupyterlite/pull/432) ([@choldgraf](https://github.com/choldgraf))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2022-01-12&to=2022-01-18&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2022-01-12..2022-01-18&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Acholdgraf+updated%3A2022-01-12..2022-01-18&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2022-01-12..2022-01-18&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2022-01-12..2022-01-18&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3AmartinRenou+updated%3A2022-01-12..2022-01-18&type=Issues) | [@qqdaiyu55](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Aqqdaiyu55+updated%3A2022-01-12..2022-01-18&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a19
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0a18...6c23eaf30b567bfc2f4a7f3b1b0b2b75f0f54e38))
@@ -19,8 +44,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2021-12-06&to=2022-01-12&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2021-12-06..2022-01-12&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2021-12-06..2022-01-12&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2021-12-06..2022-01-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0a18
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a20 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-alpha.20
@jupyterlite/app-lab: 0.1.0-alpha.20
@jupyterlite/app-retro: 0.1.0-alpha.20
@jupyterlite/metapackage: 0.1.0-alpha.20
@jupyterlite/application-extension: 0.1.0-alpha.20
@jupyterlite/contents: 0.1.0-alpha.20
@jupyterlite/iframe-extension: 0.1.0-alpha.20
@jupyterlite/javascript-kernel: 0.1.0-alpha.20
@jupyterlite/javascript-kernel-extension: 0.1.0-alpha.20
@jupyterlite/kernel: 0.1.0-alpha.20
@jupyterlite/pyolite-kernel: 0.1.0-alpha.20
@jupyterlite/pyolite-kernel-extension: 0.1.0-alpha.20
@jupyterlite/retro-application-extension: 0.1.0-alpha.20
@jupyterlite/server: 0.1.0-alpha.20
@jupyterlite/server-extension: 0.1.0-alpha.20
@jupyterlite/session: 0.1.0-alpha.20
@jupyterlite/settings: 0.1.0-alpha.20
@jupyterlite/translation: 0.1.0-alpha.20
@jupyterlite/ui-components: 0.1.0-alpha.20
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0a19 |