### PR TITLE
Fix signature for pyplot.show in Matplotlib

### DIFF
--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -14,7 +14,7 @@ def patch_matplotlib():
     _old_show = matplotlib.pyplot.show
     assert _old_show, "matplotlib.pyplot.show"
 
-    def show():
+    def show(*,block=None):
         buf = BytesIO()
         matplotlib.pyplot.savefig(buf, format="png")
         buf.seek(0)

--- a/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/patches.py
@@ -14,7 +14,7 @@ def patch_matplotlib():
     _old_show = matplotlib.pyplot.show
     assert _old_show, "matplotlib.pyplot.show"
 
-    def show(*,block=None):
+    def show(*, block=None):
         buf = BytesIO()
         matplotlib.pyplot.savefig(buf, format="png")
         buf.seek(0)


### PR DESCRIPTION
matplotlib.pyplot.show takes a single optional argument (block).

It is meaningless in jupyterlite, but some other libraries depend on being able to pass it in, e.g. mplfinance, so we should just take it and then ignore it.