### PR TITLE
Rename default name from `Consolite` to `REPLite`

### DIFF
--- a/app/repl/index.template.js
+++ b/app/repl/index.template.js
@@ -223,7 +223,7 @@ async function main() {
   const { SingleWidgetApp } = require('@jupyterlite/application');
   const app = new SingleWidgetApp({ serviceManager, mimeExtensions });
 
-  app.name = PageConfig.getOption('appName') || 'ConsoLite';
+  app.name = PageConfig.getOption('appName') || 'REPLite';
 
   app.registerPluginModules(mods);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Minor follow-up to https://github.com/jupyterlite/jupyterlite/pull/498

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Rename the default name for the `REPL` application, mostly for consistency.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
