### PR TITLE
add badge

### DIFF
--- a/docs/_static/badge.svg
+++ b/docs/_static/badge.svg
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="86"
+   height="20"
+   viewBox="0 0 22.754166 5.2916668"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="badge.svg">
+  <defs
+     id="defs2">
+    <path
+       d="m 1.74498,5.47533 c 0,1.55802 -0.12464,2.06549 -0.44515,2.43941 C 0.943119,8.23595 0.480024,8.41358 0,8.41331 L 0.124642,9.3036 C 0.86884,9.31366 1.59095,9.05078 2.15452,8.56466 2.45775,8.19487 2.6834,7.76781 2.818,7.30893 2.95261,6.85005 2.99341,6.36876 2.93798,5.89377 V 0 h -1.193 v 5.43972 z"
+       id="path0_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 5.50204,4.76309 c 0,0.66772 0,1.26422 0.05341,1.78059 H 4.496 L 4.42478,5.48423 C 4.20318,5.85909 3.88627,6.16858 3.50628,6.38125 3.12628,6.59392 2.69675,6.70219 2.26135,6.69503 1.22861,6.69503 0,6.13415 0,3.84608 V 0.0445149 H 1.193 V 3.6057 c 0,1.23752 0.38283,2.06549 1.46009,2.06549 C 2.87472,5.67358 3.09459,5.63168 3.29982,5.54796 3.50505,5.46424 3.69149,5.34039 3.84822,5.18366 4.00494,5.02694 4.1288,4.84049 4.21252,4.63527 4.29623,4.43004 4.33813,4.21016 4.33575,3.98853 V 0 h 1.19299 v 4.72748 z"
+       id="path1_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 0.0534178,2.27264 c 0,-0.82798 0,-1.504604 -0.0534178,-2.118909 H 1.06836 L 1.12177,1.2666 C 1.3598,0.864535 1.70247,0.534594 2.11325,0.311954 2.52404,0.0893145 2.98754,-0.0176786 3.45435,0.00238095 c 1.58473,0 2.77773,1.32653905 2.77773,3.30299905 0,2.33258 -1.43338,3.48997 -2.9825,3.48997 C 2.85309,6.81304 2.45874,6.7281 2.10469,6.54874 1.75064,6.36937 1.44888,6.10166 1.22861,5.77151 v 0 3.56118 H 0.0534178 V 2.29935 Z M 1.22861,4.00872 c 0.00323,0.16154 0.02111,0.32245 0.05342,0.48076 0.10101,0.39531 0.33096,0.74565 0.65345,0.99558 0.3225,0.24994 0.71913,0.3852 1.12714,0.38438 1.25532,0 1.99427,-1.02384 1.99427,-2.51064 0,-1.29983 -0.69443,-2.412704 -1.94975,-2.412704 C 2.61036,0.986777 2.14548,1.20726 1.79965,1.5662 1.45382,1.92514 1.25079,2.3979 1.22861,2.89585 Z"
+       id="path2_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1.31764,0.0178059 2.75102,3.85499 C 2.90237,4.28233 3.06262,4.7987 3.16946,5.18153 3.2941,4.7898 3.42764,4.29123 3.5879,3.82828 L 4.88773,0.0178059 H 6.14305 L 4.36246,4.64735 C 3.47216,6.87309 2.92908,8.02158 2.11,8.71601 1.69745,9.09283 1.19448,9.35658 0.649917,9.48166 L 0.356119,8.48453 C 0.736886,8.35942 1.09038,8.16304 1.39777,7.90584 1.8321,7.55188 2.17678,7.10044 2.4038,6.5882 2.45239,6.49949 2.48551,6.40314 2.50173,6.3033 2.49161,6.19586 2.46457,6.0907 2.42161,5.9917 L 0,0 h 1.29983 z"
+       id="path3_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 2.19013,0 V 1.86962 H 3.8995 v 0.8903 H 2.19013 v 3.50777 c 0,0.80127 0.23148,1.26422 0.8903,1.26422 C 3.31442,7.53574 3.54789,7.5088 3.77486,7.45179 L 3.82828,8.34208 C 3.48794,8.45999 3.12881,8.51431 2.76882,8.50234 2.53042,8.51726 2.29161,8.48043 2.06878,8.39437 1.84595,8.30831 1.64438,8.17506 1.47789,8.00377 1.11525,7.51873 0.949826,6.91431 1.01494,6.31221 V 2.75102 H 0 V 1.86072 H 1.03274 V 0.275992 Z"
+       id="path4_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 1.17716,3.57899 C 1.153,3.88093 1.19468,4.18451 1.29933,4.46876 1.40398,4.75301 1.5691,5.01114 1.78329,5.22532 1.99747,5.43951 2.2556,5.60463 2.53985,5.70928 2.8241,5.81393 3.12768,5.85561 3.42962,5.83145 4.04033,5.84511 4.64706,5.72983 5.21021,5.49313 l 0.20477,0.8903 C 4.72393,6.66809 3.98085,6.80458 3.23375,6.78406 2.79821,6.81388 2.36138,6.74914 1.95322,6.59427 1.54505,6.43941 1.17522,6.19809 0.869071,5.88688 0.562928,5.57566 0.327723,5.2019 0.179591,4.79125 0.0314584,4.38059 -0.0260962,3.94276 0.0108748,3.50777 0.0108748,1.54912 1.17716,0 3.0824,0 c 2.13671,0 2.67089,1.86962 2.67089,3.06262 0.01142,0.18382 0.01142,0.36817 0,0.55199 H 1.15046 Z M 4.66713,2.6887 C 4.70149,2.45067 4.68443,2.20805 4.61709,1.97718 4.54976,1.74631 4.43372,1.53255 4.2768,1.35031 4.11987,1.16808 3.92571,1.0216 3.70739,0.920744 3.48907,0.81989 3.25166,0.767006 3.01118,0.765656 2.52201,0.801064 2.06371,1.01788 1.72609,1.37362 1.38847,1.72935 1.19588,2.19835 1.18607,2.6887 Z"
+       id="path5_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 0.0534178,2.19228 c 0,-0.76565 0,-1.424474 -0.0534178,-2.029876 H 1.06836 V 1.43553 H 1.12177 C 1.23391,1.04259 1.4656,0.694314 1.78468,0.439049 2.10376,0.183783 2.4944,0.034196 2.90237,0.0110538 c 0.11229,-0.01473839 0.22602,-0.01473839 0.33831,0 V 1.12393 C 3.10462,1.10817 2.9672,1.10817 2.83114,1.12393 2.427,1.13958 2.04237,1.30182 1.7491,1.58035 1.45583,1.85887 1.27398,2.23462 1.23751,2.63743 1.20422,2.8196 1.18635,3.00425 1.1841,3.18941 V 6.65267 H 0.00890297 V 2.20118 Z"
+       id="path6_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 6.03059,2.83565 C 6.06715,3.43376 5.92485,4.02921 5.6218,4.54615 5.31875,5.0631 4.86869,5.47813 4.32893,5.73839 3.78917,5.99864 3.18416,6.09233 2.59097,6.00753 1.99778,5.92272 1.44326,5.66326 0.998048,5.26219 0.552837,4.86113 0.23709,4.33661 0.0910307,3.75546 -0.0550287,3.17431 -0.0247891,2.56283 0.177897,1.99893 0.380583,1.43503 0.746541,0.944221 1.22915,0.589037 1.71176,0.233853 2.28918,0.0303686 2.88784,0.00450543 3.28035,-0.0170932 3.67326,0.0391144 4.04396,0.169896 4.41467,0.300677 4.75587,0.503453 5.04794,0.766561 5.34,1.02967 5.57718,1.34792 5.74582,1.70301 5.91446,2.0581 6.01124,2.44303 6.03059,2.83565 Z"
+       id="path7_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 18.6962,7.12238 C 10.6836,7.12238 3.64131,4.24672 0,0 1.41284,3.82041 3.96215,7.1163 7.30479,9.44404 10.6474,11.7718 14.623,13.0196 18.6962,13.0196 c 4.0733,0 8.0488,-1.2478 11.3915,-3.57556 C 33.4303,7.1163 35.9796,3.82041 37.3925,0 33.7601,4.24672 26.7445,7.12238 18.6962,7.12238 Z"
+       id="path8_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 18.6962,5.89725 c 8.0127,0 15.055,2.87566 18.6963,7.12235 C 35.9796,9.19922 33.4303,5.90333 30.0877,3.57559 26.745,1.24785 22.7695,0 18.6962,0 14.623,0 10.6474,1.24785 7.30479,3.57559 3.96215,5.90333 1.41284,9.19922 0,13.0196 3.64131,8.76401 10.648,5.89725 18.6962,5.89725 Z"
+       id="path9_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 7.59576,3.56656 C 7.64276,4.31992 7.46442,5.07022 7.08347,5.72186 6.70251,6.3735 6.13619,6.89698 5.45666,7.22561 4.77713,7.55424 4.01515,7.67314 3.26781,7.56716 2.52046,7.46117 1.82158,7.13511 1.26021,6.63051 0.698839,6.12591 0.300394,5.46561 0.115637,4.73375 -0.0691191,4.00188 -0.0318219,3.23159 0.222777,2.52099 0.477376,1.8104 0.93775,1.19169 1.54524,0.743685 2.15274,0.295678 2.87985,0.0386595 3.63394,0.00537589 4.12793,-0.0210471 4.62229,0.0501173 5.08878,0.214803 5.55526,0.37949 5.98473,0.63447 6.35264,0.965179 6.72055,1.29589 7.01971,1.69584 7.233,2.1422 7.4463,2.58855 7.56957,3.07256 7.59576,3.56656 Z"
+       id="path10_fill"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 2.25061,4.37943 C 1.81886,4.39135 1.39322,4.27535 1.02722,4.04602 0.661224,3.81668 0.371206,3.48424 0.193641,3.09052 0.0160762,2.69679 -0.0411078,2.25935 0.0292804,1.83321 0.0996686,1.40707 0.294486,1.01125 0.589233,0.695542 0.883981,0.37983 1.2655,0.158316 1.68581,0.0588577 2.10611,-0.0406005 2.54644,-0.0135622 2.95143,0.136572 3.35641,0.286707 3.70796,0.553234 3.96186,0.902636 4.21577,1.25204 4.3607,1.66872 4.37842,2.10027 4.39529,2.6838 4.18131,3.25044 3.78293,3.67715 3.38455,4.10387 2.83392,4.35623 2.25061,4.37943 Z"
+       id="path11_fill"
+       inkscape:connector-curvature="0" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="60.624958"
+     inkscape:cy="18.991336"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="3840"
+     inkscape:window-height="2032"
+     inkscape:window-x="0"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     units="px"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2278"
+       originx="-2.0038469"
+       originy="8.9778788" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="as paths"
+     transform="translate(-2.0038483,-20.619548)"
+     style="display:none">
+    <g
+       id="g1743"
+       transform="matrix(0.26458333,0,0,0.26458333,2.0038483,20.619547)">
+      <path
+         style="fill:#555555"
+         inkscape:connector-curvature="0"
+         d="M 0,0 H 35 V 20 H 0 Z"
+         id="path1708" />
+      <path
+         style="fill:#44cc11"
+         inkscape:connector-curvature="0"
+         d="M 35,0 H 86 V 20 H 35 Z"
+         id="path1710" />
+      <path
+         style="fill:url(#b)"
+         inkscape:connector-curvature="0"
+         d="M 0,0 H 86 V 20 H 0 Z"
+         id="path1712" />
+      <g
+         id="g1724"
+         font-size="110"
+         style="font-size:110px;font-family:'DejaVu Sans', Verdana, Geneva, sans-serif;text-anchor:middle;fill:#ffffff">
+        <text
+           id="text1716"
+           textLength="250"
+           transform="scale(0.1)"
+           y="150"
+           x="185"
+           lengthAdjust="spacing"
+           style="fill:#010101;fill-opacity:0.3">docs</text>
+        <text
+           id="text1718"
+           textLength="250"
+           transform="scale(0.1)"
+           y="140"
+           x="185"
+           lengthAdjust="spacing">docs</text>
+        <text
+           id="text1720"
+           textLength="410"
+           transform="scale(0.1)"
+           y="150"
+           x="595"
+           lengthAdjust="spacing"
+           style="fill:#010101;fill-opacity:0.3">passing</text>
+        <text
+           id="text1722"
+           textLength="410"
+           transform="scale(0.1)"
+           y="140"
+           x="595"
+           lengthAdjust="spacing">passing</text>
+      </g>
+      <rect
+         style="opacity:1;vector-effect:none;fill:#555555;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill"
+         id="rect1748"
+         width="35"
+         height="20"
+         x="0"
+         y="1e-06" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="ours"
+     transform="translate(-0.59531249,-21.067448)">
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#555555;fill-opacity:1;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill"
+       d="m 4.875,79.625 c -1.45425,0 -2.625,1.17075 -2.625,2.625 V 97 c 0,1.45425 1.17075,2.625 2.625,2.625 H 37.25 v -20 z"
+       transform="scale(0.26458333)"
+       id="rect1796"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#f7dc1e;fill-opacity:1;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke markers fill"
+       d="m 37.25,79.625 v 20 h 48.375 c 1.45425,0 2.625,-1.17075 2.625,-2.625 V 82.25 c 0,-1.45425 -1.17075,-2.625 -2.625,-2.625 z"
+       transform="scale(0.26458333)"
+       id="rect1816"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g1762"
+       transform="matrix(0.24468283,0,0,0.24468283,0.89290335,21.630519)"
+       style="stroke-width:4.0869236">
+      <circle
+         style="display:inline;opacity:1;vector-effect:none;fill:#f7dc1e;fill-opacity:1;stroke:none;stroke-width:1.08133185;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+         id="circle2280"
+         cx="83.727013"
+         cy="85.632706"
+         r="6.5982165"
+         transform="translate(-75.191093,-79.024914)" />
+      <rect
+         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:8.1738472;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect2282"
+         width="5.6534319"
+         height="1.0099131"
+         x="80.831047"
+         y="92.343979"
+         ry="0.4125087"
+         rx="0.4125087"
+         transform="translate(-75.191093,-79.024914)" />
+      <rect
+         y="93.671165"
+         x="80.837059"
+         height="1.030736"
+         width="5.6413827"
+         id="rect2284"
+         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:8.17384624;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         ry="0.42101401"
+         rx="0.42101401"
+         transform="translate(-75.191093,-79.024914)" />
+      <rect
+         style="display:inline;opacity:1;vector-effect:none;fill:#f9f9f9;fill-opacity:1;stroke:none;stroke-width:8.1738472;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+         id="rect2286"
+         width="3.2399781"
+         height="1.0203246"
+         x="82.037766"
+         y="95.019188"
+         ry="0.41676137"
+         rx="0.41676137"
+         transform="translate(-75.191093,-79.024914)" />
+      <g
+         style="display:inline;fill:#1a1a1a;stroke-width:4.0869236"
+         id="g2302-0"
+         transform="translate(-76.408728,-79.472762)">
+        <g
+           id="text2294-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46666718px;line-height:1.25;font-family:Vibur;-inkscape-font-specification:'Vibur, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;stroke-width:1.08133185"
+           aria-label="l">
+          <path
+             inkscape:connector-curvature="0"
+             id="path3517"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46666718px;font-family:Vibur;-inkscape-font-specification:'Vibur, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;stroke-width:1.08133185"
+             d="m 87.065449,90.288925 q -0.996322,-0.04134 -1.475879,-1.21543 -0.355534,-0.8847 -0.355534,-2.166276 0,-0.06615 0.0083,-0.169498 0.05788,-0.872299 0.322461,-1.599903 0.429948,-1.174089 1.21543,-1.174089 0.04134,0 0.08682,0.0041 0.715202,0.04547 0.715202,0.830957 0,0.855761 -0.735872,1.901692 -0.467155,0.665593 -0.979786,1.079004 0.14056,0.785482 0.310059,1.178223 0.314193,0.727604 0.93431,0.727604 0.04134,0 0.08682,-0.0083 0.136426,-0.02481 0.380339,-0.198437 0.235644,-0.161231 0.367936,-0.161231 0.05788,0 0.111621,0.03721 0.11989,0.08268 0.11989,0.223242 -0.0083,0.214974 -0.305925,0.442351 -0.37207,0.268717 -0.806152,0.268717 z m -0.28112,-5.700944 q -0.243913,0.0041 -0.429948,0.21084 -0.471289,0.5333 -0.516764,2.228288 0.248046,-0.252181 0.496093,-0.595313 0.686263,-0.938444 0.686263,-1.583366 0,-0.03307 -0.01654,-0.07855 -0.06615,-0.181901 -0.219108,-0.181901 z" />
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           id="circle2296-6"
+           d="m 84.998267,83.663261 a 0.69437253,0.69437253 0 0 1 -0.694373,0.694373 0.69437253,0.69437253 0 0 1 -0.694372,-0.694373 0.69437253,0.69437253 0 0 1 0.694372,-0.694372 0.69437253,0.69437253 0 0 1 0.694373,0.694372 z"
+           style="opacity:1;vector-effect:none;fill:#1a1a1a;fill-opacity:1;stroke:none;stroke-width:1.08133185;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+        <g
+           id="text2300-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46666718px;line-height:1.25;font-family:Vibur;-inkscape-font-specification:'Vibur, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;stroke-width:1.08133185"
+           aria-label="j">
+          <path
+             inkscape:connector-curvature="0"
+             id="path3521"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46666718px;font-family:Vibur;-inkscape-font-specification:'Vibur, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;stroke-width:1.08133185"
+             d="m 84.15503,84.666527 q 0.268717,0.0041 0.276986,0.3514 l -0.458887,3.282487 q 1.033529,-0.789616 1.161686,-0.892969 0.152962,-0.132291 0.314193,-0.136426 0.05788,0 0.111621,0.03721 0.119889,0.08268 0.119889,0.21084 -0.0041,0.198438 -0.223242,0.384473 -0.607715,0.51263 -1.608171,1.260905 l -0.190169,1.368392 q -0.0124,0.09508 -0.03721,0.186035 -0.190169,0.727604 -0.95498,0.727604 -0.380339,0 -0.669727,-0.285254 -0.285254,-0.285253 -0.285254,-0.640787 0,-0.372071 0.177767,-0.611849 0.09922,-0.124024 0.388607,-0.338998 l 0.992187,-0.74414 q 0.525033,-3.468523 0.537435,-3.64629 0,-0.0248 0.0041,-0.04548 0.04548,-0.467155 0.343132,-0.467155 z m -1.087272,5.53558 q 0,0 0.07028,-0.504362 l -0.458887,0.3514 q -0.297656,0.223242 -0.30179,0.421679 0,0.07028 0.0248,0.132292 0.07028,0.181901 0.264584,0.181901 0.07855,0 0.140559,-0.02481 0.198438,-0.08682 0.26045,-0.558105 z m 0.897103,-6.325196 q 0,-0.07441 0.03721,-0.14056 0.08682,-0.16123 0.268717,-0.16123 0.07441,0 0.144694,0.03721 0.157096,0.08682 0.157096,0.264583 0,0.07441 -0.03721,0.144694 -0.08682,0.157097 -0.264583,0.157097 -0.07441,0 -0.144694,-0.03721 -0.16123,-0.08268 -0.16123,-0.264584 z" />
+        </g>
+      </g>
+    </g>
+    <text
+       id="text1824"
+       y="24.903906"
+       x="11.021549"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:2.82222223px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:0.53197674;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'DejaVu Sans', Verdana, Geneva, sans-serif;-inkscape-font-specification:'DejaVu Sans, Verdana, Geneva, sans-serif';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:0.53197674;stroke-width:0.26458332"
+         y="24.903906"
+         x="11.021549"
+         id="tspan1822"
+         sodipodi:role="line">lite now</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:2.82222223px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;fill-opacity:0.53197674;stroke-width:0.26458332"
+       x="5.2515979"
+       y="24.903906"
+       id="text1898"><tspan
+         sodipodi:role="line"
+         id="tspan1896"
+         x="5.2515979"
+         y="24.903906"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'DejaVu Sans', Verdana, Geneva, sans-serif;-inkscape-font-specification:'DejaVu Sans, Verdana, Geneva, sans-serif';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#1a1a1a;fill-opacity:0.53197674;stroke-width:0.26458332">try</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:2.82222223px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26458332"
+       x="11.021549"
+       y="24.771614"
+       id="text1820"><tspan
+         sodipodi:role="line"
+         id="tspan1818"
+         x="11.021549"
+         y="24.771614"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'DejaVu Sans', Verdana, Geneva, sans-serif;-inkscape-font-specification:'DejaVu Sans, Verdana, Geneva, sans-serif';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26458332">lite now</tspan></text>
+    <text
+       id="text1894"
+       y="24.771614"
+       x="5.2515979"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:2.82222223px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Medium';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#555555;fill-opacity:1;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.82222223px;font-family:'DejaVu Sans', Verdana, Geneva, sans-serif;-inkscape-font-specification:'DejaVu Sans, Verdana, Geneva, sans-serif';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.26458332"
+         y="24.771614"
+         x="5.2515979"
+         id="tspan1892"
+         sodipodi:role="line">try</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
## References

- blocks #486
- continues #86

## Code changes

- adds the `try lite now` badge proposed over on #86

## User-facing changes

- downstreams will be able to use the badge from `jupyterlite.rtf.io/_static` or a raw github link

## Backwards-incompatible changes

- n/a