### PR TITLE
Docs howto content: example jupyter_lite_config.json must be JSON

### DIFF
--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -64,22 +64,19 @@ provided by
 ```
 
 For example, to ensure the `.fasta` file format is served correctly as `text/plain`:
+`jupyter_lite_config.json`:
 
-```yaml
-# jupyter_lite_config.json
+```json
 {
-  'LiteBuildConfig':
-    {
-      'extra_file_types':
-        {
-          'fasta':
-            {
-              'name': 'fasta',
-              'extensions': ['.fasta'],
-              'mimetypes': ['text/plain'],
-              'fileFormat': 'text',
-            },
-        },
-    },
+  "LiteBuildConfig": {
+    "extra_file_types": {
+      "fasta": {
+        "name": "fasta",
+        "extensions": [".fasta"],
+        "mimetypes": ["text/plain"],
+        "fileFormat": "text"
+      }
+    }
+  }
 }
 ```


### PR DESCRIPTION
## References

N/A

## Code changes

N/A

## User-facing changes

Docs: The example `jupyter_lite_config.json` in https://jupyterlite.readthedocs.io/en/latest/howto/content/files.html#customizing-mime-types isn't valid JSON, so `jupyter lite build` fails to parse it.

## Backwards-incompatible changes

N/A