### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,6 +24,7 @@ tasks:
   - name: watch
     command: |
       gp sync-await setup
+      source ~/.bashrc
       micromamba activate
       doit watch
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,13 +17,14 @@ tasks:
       popd
       micromamba activate 
       micromamba install -n base -y -f .binder/environment.yml
+      doit
+      gp sync-done setup
     command: |
       micromamba activate
       doit watch
-      gp sync-done watch
   - name: watch
     command: |
-      gp sync-await watch
+      gp sync-await setup
       source ~/.bashrc
       micromamba activate
       doit serve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,16 +15,16 @@ tasks:
       ./bin/micromamba shell init -s bash -p ~/micromamba
       source ~/.bashrc
       popd
-      micromamba create -y -f .binder/environment.yml
-      micromamba activate jupyterlite-dev
+      micromamba activate 
+      micromamba install -n base -y -f .binder/environment.yml
       gp sync-done setup
     command: |
-      micromamba activate jupyterlite-dev
+      micromamba activate
       doit serve
   - name: watch
     command: |
       gp sync-await setup
-      micromamba activate jupyterlite-dev
+      micromamba activate
       doit watch
 ports:
   - port: 5000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,8 @@ github:
     addBadge: false
     addLabel: false
 tasks:
-  - init: |
+  - name: setup
+    init: |
       pushd ~
       wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
       ./bin/micromamba shell init -s bash -p ~/micromamba
@@ -16,9 +17,15 @@ tasks:
       popd
       micromamba create -y -f .binder/environment.yml
       micromamba activate jupyterlite-dev
+      gp sync-done setup
     command: |
       micromamba activate jupyterlite-dev
       doit serve
+  - name: watch
+    command: |
+      gp sync-await setup
+      micromamba activate jupyterlite-dev
+      doit watch
 ports:
   - port: 5000
   - port: 8000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,16 +17,16 @@ tasks:
       popd
       micromamba activate 
       micromamba install -n base -y -f .binder/environment.yml
-      gp sync-done setup
     command: |
-      micromamba activate
-      doit serve
-  - name: watch
-    command: |
-      gp sync-await setup
-      source ~/.bashrc
       micromamba activate
       doit watch
+      gp sync-done watch
+  - name: watch
+    command: |
+      gp sync-await watch
+      source ~/.bashrc
+      micromamba activate
+      doit serve
 ports:
   - port: 5000
   - port: 8000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,6 +28,12 @@ tasks:
       source ~/.bashrc
       micromamba activate
       doit serve
+  - name: docs
+    command: |
+      gp sync-await setup
+      source ~/.bashrc
+      micromamba activate
+      doit watch:docs
 ports:
   - port: 5000
   - port: 8000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false
+tasks:
+  - init: |
+      pushd ~
+      wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+      ./bin/micromamba shell init -s bash -p ~/micromamba
+      source ~/.bashrc
+      popd
+      micromamba create -f .binder/environment.yml
+      micromamba activate jupyterlite-dev
+    command: |
+      micromamba activate jupyterlite-dev
+      doit watch
+ports:
+  - port: 8000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,18 +1,11 @@
 github:
   prebuilds:
-    # enable for the master/default branch (defaults to true)
     master: true
-    # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
-    # enable for pull requests coming from forks (defaults to false)
     pullRequestsFromForks: true
-    # add a check to pull requests (defaults to true)
     addCheck: false
-    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
     addComment: false
-    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: false
-    # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false
 tasks:
   - init: |
@@ -21,10 +14,12 @@ tasks:
       ./bin/micromamba shell init -s bash -p ~/micromamba
       source ~/.bashrc
       popd
-      micromamba create -f .binder/environment.yml
+      micromamba create -y -f .binder/environment.yml
       micromamba activate jupyterlite-dev
     command: |
       micromamba activate jupyterlite-dev
-      doit watch
+      doit serve
 ports:
+  - port: 5000
   - port: 8000
+  - port: 8888

--- a/dodo.py
+++ b/dodo.py
@@ -1263,7 +1263,7 @@ class U:
         try:
             # try with micromamba first
             raw_lock = subprocess.check_output(
-                [which("micromamba"), "env", "export", "--explicit"]
+                [os.getenv("MAMBA_EXE"), "env", "export", "--explicit"]
             )
         except:
             # default to using conda

--- a/dodo.py
+++ b/dodo.py
@@ -1261,13 +1261,13 @@ class U:
     def sync_lite_config(from_env, to_json, marker, extra_urls, all_deps):
         """use conda list to derive tarball names for federated_extensions"""
         try:
-            # try with micromamba first
+            # try with conda first
+            raw_lock = subprocess.check_output([which("conda"), "list", "--explicit"])
+        except:
+            # try with micromamba
             raw_lock = subprocess.check_output(
                 [os.getenv("MAMBA_EXE"), "env", "export", "--explicit"]
             )
-        except:
-            # default to using conda
-            raw_lock = subprocess.check_output([which("conda"), "list", "--explicit"])
 
         ext_packages = [
             p.strip().split(" ")[0]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

This should make it easier for folks to start contributing to JupyterLite, especially when working on the docs and not wanting to install node and all the tooling.

The dev setup can sometimes be challenging with the combination of JS / Node and Python.

## Code changes

Add a Gitpod config file to:

- [x] Automatically setup a `micromamba` environment on `init`
- [x] Serve the assets with `doit serve`
- [x] Watch for changes with `doit watch`
- [x] Serve and watch the docs

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for end users.

Contributors should be able to work on the JupyterLite repo from a web browser directly:

![image](https://user-images.githubusercontent.com/591645/174114190-34ed1c2c-c72b-4ed0-9850-ae3963b45f5f.png)

## Backwards-incompatible changes

None

