### PR TITLE
More granular way to ignore components from `sys.prefix`

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -130,6 +130,18 @@ environment, e.g. `{sys.prefix}/share/jupyter/labextensions` will be:
 This discovery behavior can be disabled with the CLI flag `--ignore-sys-prefix` or
 `LiteBuildConfig/ignore_sys_prefix`.
 
+The `--ignore-sys-prefix` CLI flag will disable using components from the JupyterLab
+environment for _all_ addons. This behavior can be configured in a more granular way on
+a per-addon basis, for example:
+
+```json
+{
+  "LiteBuildConfig": {
+    "ignore_sys_prefix": ["federated_extensions"]
+  }
+}
+```
+
 #### Extensions for a Specific App
 
 Similar to the above, by updating `$YOUR_JUPYTERLITE/{app}/jupyter-lite.json`, the

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -1,10 +1,4 @@
 {
-  "FederatedExtensionAddon": {
-    "ignore_sys_prefix": true
-  },
-  "MathjaxAddon": {
-    "ignore_sys_prefix": true
-  },
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
@@ -30,6 +24,7 @@
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
     "output_dir": "../build/docs-app",
+    "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "piplite_urls": [
       "https://files.pythonhosted.org/packages/e6/0b/24795939622d60f4b453aa7040f23c6a6f8b44c7c026c3b42d9842e6cc31/fastjsonschema-2.15.3-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py2.py3/a/asttokens/asttokens-2.0.5-py2.py3-none-any.whl",

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -1,4 +1,10 @@
 {
+  "FederatedExtensionAddon": {
+    "ignore_sys_prefix": true
+  },
+  "MathjaxAddon": {
+    "ignore_sys_prefix": true
+  },
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
@@ -23,7 +29,6 @@
       "https://github.com/conda-forge/releases/releases/download/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
-    "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "output_dir": "../build/docs-app",
     "piplite_urls": [
       "https://files.pythonhosted.org/packages/e6/0b/24795939622d60f4b453aa7040f23c6a6f8b44c7c026c3b42d9842e6cc31/fastjsonschema-2.15.3-py3-none-any.whl",

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -23,7 +23,7 @@
       "https://github.com/conda-forge/releases/releases/download/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
-    "ignore_sys_prefix": true,
+    "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "output_dir": "../build/docs-app",
     "piplite_urls": [
       "https://files.pythonhosted.org/packages/e6/0b/24795939622d60f4b453aa7040f23c6a6f8b44c7c026c3b42d9842e6cc31/fastjsonschema-2.15.3-py3-none-any.whl",

--- a/py/jupyterlite/src/jupyterlite/addons/base.py
+++ b/py/jupyterlite/src/jupyterlite/addons/base.py
@@ -33,10 +33,7 @@ class BaseAddon(LoggingConfigurable):
 
     manager: LiteManager = Instance(LiteManager)
 
-    ignore_sys_prefix: bool = Bool(
-        False,
-        help="ignore components from sys.prefix",
-    ).tag(config=True)
+    ignore_sys_prefix: bool = Bool(False)
 
     def __init__(self, manager, *args, **kwargs):
         kwargs["parent"] = manager

--- a/py/jupyterlite/src/jupyterlite/addons/base.py
+++ b/py/jupyterlite/src/jupyterlite/addons/base.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from pathlib import Path
 
-from traitlets import Instance
+from traitlets import Bool, Instance
 from traitlets.config import LoggingConfigurable
 
 from ..constants import (
@@ -32,6 +32,11 @@ class BaseAddon(LoggingConfigurable):
     """
 
     manager: LiteManager = Instance(LiteManager)
+
+    ignore_sys_prefix: bool = Bool(
+        False,
+        help="ignore components from sys.prefix",
+    ).tag(config=True)
 
     def __init__(self, manager, *args, **kwargs):
         kwargs["parent"] = manager
@@ -276,3 +281,6 @@ class BaseAddon(LoggingConfigurable):
                     is_ignored = True
                     break
         return is_ignored
+
+    def is_sys_prefix_ignored(self):
+        return self.ignore_sys_prefix

--- a/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
+++ b/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
@@ -57,7 +57,7 @@ class FederatedExtensionAddon(BaseAddon):
         """yield a doit task to copy each federated extension into the output_dir"""
         root = ENV_EXTENSIONS
 
-        if not manager.ignore_sys_prefix:
+        if not "federated_extensions" in manager.ignore_sys_prefix:
             for pkg_json in self.env_extensions(root):
                 yield from self.copy_one_extension(pkg_json)
 

--- a/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
+++ b/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
@@ -57,7 +57,7 @@ class FederatedExtensionAddon(BaseAddon):
         """yield a doit task to copy each federated extension into the output_dir"""
         root = ENV_EXTENSIONS
 
-        if not "federated_extensions" in manager.ignore_sys_prefix:
+        if not self.is_sys_prefix_ignored():
             for pkg_json in self.env_extensions(root):
                 yield from self.copy_one_extension(pkg_json)
 

--- a/py/jupyterlite/src/jupyterlite/addons/mathjax.py
+++ b/py/jupyterlite/src/jupyterlite/addons/mathjax.py
@@ -44,7 +44,7 @@ class MathjaxAddon(BaseAddon):
 
         if manager_path is not None:
             path = manager_path
-        elif not "mathjax" in self.manager.ignore_sys_prefix and MATHJAX_PATH:
+        elif not self.is_sys_prefix_ignored() and MATHJAX_PATH:
             path = MATHJAX_PATH
 
         if path and path.exists():
@@ -97,7 +97,7 @@ class MathjaxAddon(BaseAddon):
         )
 
     def log_status(self):
-        ignore = "mathjax" in self.manager.ignore_sys_prefix
+        ignore = self.is_sys_prefix_ignored()
         print(
             "     jupyter-server-mathjax:",
             MATHJAX_PATH,

--- a/py/jupyterlite/src/jupyterlite/addons/mathjax.py
+++ b/py/jupyterlite/src/jupyterlite/addons/mathjax.py
@@ -44,7 +44,7 @@ class MathjaxAddon(BaseAddon):
 
         if manager_path is not None:
             path = manager_path
-        elif not self.manager.ignore_sys_prefix and MATHJAX_PATH:
+        elif not "mathjax" in self.manager.ignore_sys_prefix and MATHJAX_PATH:
             path = MATHJAX_PATH
 
         if path and path.exists():
@@ -97,21 +97,7 @@ class MathjaxAddon(BaseAddon):
         )
 
     def log_status(self):
-        """
-
-        def mathjax_path(self):
-            path = None
-
-            if self.manager.mathjax_dir:
-                path = self.manager.mathjax_dir
-            elif not self.manager.ignore_sys_prefix and MATHJAX_PATH:
-                path = MATHJAX_PATH
-
-            if path and path.exists():
-                return path
-
-        """
-        ignore = self.manager.ignore_sys_prefix
+        ignore = "mathjax" in self.manager.ignore_sys_prefix
         print(
             "     jupyter-server-mathjax:",
             MATHJAX_PATH,

--- a/py/jupyterlite/src/jupyterlite/addons/translation.py
+++ b/py/jupyterlite/src/jupyterlite/addons/translation.py
@@ -80,7 +80,7 @@ class TranslationAddon(BaseAddon):
         }
         packs = {"en": {"data": {}, "message": "Language pack 'en' not installed!"}}
 
-        if not "translations" in self.manager.ignore_sys_prefix:
+        if not self.is_sys_prefix_ignored():
             try:
                 from jupyterlab_server.translation_utils import (
                     get_language_pack,

--- a/py/jupyterlite/src/jupyterlite/addons/translation.py
+++ b/py/jupyterlite/src/jupyterlite/addons/translation.py
@@ -80,7 +80,7 @@ class TranslationAddon(BaseAddon):
         }
         packs = {"en": {"data": {}, "message": "Language pack 'en' not installed!"}}
 
-        if not self.manager.ignore_sys_prefix:
+        if not "translations" in self.manager.ignore_sys_prefix:
             try:
                 from jupyterlab_server.translation_utils import (
                     get_language_pack,

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -15,9 +15,9 @@ from .trait_types import CPath
 lite_flags = {
     "ignore-sys-prefix": (
         {
-            "LiteBuildConfig": {
-                "ignore_sys_prefix": ["federated_extensions", "mathjax", "translations"]
-            }
+            "FederatedExtensionAddon": {"ignore_sys_prefix": True},
+            "TranslationAddon": {"ignore_sys_prefix": True},
+            "MathjaxAddon": {"ignore_sys_prefix": True},
         },
         "Do not copy anything from sys.prefix",
     ),
@@ -127,8 +127,6 @@ class ManagedApp(BaseLiteApp):
             kwargs["base_url"] = self.base_url
         if self.federated_extensions is not None:
             kwargs["federated_extensions"] = self.federated_extensions
-        if self.ignore_sys_prefix is not None:
-            kwargs["ignore_sys_prefix"] = self.ignore_sys_prefix
         if self.piplite_urls is not None:
             kwargs["piplite_urls"] = self.piplite_urls
         if self.pyodide_url is not None:

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -14,7 +14,11 @@ from .trait_types import CPath
 #: some flags we use
 lite_flags = {
     "ignore-sys-prefix": (
-        {"LiteBuildConfig": {"ignore_sys_prefix": ["federated_extensions", "mathjax", "translations"]}},
+        {
+            "LiteBuildConfig": {
+                "ignore_sys_prefix": ["federated_extensions", "mathjax", "translations"]
+            }
+        },
         "Do not copy anything from sys.prefix",
     ),
     "no-sourcemaps": (

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -127,6 +127,8 @@ class ManagedApp(BaseLiteApp):
             kwargs["base_url"] = self.base_url
         if self.federated_extensions is not None:
             kwargs["federated_extensions"] = self.federated_extensions
+        if self.ignore_sys_prefix is not None:
+            kwargs["ignore_sys_prefix"] = self.ignore_sys_prefix
         if self.piplite_urls is not None:
             kwargs["piplite_urls"] = self.piplite_urls
         if self.pyodide_url is not None:

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -14,7 +14,7 @@ from .trait_types import CPath
 #: some flags we use
 lite_flags = {
     "ignore-sys-prefix": (
-        {"LiteBuildConfig": {"ignore_sys_prefix": True}},
+        {"LiteBuildConfig": {"ignore_sys_prefix": ["federated_extensions", "mathjax", "translations"]}},
         "Do not copy anything from sys.prefix",
     ),
     "no-sourcemaps": (

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -14,11 +14,7 @@ from .trait_types import CPath
 #: some flags we use
 lite_flags = {
     "ignore-sys-prefix": (
-        {
-            "FederatedExtensionAddon": {"ignore_sys_prefix": True},
-            "TranslationAddon": {"ignore_sys_prefix": True},
-            "MathjaxAddon": {"ignore_sys_prefix": True},
-        },
+        {"LiteBuildConfig": {"ignore_sys_prefix": True}},
         "Do not copy anything from sys.prefix",
     ),
     "no-sourcemaps": (

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -64,12 +64,6 @@ class LiteBuildConfig(LoggingConfigurable):
         config=True
     )
 
-    ignore_sys_prefix: _Tuple[str] = TypedTuple(
-        Unicode(),
-        help="list of components from sys.prefix to ignore."
-        "Values: ['federated_extensions', 'mathjax', 'translations']",
-    ).tag(config=True)
-
     mathjax_dir: Path = CPath(
         help="A local path to a complete/sufficient installation of MathJax 2"
     ).tag(config=True)

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -10,8 +10,9 @@ from pathlib import Path
 from typing import Optional as _Optional
 from typing import Text as _Text
 from typing import Tuple as _Tuple
+from typing import Union as _Union
 
-from traitlets import Bool, CInt, Dict, Tuple, Unicode, default
+from traitlets import Bool, CInt, Dict, Tuple, Unicode, Union, default
 from traitlets.config import LoggingConfigurable
 
 from . import constants as C
@@ -63,6 +64,10 @@ class LiteBuildConfig(LoggingConfigurable):
     contents: _Tuple[Path] = TypedTuple(CPath(), help="Contents to add and index").tag(
         config=True
     )
+
+    ignore_sys_prefix: _Union[bool, _Tuple[_Text]] = Union(
+        [Bool(), TypedTuple(Unicode())], help="ignore components from sys.prefix"
+    ).tag(config=True)
 
     mathjax_dir: Path = CPath(
         help="A local path to a complete/sufficient installation of MathJax 2"

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -66,7 +66,8 @@ class LiteBuildConfig(LoggingConfigurable):
 
     ignore_sys_prefix: _Tuple[str] = TypedTuple(
         Unicode(),
-        help="list of components from sys.prefix to ignore." "Values: ['federated_extensions', 'mathjax', 'translations']",
+        help="list of components from sys.prefix to ignore."
+        "Values: ['federated_extensions', 'mathjax', 'translations']",
     ).tag(config=True)
 
     mathjax_dir: Path = CPath(

--- a/py/jupyterlite/src/jupyterlite/config.py
+++ b/py/jupyterlite/src/jupyterlite/config.py
@@ -64,9 +64,9 @@ class LiteBuildConfig(LoggingConfigurable):
         config=True
     )
 
-    ignore_sys_prefix: bool = Bool(
-        False,
-        help="ignore lab components from sys.prefix, such as federated_extensions",
+    ignore_sys_prefix: _Tuple[str] = TypedTuple(
+        Unicode(),
+        help="list of components from sys.prefix to ignore." "Values: ['federated_extensions', 'mathjax', 'translations']",
     ).tag(config=True)
 
     mathjax_dir: Path = CPath(

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -68,10 +68,7 @@ class LiteManager(LiteBuildConfig):
             self.log.debug(f"[lite] [addon] [{name}] load ...")
             try:
                 addon_inst = addon.load()(manager=self)
-                if (
-                    isinstance(self.ignore_sys_prefix, bool)
-                    and self.ignore_sys_prefix == True
-                ) or name in self.ignore_sys_prefix:
+                if self._is_sys_prefix_ignored(name):
                     self.log.debug(f"[lite] [addon] ignore sys prefix for [{name}] ...")
                     addon_inst.ignore_sys_prefix = True
                 addons[name] = addon_inst
@@ -137,3 +134,9 @@ class LiteManager(LiteBuildConfig):
                 yield task
 
         return _delayed_gather
+
+    def _is_sys_prefix_ignored(self, addon):
+        ignore = self.ignore_sys_prefix
+        all_ignored = isinstance(ignore, bool) and ignore == True
+        addon_ignored = isinstance(ignore, tuple) and addon in ignore
+        return all_ignored or addon_ignored

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -68,7 +68,10 @@ class LiteManager(LiteBuildConfig):
             self.log.debug(f"[lite] [addon] [{name}] load ...")
             try:
                 addon_inst = addon.load()(manager=self)
-                if self.ignore_sys_prefix == True or name in self.ignore_sys_prefix:
+                if (
+                    isinstance(self.ignore_sys_prefix, bool)
+                    and self.ignore_sys_prefix == True
+                ) or name in self.ignore_sys_prefix:
                     self.log.debug(f"[lite] [addon] ignore sys prefix for [{name}] ...")
                     addon_inst.ignore_sys_prefix = True
                 addons[name] = addon_inst

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -67,10 +67,11 @@ class LiteManager(LiteBuildConfig):
                 continue
             self.log.debug(f"[lite] [addon] [{name}] load ...")
             try:
-                addon_inst = addon.load()(manager=self)
+                addon_kwargs = dict(manager=self)
                 if self._is_sys_prefix_ignored(name):
                     self.log.debug(f"[lite] [addon] ignore sys prefix for [{name}] ...")
-                    addon_inst.ignore_sys_prefix = True
+                    addon_kwargs.update(ignore_sys_prefix=True)
+                addon_inst = addon.load()(**addon_kwargs)
                 addons[name] = addon_inst
                 for one in sorted(addon_inst.__all__):
                     self.log.debug(f"""[lite] [addon] [{name}] ... will {one}""")
@@ -137,6 +138,4 @@ class LiteManager(LiteBuildConfig):
 
     def _is_sys_prefix_ignored(self, addon):
         ignore = self.ignore_sys_prefix
-        all_ignored = isinstance(ignore, bool) and ignore == True
-        addon_ignored = isinstance(ignore, tuple) and addon in ignore
-        return all_ignored or addon_ignored
+        return addon in ignore if isinstance(ignore, tuple) else ignore

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -69,7 +69,7 @@ class LiteManager(LiteBuildConfig):
             try:
                 addon_kwargs = dict(manager=self)
                 if self._is_sys_prefix_ignored(name):
-                    self.log.debug(f"[lite] [addon] ignore sys prefix for [{name}] ...")
+                    self.log.debug(f"[lite] [addon] [{name}] ... ignore sys prefix")
                     addon_kwargs.update(ignore_sys_prefix=True)
                 addon_inst = addon.load()(**addon_kwargs)
                 addons[name] = addon_inst

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -68,6 +68,9 @@ class LiteManager(LiteBuildConfig):
             self.log.debug(f"[lite] [addon] [{name}] load ...")
             try:
                 addon_inst = addon.load()(manager=self)
+                if self.ignore_sys_prefix == True or name in self.ignore_sys_prefix:
+                    self.log.debug(f"[lite] [addon] ignore sys prefix for [{name}] ...")
+                    addon_inst.ignore_sys_prefix = True
                 addons[name] = addon_inst
                 for one in sorted(addon_inst.__all__):
                     self.log.debug(f"""[lite] [addon] [{name}] ... will {one}""")

--- a/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
@@ -29,7 +29,7 @@ def test_extend_addon_config(an_empty_lite_dir, a_configured_mock_addon, capsys)
 @pytest.fixture
 def a_configured_mock_addon(a_mock_addon, an_empty_lite_dir, monkeypatch):
     config = {
-        "LiteBuildConfig": {"ignore_sys_prefix": ["federated_extensions"]},
+        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
         "MockAddon": {"some_feature": 42},
     }
     conf = an_empty_lite_dir / "jupyter_lite_config.json"

--- a/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
@@ -27,7 +27,7 @@ def test_extend_addon_config(an_empty_lite_dir, a_configured_mock_addon, capsys)
 @pytest.fixture
 def a_configured_mock_addon(a_mock_addon, an_empty_lite_dir, monkeypatch):
     config = {
-        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
+        "LiteBuildConfig": {"ignore_sys_prefix": ["federated_extensions"]},
         "MockAddon": {"some_feature": 42},
     }
     conf = an_empty_lite_dir / "jupyter_lite_config.json"

--- a/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
@@ -29,7 +29,7 @@ def test_extend_addon_config(an_empty_lite_dir, a_configured_mock_addon, capsys)
 @pytest.fixture
 def a_configured_mock_addon(a_mock_addon, an_empty_lite_dir, monkeypatch):
     config = {
-        "LiteBuildConfig": {"ignore_sys_prefix": True},
+        "LiteBuildConfig": {"ignore_sys_prefix": ["federated_extensions"]},
         "MockAddon": {"some_feature": 42},
     }
     conf = an_empty_lite_dir / "jupyter_lite_config.json"

--- a/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
@@ -13,8 +13,6 @@ def test_extend_addon_config(an_empty_lite_dir, a_configured_mock_addon, capsys)
     app.initialize()
     manager = app.lite_manager
 
-    assert manager.ignore_sys_prefix, "didn't configure"
-
     addon = manager._addons["mock"]
     assert addon.parent == manager, "not the parent"
 

--- a/py/jupyterlite/src/jupyterlite/tests/test_federated.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_federated.py
@@ -31,7 +31,7 @@ def test_federated_extensions(
     config = {
         "LiteBuildConfig": {
             "federated_extensions": federated_extensions,
-            "ignore_sys_prefix": True,
+            "ignore_sys_prefix": ["federated_extensions"],
             "overrides": ["overrides.json"],
             "apps": ["lab"],
         }

--- a/py/jupyterlite/src/jupyterlite/tests/test_federated.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_federated.py
@@ -29,12 +29,12 @@ def test_federated_extensions(
         federated_extensions = [ext.name]
 
     config = {
+        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
         "LiteBuildConfig": {
             "federated_extensions": federated_extensions,
-            "ignore_sys_prefix": ["federated_extensions"],
             "overrides": ["overrides.json"],
             "apps": ["lab"],
-        }
+        },
     }
     overrides = {"the-smallest-extension:plugin": {}}
 

--- a/py/jupyterlite/src/jupyterlite/tests/test_federated.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_federated.py
@@ -29,9 +29,9 @@ def test_federated_extensions(
         federated_extensions = [ext.name]
 
     config = {
-        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
         "LiteBuildConfig": {
             "federated_extensions": federated_extensions,
+            "ignore_sys_prefix": ["federated_extensions"],
             "overrides": ["overrides.json"],
             "apps": ["lab"],
         },

--- a/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
@@ -51,7 +51,7 @@ def test_piplite_urls(
 
     config = {
         "LiteBuildConfig": {
-            "ignore_sys_prefix": True,
+            "ignore_sys_prefix": ["federated_extensions"],
             "piplite_urls": piplite_urls,
             "apps": ["lab"],
         }

--- a/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
@@ -50,11 +50,11 @@ def test_piplite_urls(
             piplite_urls = [WHEELS[0].name]
 
     config = {
+        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
         "LiteBuildConfig": {
-            "ignore_sys_prefix": ["federated_extensions"],
             "piplite_urls": piplite_urls,
             "apps": ["lab"],
-        }
+        },
     }
     print("CONFIG", config)
 

--- a/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_piplite.py
@@ -50,10 +50,10 @@ def test_piplite_urls(
             piplite_urls = [WHEELS[0].name]
 
     config = {
-        "FederatedExtensionAddon": {"ignore_sys_prefix": True},
         "LiteBuildConfig": {
             "piplite_urls": piplite_urls,
             "apps": ["lab"],
+            "ignore_sys_prefix": ["federated_extensions"],
         },
     }
     print("CONFIG", config)

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -1,4 +1,7 @@
 {
+  "FederatedExtensionAddon": {
+    "ignore_sys_prefix": true
+  },
   "LiteBuildConfig": {
     "contents": ["../examples"],
     "federated_extensions": [
@@ -10,7 +13,6 @@
       "https://github.com/conda-forge/releases/releases/download/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
-    "ignore_sys_prefix": ["federated_extensions"],
     "output_dir": "ui-tests-app"
   }
 }

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -1,7 +1,4 @@
 {
-  "FederatedExtensionAddon": {
-    "ignore_sys_prefix": true
-  },
   "LiteBuildConfig": {
     "contents": ["../examples"],
     "federated_extensions": [
@@ -13,6 +10,7 @@
       "https://github.com/conda-forge/releases/releases/download/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
-    "output_dir": "ui-tests-app"
+    "output_dir": "ui-tests-app",
+    "ignore_sys_prefix": ["federated_extensions"]
   }
 }

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -10,7 +10,7 @@
       "https://github.com/conda-forge/releases/releases/download/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
-    "ignore_sys_prefix": true,
+    "ignore_sys_prefix": ["federated_extensions"],
     "output_dir": "ui-tests-app"
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/529

## Code changes

- [x] Update the logic around `ignore_sys_prefix` so site builders can choose what to ignore more easily (more granular).
- [x] Update docs

## User-facing changes

Should fix some situations of translations being ignored when building the site with `ignore_sys_prefix`.

## Backwards-incompatible changes

~The `ignore_sys_prefix` is a list of components to ignore instead of being a `boolean`~

Since `ignore_sys_prefix` still supports boolean values, previous configurations should still be compatible after this change.
