### PR TITLE
Fix CSV file upload

### DIFF
--- a/packages/contents/src/tokens.ts
+++ b/packages/contents/src/tokens.ts
@@ -129,10 +129,14 @@ export interface IContents {
  * Commonly-used mimetypes
  */
 export namespace MIME {
-  export const JS = 'application/javascript';
   export const JSON = 'application/json';
   export const MANIFEST_JSON = 'application/manifest+json';
   export const PLAIN_TEXT = 'text/plain';
+  export const CSV = 'text/csv';
+  export const CALENDAR = 'text/calendar';
+  export const CSS = 'text/css';
+  export const HTML = 'text/html';
+  export const JS = 'text/javascript';
   export const PYTHON = 'application/x-python-code';
   export const SVG = 'image/svg+xml';
   export const XML = 'application/xml';
@@ -141,10 +145,14 @@ export namespace MIME {
    * A list of mime types of common text file types
    */
   export const KNOWN_TEXT_TYPES = new Set([
-    JS,
     JSON,
     MANIFEST_JSON,
     PLAIN_TEXT,
+    CSV,
+    CALENDAR,
+    CSS,
+    HTML,
+    JS,
     PYTHON,
     SVG,
     XML,

--- a/packages/contents/src/tokens.ts
+++ b/packages/contents/src/tokens.ts
@@ -136,7 +136,7 @@ export namespace MIME {
   export const CALENDAR = 'text/calendar';
   export const CSS = 'text/css';
   export const HTML = 'text/html';
-  export const JS = 'text/javascript';
+  export const JS = 'application/javascript';
   export const PYTHON = 'application/x-python-code';
   export const SVG = 'image/svg+xml';
   export const XML = 'application/xml';


### PR DESCRIPTION
## References

A partial fix for https://github.com/jupyterlite/jupyterlite/issues/665. This PR fixes the upload of CSV file by making it a known text type.

In combination with https://github.com/jupyterlite/jupyterlite/pull/655 we can open the CSV file with pandas:

![csv](https://user-images.githubusercontent.com/21197331/173301875-4d2685b2-9726-426d-afc4-175bb59b5b1d.png)

## Code changes

Make the CSV mimetype a known text type

## User-facing changes

They can now upload CSV files

## Backwards-incompatible changes

None