### PR TITLE
[wip] split up eslint, add linter skips env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.7', '3.10', 'pypy3.8']
+        python-version: ['3.7', '3.10', 'pypy-3.8']
         include:
           # OS-specifics for running pip
           - os: ubuntu
@@ -115,13 +115,13 @@ jobs:
             pytest-args: '[]'
           - python-version: '3.10'
             pytest-args: '[]'
-          # - python-version: 'pypy3.8'
+          # - python-version: 'pypy-3.8'
           #   # TODO: some instability with libarchive, might be better with pypy-3.8
           #   # after https://github.com/cloudpipe/cloudpickle/pull/461
           #   pytest-args: '["-k", "not _archive_is_"]'
         exclude:
           - os: windows
-            python-version: pypy3.8
+            python-version: pypy-3.8
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.7', '3.10', 'pypy-3.8']
+        python-version: ['3.7', '3.10', 'pypy-3.7']
         include:
           # OS-specifics for running pip
           - os: ubuntu
@@ -115,13 +115,13 @@ jobs:
             pytest-args: '[]'
           - python-version: '3.10'
             pytest-args: '[]'
-          # - python-version: 'pypy-3.8'
-          #   # TODO: some instability with libarchive, might be better with pypy-3.8
-          #   # after https://github.com/cloudpipe/cloudpickle/pull/461
-          #   pytest-args: '["-k", "not _archive_is_"]'
+          - python-version: 'pypy-3.7'
+            # TODO: some instability with libarchive, might be better with pypy-3.7
+            # after https://github.com/cloudpipe/cloudpickle/pull/461
+            pytest-args: '["-k", "not _archive_is_"]'
         exclude:
           - os: windows
-            python-version: pypy-3.8
+            python-version: pypy-3.7
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.7', '3.10', 'pypy-3.7']
+        python-version: ['3.7', '3.10', 'pypy3.8']
         include:
           # OS-specifics for running pip
           - os: ubuntu
@@ -115,13 +115,13 @@ jobs:
             pytest-args: '[]'
           - python-version: '3.10'
             pytest-args: '[]'
-          - python-version: 'pypy-3.7'
-            # TODO: some instability with libarchive, might be better with pypy-3.8
-            # after https://github.com/cloudpipe/cloudpickle/pull/461
-            pytest-args: '["-k", "not _archive_is_"]'
+          # - python-version: 'pypy3.8'
+          #   # TODO: some instability with libarchive, might be better with pypy-3.8
+          #   # after https://github.com/cloudpipe/cloudpickle/pull/461
+          #   pytest-args: '["-k", "not _archive_is_"]'
         exclude:
           - os: windows
-            python-version: pypy-3.7
+            python-version: pypy3.8
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ doit info build:js:app:retro
 
 #### Task and Action Defaults
 
-The default `doit` _action_ is `run` which... runs the named _tasks_.
+The default `doit` _action_ is `run` which... runs the named _tasks_, but crucially any
+tasks needed to created the _file dependencies_ of the task to be up-to-date.
 
 The default tasks are `lint`, `build` and `docs:app:build`, so the following are
 equivalent:
@@ -76,6 +77,20 @@ doit
 doit lint build docs:app:build
 doit run lint build docs:app:build
 ```
+
+and entails building nearly the whole non-documentation stack.
+
+#### Running Just One Task
+
+It is possible to run a _single_ task, ignoring any dependencies.
+
+```bash
+doit --single serve:core:js
+doit -s serve:core:js
+```
+
+Note: this may not leave the system in a working state, but re-running _without_ `-s`
+will usually restore everything.
 
 #### `doit auto`
 
@@ -103,6 +118,18 @@ Offering different assets and tools, and obey different environment variables:
 - `8888`: JupyterLab
   - `doit serve:lab`
     - `LAB_ARGS` (a JSON list of strings) controls CLI arguments to `jupyter lab`
+
+#### More task options
+
+- `doit lint`
+  - `SKIP_LINT` (a JSON list of strings) skips a number of linters.
+    - Some options include: `black`, `pyflakes`, `pyodide`, `schema`, `prettier`, `lite`
+- `doit test`
+  - `PYTEST_ARGS` (a JSON list of strings) passes arguments to `pytest`
+  - `PYTEST_PROCS` (an integer) uses a different number of processes to test
+- `doit docs`
+  - `SPHINX_ARGS` (a JSON list of strings) passes arguments to `sphinx-build`
+  - `LITE_ARGS` (a JSON list of strings) passes arguments to `jupyter-lite`
 
 ### Core JavaScript development
 

--- a/dodo.py
+++ b/dodo.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import doit
 import pkginfo
-import requests_cache
 
 
 def which(cmd):
@@ -1247,15 +1246,30 @@ class U:
 
     @staticmethod
     def session():
-        if U._SESSION is None:
-            if not B.BUILD.exists():
-                B.BUILD.mkdir()
+        try:
+            import requests_cache
 
-            U._SESSION = requests_cache.CachedSession(
-                str(B.BUILD / B.REQ_CACHE.stem),
-                allowable_methods=["GET", "POST", "HEAD"],
-                allowable_codes=[200, 302, 404],
-            )
+            HAS_REQUESTS_CACHE = True
+        except Exception as err:
+            print(f"requests_cache not available: {err}")
+            HAS_REQUESTS_CACHE = False
+
+        if U._SESSION is None:
+            if HAS_REQUESTS_CACHE:
+                if not B.BUILD.exists():
+                    B.BUILD.mkdir()
+
+                U._SESSION = requests_cache.CachedSession(
+                    str(B.BUILD / B.REQ_CACHE.stem),
+                    allowable_methods=["GET", "POST", "HEAD"],
+                    allowable_codes=[200, 302, 404],
+                )
+            else:
+                import requests
+
+                U._SESSION = requests.Session()
+                print("Using uncached requests session")
+
         return U._SESSION
 
     @staticmethod


### PR DESCRIPTION
## References

- more work towards #194
- makes #684 worse :imp: 

## Code changes

- [x] runs `eslint` per directory in `packages`
  - it is now slower, as starting eslint has overhead, but doesn't _seem_ to error out?
    - probably need to do some actual dev to see more issues
  - subsequent runs will be smaller
  - i personally disable `pre-commit` hooks, this won't impact it
- [x] skips `eslint` for `_metapackage`
- [x] adds some docs about various run options

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a