### PR TITLE
Automated Changelog Entry for 0.1.0b2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0b2
+
+([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0b1...fb4f063daadebd1d6a85af7cdd2dae65d1e454aa))
+
+### Bugs fixed
+
+- Delay commands notified in retrolab [#538](https://github.com/jupyterlite/jupyterlite/pull/538) ([@jtpio](https://github.com/jtpio))
+- Update content creating method in `_getServerContents` [#532](https://github.com/jupyterlite/jupyterlite/pull/532) ([@trungleduc](https://github.com/trungleduc))
+
+### Maintenance and upkeep improvements
+
+- Minor contents refactoring, skip dedupe on binder [#541](https://github.com/jupyterlite/jupyterlite/pull/541) ([@bollwyvl](https://github.com/bollwyvl))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2022-03-04&to=2022-03-08&type=c))
+
+[@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2022-03-04..2022-03-08&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2022-03-04..2022-03-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2022-03-04..2022-03-08&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Atrungleduc+updated%3A2022-03-04..2022-03-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0b1
 
 ([Full Changelog](https://github.com/jupyterlite/jupyterlite/compare/v0.1.0b0...34921cbb4cb5216d6149ef5b7cef1edb131d687f))
@@ -23,8 +44,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/jupyterlite/graphs/contributors?from=2022-02-22&to=2022-03-04&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Abollwyvl+updated%3A2022-02-22..2022-03-04&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Adependabot+updated%3A2022-02-22..2022-03-04&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Agithub-actions+updated%3A2022-02-22..2022-03-04&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fjupyterlite+involves%3Ajtpio+updated%3A2022-02-22..2022-03-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.0b0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0b2 on main
```
npm workspace versions:
@jupyterlite/app: 0.1.0-beta.2
@jupyterlite/app-lab: 0.1.0-beta.2
@jupyterlite/app-repl: 0.1.0-beta.2
@jupyterlite/app-retro: 0.1.0-beta.2
@jupyterlite/metapackage: 0.1.0-beta.2
@jupyterlite/application: 0.1.0-beta.2
@jupyterlite/application-extension: 0.1.0-beta.2
@jupyterlite/contents: 0.1.0-beta.2
@jupyterlite/iframe-extension: 0.1.0-beta.2
@jupyterlite/javascript-kernel: 0.1.0-beta.2
@jupyterlite/javascript-kernel-extension: 0.1.0-beta.2
@jupyterlite/kernel: 0.1.0-beta.2
@jupyterlite/licenses: 0.1.0-beta.2
@jupyterlite/pyolite-kernel: 0.1.0-beta.2
@jupyterlite/pyolite-kernel-extension: 0.1.0-beta.2
@jupyterlite/repl-extension: 0.1.0-beta.2
@jupyterlite/retro-application-extension: 0.1.0-beta.2
@jupyterlite/server: 0.1.0-beta.2
@jupyterlite/server-extension: 0.1.0-beta.2
@jupyterlite/session: 0.1.0-beta.2
@jupyterlite/settings: 0.1.0-beta.2
@jupyterlite/translation: 0.1.0-beta.2
@jupyterlite/types: 0.1.0-beta.2
@jupyterlite/ui-components: 0.1.0-beta.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/jupyterlite  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.0b1 |