### PR TITLE
Add encoding to LiteStream

### DIFF
--- a/packages/pyolite-kernel/py/pyolite/pyolite/display.py
+++ b/packages/pyolite-kernel/py/pyolite/pyolite/display.py
@@ -14,6 +14,8 @@ class Image:
 
 
 class LiteStream:
+    encoding = "utf-8"
+
     def __init__(self, name):
         self.name = name
         self.publish_stream_callback = None


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/sympy/live/issues/10
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
`LiteStream` should have a field `encoding` to mock `sys.stdout`.
Since it's just a placeholder, I'm not sure whether it should be put as a class field, as `self.encoding`, or as a read-only `property`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
User code that access `sys.stdout.encoding` won't throw.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
