### PR TITLE
Propagate doit return codes to CLI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,9 +89,9 @@ exclude_patterns = [
     "tsconfig.*",
     "webpack.config.*",
 ]
-jupyter_execute_notebooks = "auto"
+nb_execution_mode = "auto"
 
-execution_excludepatterns = [
+nb_execution_excludepatterns = [
     "_static/**/*",
 ]
 html_css_files = [

--- a/py/jupyterlite/src/jupyterlite/addons/piplite.py
+++ b/py/jupyterlite/src/jupyterlite/addons/piplite.py
@@ -120,6 +120,8 @@ class PipliteAddon(BaseAddon):
             if not wheel_index_url.startswith("./"):
                 continue
 
+            wheel_index_url = wheel_index_url.split("?")[0].split("#")[0]
+
             path = manager.output_dir / wheel_index_url
 
             if not path.exists():

--- a/py/jupyterlite/src/jupyterlite/addons/static.py
+++ b/py/jupyterlite/src/jupyterlite/addons/static.py
@@ -89,8 +89,11 @@ class StaticAddon(BaseAddon):
     def post_init(self, manager):
         """maybe remove sourcemaps, or all static assets if an app is not installed"""
         output_dir = manager.output_dir
-        pkg_json = output_dir / "package.json"
-        pkg_data = json.loads(pkg_json.read_text(**UTF8))
+
+        with tarfile.open(str(self.app_archive), "r:gz") as tar:
+            pkg_data = json.loads(
+                tar.extractfile(tar.getmember("package/package.json")).read()
+            )
 
         all_apps = set(pkg_data["jupyterlite"]["apps"])
         mgr_apps = set(manager.apps if manager.apps else all_apps)

--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -144,7 +144,7 @@ class LiteDoitApp(ManagedApp):
 
     def start(self):
         super().start()
-        self.lite_manager.doit_run(*self._doit_cmd)
+        self.exit(self.lite_manager.doit_run(*self._doit_cmd))
 
 
 # special non-task apps

--- a/py/jupyterlite/src/jupyterlite/manager.py
+++ b/py/jupyterlite/src/jupyterlite/manager.py
@@ -47,7 +47,7 @@ class LiteManager(LiteBuildConfig):
         loader = doit.cmd_base.ModuleTaskLoader(self._doit_tasks)
         config = dict(GLOBAL=self._doit_config)
         runner = doit.doit_cmd.DoitMain(task_loader=loader, extra_config=config)
-        runner.run([task, *args])
+        return runner.run([task, *args])
 
     @default("log")
     def _default_log(self):

--- a/py/jupyterlite/src/jupyterlite/tests/test_cli.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_cli.py
@@ -75,6 +75,12 @@ def test_cli_help(lite_args, help, script_runner):
     assert returned_version.stderr == ""
 
 
+@mark.parametrize("lite_args", LITE_INVOCATIONS)
+def test_nonzero_rc(lite_args, script_runner):
+    a_step = script_runner.run(*lite_args, "doit", "this-is-not-a-step")
+    assert not a_step.success
+
+
 @mark.parametrize("lite_hook", ["list", "status"])
 def test_cli_status_null(lite_hook, an_empty_lite_dir, script_runner):
     """do the "side-effect-free" commands create exactly one file?"""

--- a/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_extend_addon.py
@@ -18,8 +18,11 @@ def test_extend_addon_config(an_empty_lite_dir, a_configured_mock_addon, capsys)
 
     assert addon.some_feature == 42, "didn't configure"
 
-    app.start()
+    with pytest.raises(SystemExit) as exit:
+        app.start()
 
+    assert exit.type == SystemExit
+    assert exit.value.code == 0
     cap = capsys.readouterr()
     assert "hello world" in cap.out
 


### PR DESCRIPTION
## References

- fixes #673

## Code changes

- [x] ensure manager returns the error code from doit
- [x] ensure the app exists with the error code from the manager
- [x] add test 
- [x] fix tests that weren't expecting a `SystemExit`
- [x] fix bug where task plan generation was relying on `output_dir` already being populated
- [x] fix bug where cache-busting params were being propagated for cache stat checks, resulting in long windows paths
- [x] pull across docs config changes from #670 (thx @jtpio)  

## User-facing changes

- errors should be reported more robustly

## Backwards-incompatible changes

- some errors might not have been critical before... but it was probably broken