### PR TITLE
Fix markdown table in the docs

### DIFF
--- a/docs/kernels/index.md
+++ b/docs/kernels/index.md
@@ -4,7 +4,7 @@ JupyterLite Kernels implement [Jupyter Kernel Messaging][jkm] in the browser wit
 help of [`mock-socket`][mock-socket].
 
 | Feature       | Message                                       | [pyolite](./pyolite.md) | [javascript](./js.md) | [p5](./p5.md) |
-| ------------- | --------------------------------------------- | ----------------------- | --------------------- | ------------- | --- |
+| ------------- | --------------------------------------------- | ----------------------- | --------------------- | ------------- |
 |               | Language                                      | Python 3.8              | Browser JS            | JS + p5.js    |
 | Start session | `kernel_info_request`<br/>`kernel_info_reply` | ✔️                      | ✔️                    | ✔️            | ✔️  |
 | Run code      | `execute_request`<br/>`execute_reply`         | ✔️                      | ✔️                    | ✔️            | ✔️  |

--- a/docs/kernels/index.md
+++ b/docs/kernels/index.md
@@ -6,8 +6,8 @@ help of [`mock-socket`][mock-socket].
 | Feature       | Message                                       | [pyolite](./pyolite.md) | [javascript](./js.md) | [p5](./p5.md) |
 | ------------- | --------------------------------------------- | ----------------------- | --------------------- | ------------- |
 |               | Language                                      | Python 3.8              | Browser JS            | JS + p5.js    |
-| Start session | `kernel_info_request`<br/>`kernel_info_reply` | ✔️                      | ✔️                    | ✔️            | ✔️  |
-| Run code      | `execute_request`<br/>`execute_reply`         | ✔️                      | ✔️                    | ✔️            | ✔️  |
+| Start session | `kernel_info_request`<br/>`kernel_info_reply` | ✔️                      | ✔️                    | ✔️            |
+| Run code      | `execute_request`<br/>`execute_reply`         | ✔️                      | ✔️                    | ✔️            |
 | Completion    | `complete_request`<br/>`complete_reply`       | ✔️                      |                       |               |
 | Custom Comms  | `comm_open`<br/>`comm_msg`<br/>`comm_close`   | ✔️                      |                       |               |
 | History       | `history_request`<br/>`history_reply`         |                         |                       |               |


### PR DESCRIPTION
I fixed a markdown table whose layout was broken in the docs.
