### PR TITLE
Add `repl` to `rediraffe_redirects`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ rediraffe_redirects = {
     "try/index": "_static/index",
     "try/lab/index": "_static/lab/index",
     "try/retro/index": "_static/retro/tree/index",
+    "try/repl/index": "_static/repl/index",
 }
 
 # files


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #498 

So we can use shorter URLs to point to the repo

## Code changes

Docs changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users will be able to open the default REPL with https://jupyterlite.rtfd.io/en/latest/try/repl

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
