### PR TITLE
add config docs to getting started

### DIFF
--- a/docs/quickstart/configure.md
+++ b/docs/quickstart/configure.md
@@ -1,0 +1,23 @@
+# Configure a JupyterLite site
+
+Once you have initialized a JupyterLite site, configuration changes can be made by
+either adding or editing configutation files in the
+[Lite Dir](../reference/cli.ipynb#the-lite-dir).
+
+Configuration values are set in one or more of the
+[Runtime Configuration Files](../reference/config.md) in
+[well known locations in the Lite Dir](../reference/cli.ipynb#the-lite-dir).
+Configuration information is merged in a cascade, allowing settings to be set in the
+root of the [Lite Dir](../reference/cli.ipynb#the-lite-dir), and superceeded by settings
+for an individual app such as `retro` and `lab`.
+
+Available options are defined in the Jupyter Config Data
+[Schema](../reference/schema-v0.md) and include settings such as `appName`,
+`appVersion`, `settingsOverrides`, `exposeAppInBrowser`.
+
+## Overrides
+
+In addition to the [Runtime Configuration Files](../reference/config.md) additional
+`overrides.json` files can be created as described in
+[Customizing Settings](../howto/configure/settings.md). These override specific
+`@jupyterlab` settings, are merged into the `settingsOverrides` of the jupyter config.

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -12,4 +12,5 @@ using
 deploy
 embed-repl
 standalone
+configure
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Addresses #681 

## Code changes

Added a new page in the Getting Started section of the docs, mainly linking to other ket reference material that it is useful to group together and expose the reader to early.

## User-facing changes

![image](https://user-images.githubusercontent.com/1473646/175401138-6ef0cd62-d790-4d98-9555-5e1d54295349.png)

## Backwards-incompatible changes

None
