### PR TITLE
Show in file browser when opening files on startup

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -508,6 +508,7 @@ const opener: JupyterFrontEndPlugin<void> = {
               router.navigate(`${pathname}${search}`, { skipRouting: true });
 
               if (labShell) {
+                // open the folder where the files are located on startup
                 const showInBrowser = () => {
                   commands.execute('docmanager:show-in-file-browser');
                   labShell.currentChanged.disconnect(showInBrowser);

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -452,10 +452,12 @@ const opener: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/application-extension:opener',
   autoStart: true,
   requires: [IRouter, IDocumentManager],
+  optional: [ILabShell],
   activate: (
     app: JupyterFrontEnd,
     router: IRouter,
-    docManager: IDocumentManager
+    docManager: IDocumentManager,
+    labShell: ILabShell | null
   ): void => {
     const { commands } = app;
 
@@ -504,6 +506,15 @@ const opener: JupyterFrontEndPlugin<void> = {
               url.searchParams.delete('path');
               const { pathname, search } = url;
               router.navigate(`${pathname}${search}`, { skipRouting: true });
+
+              if (labShell) {
+                const showInBrowser = () => {
+                  commands.execute('docmanager:show-in-file-browser');
+                  labShell.currentChanged.disconnect(showInBrowser);
+                };
+
+                labShell.currentChanged.connect(showInBrowser);
+              }
               break;
             }
           }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/613

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Trigger a `docmanager:show-in-file-browser` when opening files on startup with `?path`.

This is independent of the "Navigate to current drectory" setting mentioned in https://github.com/jupyterlite/jupyterlite/issues/613#issuecomment-1106427183.

## User-facing changes

https://user-images.githubusercontent.com/591645/164715262-d45ac557-5d4f-4874-95ae-76866b38afc0.mp4

## Backwards-incompatible changes

None
