### PR TITLE
Save files before downloading

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -287,7 +287,6 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
             if (item.type === 'directory') {
               return;
             }
-            await contents.save(item.path);
             const content = await formatContent(item.path);
             downloadContent(content, item.name);
           });

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -260,6 +260,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
             buttons: [Dialog.okButton({ label: trans.__('OK') })],
           });
         }
+        await context.save();
         const content = await formatContent(context.path);
         downloadContent(content, context.path);
       },
@@ -286,6 +287,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
             if (item.type === 'directory') {
               return;
             }
+            await contents.save(item.path);
             const content = await formatContent(item.path);
             downloadContent(content, item.name);
           });


### PR DESCRIPTION
## References

Addresses #628 .

## Code changes

Automatically (and unconditionally) saves files before downloading.

## User-facing changes

This applies when the Download option is selected from the File menu or from the File Browser context menu.

## Backwards-incompatible changes

None known.
