### PR TITLE
Fix typo for the `--piplite-wheels` CLI flag in the docs

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -232,7 +232,7 @@ customized python wheels, which in turn require other wheels and pre-built WASM 
 and other JavaScript.
 
 Extra wheels that can be installed via `piplite` in a running kernel can be added via
-the `--piplite-urls` CLI flag or `LiteBuildConfig/piplite_urls` config value, or simply
+the `--piplite-wheels` CLI flag or `LiteBuildConfig/piplite_urls` config value, or simply
 left in-place in `lite_dir/pypi`.
 
 These will be:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -232,8 +232,8 @@ customized python wheels, which in turn require other wheels and pre-built WASM 
 and other JavaScript.
 
 Extra wheels that can be installed via `piplite` in a running kernel can be added via
-the `--piplite-wheels` CLI flag or `LiteBuildConfig/piplite_urls` config value, or simply
-left in-place in `lite_dir/pypi`.
+the `--piplite-wheels` CLI flag or `LiteBuildConfig/piplite_urls` config value, or
+simply left in-place in `lite_dir/pypi`.
 
 These will be:
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

The CLI flag is `--piplite-wheels`, and the config option is `piplite_urls`.

Maybe these two should actually be named the same?

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix typo in the documentation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Developer Documentation changes.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
