### PR TITLE
Delay commands notified in retrolab

### DIFF
--- a/packages/retro-application-extension/src/index.ts
+++ b/packages/retro-application-extension/src/index.ts
@@ -112,7 +112,9 @@ const notifyCommands: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd, retroShell: IRetroShell | null) => {
     if (retroShell) {
       retroShell.currentChanged.connect(() => {
-        app.commands.notifyCommandChanged();
+        requestAnimationFrame(() => {
+          app.commands.notifyCommandChanged();
+        });
       });
     }
   },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Attempt at fixing #537 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Try to delay the commands refresh to mitigate race conditions when opening a notebook with RetroLab.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should show enabled toolbar items.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
