### PR TITLE
Add UI test for embedding the REPL

### DIFF
--- a/ui-tests/embed/index.html
+++ b/ui-tests/embed/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>JupyterLite REPL embed</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <style>
+    iframe {
+      width: 800px;
+      height: 600px;
+      border: none;
+    }
+  </style>
+  <body>
+    <h1>Embedding the JupyterLite REPL with an IFrame</h1>
+    <iframe
+      src="../repl/index.html?toolbar=1&kernel=javascript"
+    ></iframe>
+  </body>
+</html>

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-3-Clause",
   "description": "JupyterLite UI Tests",
   "scripts": {
-    "build": "jupyter lite build",
+    "build": "jupyter lite build && cp -r embed ui-tests-app",
     "start": "cd ui-tests-app && python -m http.server -b 127.0.0.1",
     "start:detached": "yarn run start&",
     "test": "playwright test",

--- a/ui-tests/test/embed.test.ts
+++ b/ui-tests/test/embed.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) JupyterLite Contributors
+// Distributed under the terms of the Modified BSD License.
+
+import { test as base } from '@jupyterlab/galata';
+
+import { expect } from '@playwright/test';
+
+// TODO: fix upstream condition so it's not specific to JupyterLab?
+const test = base.extend({
+  waitForApplication: async ({ baseURL }, use, testInfo) => {
+    const waitIsReady = async (page): Promise<void> => {
+      await page.frameLocator('iframe');
+      await iframe.waitForSelector('.jp-InputArea');
+    };
+    await use(waitIsReady);
+  },
+});
+
+test.describe('Embed the REPL app', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('embed/index.html');
+  });
+
+  test('Page', async ({ page }) => {
+    const imageName = 'page.png';
+    expect(await page.screenshot()).toMatchSnapshot(imageName.toLowerCase());
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

This should help catch issues when embedding a REPL in another web page.

Still a WIP for now.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add new UI tests.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
