### PR TITLE
Fix micromamba environment on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,29 +10,32 @@ github:
 tasks:
   - name: setup
     init: |
-      pushd ~
+      pushd /workspace
       wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-      ./bin/micromamba shell init -s bash -p ~/micromamba
-      source ~/.bashrc
       popd
-      micromamba activate 
-      micromamba install -n base -y -f .binder/environment.yml
-      doit
-      gp sync-done setup
-    command: |
+      # bootstrap activation commands for other tasks to reuse
+      cat <<EOT > /workspace/bin/activate-env.sh
+      export MAMBA_ROOT_PREFIX=/workspace/.micromamba
+      export MAMBA_EXE=/workspace/bin/micromamba
+      $(/workspace/bin/micromamba shell hook --shell=bash)
       micromamba activate
+      EOT
+      source /workspace/bin/activate-env.sh
+      micromamba install -n base -y -f .binder/environment.yml
+      doit build
+    command: |
+      gp sync-done setup
+      source /workspace/bin/activate-env.sh
       doit watch
   - name: watch
     command: |
       gp sync-await setup
-      source ~/.bashrc
-      micromamba activate
+      source /workspace/bin/activate-env.sh
       doit serve
   - name: docs
     command: |
       gp sync-await setup
-      source ~/.bashrc
-      micromamba activate
+      source /workspace/bin/activate-env.sh
       doit watch:docs
 ports:
   - port: 5000


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #672 

Turns out the prefix under `~/micromamba` is not persisted when the Gitpod workspaces go idle and need to be restarted. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Try to place the `micromamba` environment under `/workspace`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
