### PR TITLE
Create and use dedicated jupyterlite i18n bundle

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -69,6 +69,12 @@ namespace CommandIDs {
 }
 
 /**
+ * The name of the translation bundle for internationalized strings.
+ */
+
+const I18N_BUNDLE = 'jupyterlite';
+
+/**
  * Add a command to show an About dialog.
  */
 const about: JupyterFrontEndPlugin<void> = {
@@ -83,7 +89,7 @@ const about: JupyterFrontEndPlugin<void> = {
     menu: IMainMenu | null
   ): void => {
     const { commands } = app;
-    const trans = translator.load('jupyterlab');
+    const trans = translator.load(I18N_BUNDLE);
     const category = trans.__('Help');
 
     commands.addCommand(CommandIDs.about, {
@@ -169,14 +175,15 @@ const about: JupyterFrontEndPlugin<void> = {
 const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
   id: '@jupyterlite/application-extension:docprovider',
   provides: IDocumentProviderFactory,
+  requires: [ITranslator],
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator
   ): IDocumentProviderFactory => {
-    const trans = translator.load('jupyterlab');
     const collaborative = PageConfig.getOption('collaborative') === 'true';
     const factory = (options: IDocumentProviderFactory.IOptions): IDocumentProvider => {
       if (collaborative) {
+        const trans = translator.load(I18N_BUNDLE);
         console.warn(
           trans.__(
             'The `collaborative` feature was enabled, but no docprovider is available.'
@@ -209,7 +216,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     palette: ICommandPalette | null,
     factory: IFileBrowserFactory | null
   ) => {
-    const trans = translator.load('jupyterlab');
+    const trans = translator.load(I18N_BUNDLE);
     const { commands, serviceManager, shell } = app;
     const { contents } = serviceManager;
 
@@ -430,7 +437,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
     factory: IFileBrowserFactory,
     translator: ITranslator
   ): void => {
-    const trans = translator.load('jupyterlab');
+    const trans = translator.load(I18N_BUNDLE);
     const { commands } = app;
     const { tracker } = factory;
 

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -24,6 +24,11 @@ import { liteIcon } from '@jupyterlite/ui-components';
 import { Widget } from '@lumino/widgets';
 
 /**
+ * The name of the translation bundle for internationalized strings.
+ */
+const I18N_BUNDLE = 'jupyterlite';
+
+/**
  * A plugin to add buttons to the console toolbar.
  */
 const buttons: JupyterFrontEndPlugin<void> = {
@@ -41,7 +46,7 @@ const buttons: JupyterFrontEndPlugin<void> = {
     }
 
     const { commands } = app;
-    const trans = translator.load('jupyterlab');
+    const trans = translator.load(I18N_BUNDLE);
 
     // wrapper commands to be able to override the icon
     const runCommand = 'repl:run';
@@ -172,9 +177,11 @@ const status: JupyterFrontEndPlugin<ILabStatus> = {
   id: '@jupyterlite/repl-extension:status',
   autoStart: true,
   provides: ILabStatus,
-  activate: (app: JupyterFrontEnd) => {
+  requires: [ITranslator],
+  activate: (app: JupyterFrontEnd, translator: ITranslator) => {
     if (!(app instanceof SingleWidgetApp)) {
-      throw new Error(`${status.id} must be activated in SingleWidgetApp.`);
+      const trans = translator.load(I18N_BUNDLE);
+      throw new Error(trans.__('%1 must be activated in SingleWidgetApp.', status.id));
     }
     return app.status;
   },
@@ -187,9 +194,11 @@ const paths: JupyterFrontEndPlugin<JupyterFrontEnd.IPaths> = {
   id: '@jupyterlite/repl-extension:paths',
   autoStart: true,
   provides: JupyterFrontEnd.IPaths,
-  activate: (app: JupyterFrontEnd): JupyterFrontEnd.IPaths => {
+  requires: [ITranslator],
+  activate: (app: JupyterFrontEnd, translator: ITranslator): JupyterFrontEnd.IPaths => {
     if (!(app instanceof SingleWidgetApp)) {
-      throw new Error(`${paths.id} must be activated in SingleWidgetApp.`);
+      const trans = translator.load(I18N_BUNDLE);
+      throw new Error(trans.__('%1 must be activated in SingleWidgetApp.', paths.id));
     }
     return app.paths;
   },

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -194,11 +194,9 @@ const paths: JupyterFrontEndPlugin<JupyterFrontEnd.IPaths> = {
   id: '@jupyterlite/repl-extension:paths',
   autoStart: true,
   provides: JupyterFrontEnd.IPaths,
-  requires: [ITranslator],
-  activate: (app: JupyterFrontEnd, translator: ITranslator): JupyterFrontEnd.IPaths => {
+  activate: (app: JupyterFrontEnd): JupyterFrontEnd.IPaths => {
     if (!(app instanceof SingleWidgetApp)) {
-      const trans = translator.load(I18N_BUNDLE);
-      throw new Error(trans.__('%1 must be activated in SingleWidgetApp.', paths.id));
+      throw new Error(`${paths.id} must be activated in SingleWidgetApp.`);
     }
     return app.paths;
   },


### PR DESCRIPTION
## References

- fixes #622

## Code changes

- [x] hoist bundle name to a constant
- [x] use bundle name constant in repl and application

## User-facing changes

- n/a (unless we _happen_ to get overlapping ones)

## Backwards-incompatible changes

- n/a (unless someone had been doing some translation we didn't know about)