### PR TITLE
[wip] Use appUrl and file name for shareable link

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -919,6 +919,7 @@ class L:
     ALL_ESLINT = _clean_paths(
         P.PACKAGES.rglob("*/src/**/*.js"),
         P.PACKAGES.rglob("*/src/**/*.ts"),
+        P.PACKAGES.rglob("*/src/**/*.tsx"),
     )
     ALL_JSON = _clean_paths(
         P.PACKAGE_JSONS,

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -518,7 +518,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        const url = new URL(URLExt.join(PageConfig.getBaseUrl(), 'lab'));
+        const url = new URL(URLExt.join(PageConfig.getBaseUrl(), 'lab', 'index.html'));
         const models = toArray(
           filter(widget.selectedItems(), item => item.type !== 'directory')
         );

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -498,13 +498,11 @@ const opener: JupyterFrontEndPlugin<void> = {
 const shareFile: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/application-extension:share-file',
   requires: [IFileBrowserFactory, ITranslator],
-  optional: [ICommandPalette],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     factory: IFileBrowserFactory,
-    translator: ITranslator,
-    palette?: ICommandPalette
+    translator: ITranslator
   ): void => {
     const trans = translator.load('jupyterlab');
     const { commands } = app;
@@ -520,7 +518,15 @@ const shareFile: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        const url = new URL(URLExt.join(PageConfig.getOption('appUrl'), 'index.html'));
+        const url = new URL(
+          URLExt.join(
+            PageConfig.getBaseUrl(),
+            PageConfig.getOption('appUrl').slice(
+              PageConfig.getOption('baseUrl').length
+            ),
+            'index.html'
+          )
+        );
         const models = toArray(
           filter(widget.selectedItems(), item => item.type !== 'directory')
         );
@@ -538,13 +544,6 @@ const shareFile: JupyterFrontEndPlugin<void> = {
       icon: linkIcon.bindprops({ stylesheet: 'menuItem' }),
       label: trans.__('Copy Shareable Link')
     });
-
-    if (palette) {
-      palette.addItem({
-        command: CommandIDs.copyShareableLink,
-        category: trans.__('File Operations')
-      });
-    }
   }
 };
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -498,11 +498,13 @@ const opener: JupyterFrontEndPlugin<void> = {
 const shareFile: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/application-extension:share-file',
   requires: [IFileBrowserFactory, ITranslator],
+  optional: [ICommandPalette],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     factory: IFileBrowserFactory,
-    translator: ITranslator
+    translator: ITranslator,
+    palette?: ICommandPalette
   ): void => {
     const trans = translator.load('jupyterlab');
     const { commands } = app;
@@ -536,6 +538,13 @@ const shareFile: JupyterFrontEndPlugin<void> = {
       icon: linkIcon.bindprops({ stylesheet: 'menuItem' }),
       label: trans.__('Copy Shareable Link')
     });
+
+    if (palette) {
+      palette.addItem({
+        command: CommandIDs.copyShareableLink,
+        category: trans.__('File Operations')
+      });
+    }
   }
 };
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -520,7 +520,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
           return;
         }
 
-        const url = new URL(URLExt.join(PageConfig.getBaseUrl(), 'lab', 'index.html'));
+        const url = new URL(URLExt.join(PageConfig.getOption('appUrl'), 'index.html'));
         const models = toArray(
           filter(widget.selectedItems(), item => item.type !== 'directory')
         );


### PR DESCRIPTION
## References

- fixes #450
- follow-on to #382
- might address #398

## Code changes

- uses `{appUrl}/index.html` (where `appUrl` is usually `lab`) for the full link

## User-facing changes

- the back button should work after redirecting (should be able to test from the rtd preview)

## Backwards-incompatible changes

- n/a

## Future work

We might want to open up the API to support making the shareable params configurable. For example, jupyter-video chat offers the `?jvc=room` feature, and it would make sense to be able to share that room state as well. 

This also initially supported the command palette, but I've rolled this back, as I didn't realize it only applied to the selection from the file tree, not the main area. This would probably be a useful feature in its own right, but would have a different name, e.g. _Copy Workspace Link_ or something along those lines, and is probably out of scope