### PR TITLE
Have pyolite kernel `execute_request` does not honor `store_history` option

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -533,7 +533,9 @@ export abstract class BaseKernel implements IKernel {
   private async _execute(msg: KernelMessage.IMessage): Promise<void> {
     const executeMsg = msg as KernelMessage.IExecuteRequestMsg;
     const content = executeMsg.content;
-    this._executionCount++;
+    if (content['store_history']) {
+      this._executionCount++;
+    }
 
     // TODO: handle differently
     this._parentHeader = executeMsg.header;

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -542,7 +542,9 @@ export abstract class BaseKernel implements IKernel {
 
     this._executeInput(executeMsg);
 
-    this._history.push([0, 0, content.code]);
+    if (content['store_history']) {
+      this._history.push([0, 0, content.code]);
+    }
 
     const reply = await this.executeRequest(executeMsg.content);
     const message = KernelMessage.createMessage<KernelMessage.IExecuteReplyMsg>({


### PR DESCRIPTION
Fixes #478.