### PR TITLE
Add the lite now badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # JupyterLite
 
-[![ci-badge]][ci] [![binder-badge]][binder] [![docs-badge]][docs]
+[![ci-badge]][ci] [![lite-badge]][lite] [![binder-badge]][binder] [![docs-badge]][docs]
 
 [ci-badge]: https://github.com/jupyterlite/jupyterlite/workflows/Build/badge.svg
+[lite-badge]: https://gist.githubusercontent.com/bollwyvl/72565d11c9f0340c98c8199438cd63d5/raw/d78510cafbc45f83eba2acf51a38e5885d0bb3ce/badge.svg
+[lite]: https://jupyterlite.rtfd.io/en/latest/try/lab
 [ci]: https://github.com/jupyterlite/jupyterlite/actions?query=branch%3Amain
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/jupyterlite/jupyterlite/main?urlpath=lab


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

So it pops up a bit more on the README.md:

![image](https://user-images.githubusercontent.com/591645/153562370-ebaa9351-aa0e-475e-98ba-67b8bb3b68f1.png)

We should eventually host that badge somewhere in the `jupyterlite` org for nicer URLs, for example:

- in a new design repo: https://jupyterlite.github.io/design/badge.svg
- on the demo site: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update `README.md`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Folks landing on the README directly for example from the PyPI page can more easily try the RTD demo.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
