### PR TITLE
Mention `jupyterlab-filesystem-access` in the documentation

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -103,7 +103,8 @@ See the [MDN][mdn] documentation for more information.
 
 [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
 [filesystem-access-pypi]: https://pypi.org/project/jupyterlab-filesystem-access/
-[filesystem-access-github]: https://github.com/jtpio/jupyterlab-filesystem-access
+[filesystem-access-github]:
+  https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access
 
 ## Adding Extensions
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -85,6 +85,26 @@ particular set of drivers to try with
 `jupyter-lite.json#jupyter-config-data/contentsStorageDrivers`. See more about
 [local storage drivers](#local-storage-drivers).
 
+### Accessing local files with the `jupyterlab-filesystem-access` extension
+
+The `jupyterlab-filesystem-access` extension allows accessing local files using the
+(non-standard) Web Browser File System Access API.
+
+The extension is available on [GitHub][filesystem-access-github] and published to
+[PyPI][filesystem-access-pypi] . It is compatible with both JupyterLab and JupyterLite.
+
+See the section below to learn how to add extensions to your deployment.
+
+```{warning}
+This extension is compatible with Chromium-based browsers only (for now).
+
+See the [MDN][mdn] documentation for more information.
+```
+
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+[filesystem-access-pypi]: https://pypi.org/project/jupyterlab-filesystem-access/
+[filesystem-access-github]: https://github.com/jtpio/jupyterlab-filesystem-access
+
 ## Adding Extensions
 
 JupyterLab 3 [pre-built extensions] allow for adding new capabilities to JupyterLite


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/403

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes to mention the `jupyterlab-filesystem-access` extension and provide other options to access contents.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Deployers will then be more aware of such extension.

![image](https://user-images.githubusercontent.com/591645/163342534-fc3055a3-f1a4-42c7-898f-207bbea01c68.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
