### PR TITLE
Ensure TypeDoc before docs job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
             build/pytest
 
   docs:
-    needs: [build]
+    needs: [build, lint-js-test]
     runs-on: ubuntu-latest
     env:
       DOCS_IN_CI: 1


### PR DESCRIPTION
## References

- fix regression found in https://github.com/jupyterlite/jupyterlite/pull/521#discussion_r816154441

## Code changes

- blocks the `docs` job by the `lint-js-tests` job

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a