### PR TITLE
Switch to `standby: 'never'` for the server polling to ensure kernel specs are ready

### DIFF
--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -19,6 +19,7 @@
  * assumed that the page HTML includes a script tag with the id
  * `jupyter-config-data` containing the configuration as valid JSON.
  */
+
 let _CONFIG_DATA = null;
 function getOption(name) {
   if (_CONFIG_DATA === null) {
@@ -88,5 +89,5 @@ void (async function bootstrap() {
   // Now that all federated containers are initialized with the main
   // container, we can import the main function.
   let main = (await import('./index.js')).main;
-  window.addEventListener('load', main);
+  void main();
 })();

--- a/app/config-utils.js
+++ b/app/config-utils.js
@@ -257,11 +257,11 @@ async function main() {
   const preloader = document.getElementById(LITE_MAIN);
   const bundle = document.createElement('script');
   bundle.src = preloader.href;
-  bundle.main = preloader.main;
+  bundle.main = preloader.attributes.main;
   document.head.appendChild(bundle);
 }
 
 /**
  * TODO: consider better pattern for invocation.
  */
-void main();
+await main();

--- a/app/lab/index.template.js
+++ b/app/lab/index.template.js
@@ -42,7 +42,7 @@ async function createModule(scope, module) {
 /**
  * The main entry point for the application.
  */
-async function main() {
+export async function main() {
   // Make sure the styles have loaded
   await styles;
 
@@ -215,5 +215,3 @@ async function main() {
   await lab.start();
   await lab.restored;
 }
-
-main();

--- a/app/repl/index.template.js
+++ b/app/repl/index.template.js
@@ -34,7 +34,7 @@ async function createModule(scope, module) {
 /**
  * The main entry point for the application.
  */
-async function main() {
+export async function main() {
   const mimeExtensions = await Promise.all(mimeExtensionsMods);
 
   let baseMods = [
@@ -238,5 +238,3 @@ async function main() {
   await app.start();
   await app.restored;
 }
-
-main();

--- a/app/retro/index.template.js
+++ b/app/retro/index.template.js
@@ -34,7 +34,7 @@ async function createModule(scope, module) {
 /**
  * The main entry point for the application.
  */
-async function main() {
+export async function main() {
   const mimeExtensions = await Promise.all(mimeExtensionsMods);
 
   let baseMods = [
@@ -306,5 +306,3 @@ async function main() {
   await app.start();
   await app.restored;
 }
-
-main();

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -176,7 +176,7 @@ for (const [name, data] of Object.entries(liteAppData)) {
   const entryPoint = `./${name}/build/bootstrap.js`;
   fs.copySync('bootstrap.js', entryPoint);
   allEntryPoints[`${name}/bundle`] = entryPoint;
-  allEntryPoints[`${name}/publicpath`] = path.resolve(name, 'publicpath.js');
+  allEntryPoints[`${name}/publicpath`] = `./${name}/publicpath.js`;
 
   // Use templates to create cache-busting templates
   for (const page of data.jupyterlite.pages) {
@@ -190,8 +190,6 @@ for (const [name, data] of Object.entries(liteAppData)) {
     );
   }
 }
-
-// const name = path.basename(path.dirname(path.resolve(packageJson)));
 
 /**
  * Define a custom plugin to ensure schemas are statically compiled

--- a/packages/kernel/src/kernelspecs.ts
+++ b/packages/kernel/src/kernelspecs.ts
@@ -7,15 +7,6 @@ import { IKernel, IKernelSpecs } from './tokens';
  */
 export class KernelSpecs implements IKernelSpecs {
   /**
-   * Construct a new KernelSpecs.
-   *
-   * @param options The instantiation options.
-   */
-  constructor(options: KernelSpecs.IOptions) {
-    // no-op
-  }
-
-  /**
    * Get the kernel specs.
    */
   get specs(): KernelSpec.ISpecModels | null {
@@ -54,11 +45,6 @@ export class KernelSpecs implements IKernelSpecs {
  * A namespace for KernelSpecs statics.
  */
 export namespace KernelSpecs {
-  /**
-   * The instantiation options for a KernelSpecs
-   */
-  export interface IOptions {}
-
   /**
    * Registration options for a new kernel.
    */

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -136,7 +136,7 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
     if (!tracker) {
       return;
     }
-    const { commands } = app;
+    const { commands, serviceManager, started } = app;
 
     const search = window.location.search;
     const urlParams = new URLSearchParams(search);
@@ -145,7 +145,7 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
     const theme = urlParams.get('theme')?.trim();
     const toolbar = urlParams.get('toolbar');
 
-    app.started.then(() => {
+    Promise.all([started, serviceManager.ready]).then(async () => {
       commands.execute('console:create', { kernelPreference: { name: kernel } });
     });
 

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -250,7 +250,6 @@ const kernelSpecRoutesPlugin: JupyterLiteServerPlugin<void> = {
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
     app.router.get('/api/kernelspecs', async (req: Router.IRequest) => {
       const res = kernelspecs.specs;
-      console.log('KERNELSPECS', res);
       return new Response(JSON.stringify(res));
     });
   },

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -236,7 +236,7 @@ const kernelSpecPlugin: JupyterLiteServerPlugin<IKernelSpecs> = {
   autoStart: true,
   provides: IKernelSpecs,
   activate: (app: JupyterLiteServer) => {
-    return new KernelSpecs({});
+    return new KernelSpecs();
   },
 };
 

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -250,6 +250,7 @@ const kernelSpecRoutesPlugin: JupyterLiteServerPlugin<void> = {
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
     app.router.get('/api/kernelspecs', async (req: Router.IRequest) => {
       const res = kernelspecs.specs;
+      console.log('KERNELSPECS', res);
       return new Response(JSON.stringify(res));
     });
   },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -23,6 +23,7 @@ export class JupyterLiteServer extends Application<never> {
   constructor(options: Application.IOptions<never>) {
     super(options);
     this._serviceManager = new ServiceManager({
+      standby: 'never',
       serverSettings: {
         ...ServerConnection.makeSettings(),
         WebSocket,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #610 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Switch to `standby: 'never'` when instantiating the `ServiceManager`.

There is no real server polling anyway since the server runs in the browser, so we should be able to use this default.

Various other cleanups.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users opening JupyterLite in a new background tab (for example via Ctrl+click) should still be able to see the list of kernels when switching to the tab later on. 

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
