### PR TITLE
Update pyodide.py

### DIFF
--- a/py/jupyterlite/src/jupyterlite/addons/pyodide.py
+++ b/py/jupyterlite/src/jupyterlite/addons/pyodide.py
@@ -73,7 +73,7 @@ class PyodideAddon(BaseAddon):
 
     def build(self, manager):
         """copy a local (cached or well-known) pyodide into the output_dir"""
-        cached_pyodide = self.pyodide_cache / PYODIDE / PYODIDE
+        cached_pyodide = self.pyodide_cache / PYODIDE
 
         the_pyodide = None
 


### PR DESCRIPTION
fix pyodide cache path when using `--pyodide` option in `jupyter lite serve`

<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

#567

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

py/jupyterlite/src/jupyterlite/addons/pyodide.py

## User-facing changes

None

## Backwards-incompatible changes

None
