### PR TITLE
Update copyright year in the about dialog

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -136,7 +136,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© 2021 JupyterLite Contributors')}
+            {trans.__('© 2021-2022 JupyterLite Contributors')}
           </span>
         );
         const body = (


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Small tweak to add 2022 to the copyright year in the about dialog so it's consistent with the one from JupyterLab:

![image](https://user-images.githubusercontent.com/591645/176282068-00e642be-dd82-49fc-b03f-a3ba70b69703.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Update the about dialog:

![image](https://user-images.githubusercontent.com/591645/176281826-33c7868f-16c9-4516-80ab-b975cae04877.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
