### PR TITLE
Allow worker.js to work with pyodide.mjs

### DIFF
--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -163,10 +163,10 @@ export class PyoliteRemoteKernel {
 
   protected async initRuntime(options: IPyoliteWorkerKernel.IOptions): Promise<void> {
     const { pyodideUrl, indexUrl } = options;
-    if(pyodideUrl.endsWith(".mjs")){
-      let pyodideModule:any=await import(/* webpackIgnore: true */ pyodideUrl);
-      this._pyodide = await (pyodideModule as any).loadPyodide({ indexURL: indexUrl });       
-    }else{
+    if (pyodideUrl.endsWith('.mjs')) {
+      const pyodideModule: any = await import(/* webpackIgnore: true */ pyodideUrl);
+      this._pyodide = await (pyodideModule as any).loadPyodide({ indexURL: indexUrl });
+    } else {
       importScripts(pyodideUrl);
       this._pyodide = await (self as any).loadPyodide({ indexURL: indexUrl });
     }

--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -163,8 +163,13 @@ export class PyoliteRemoteKernel {
 
   protected async initRuntime(options: IPyoliteWorkerKernel.IOptions): Promise<void> {
     const { pyodideUrl, indexUrl } = options;
-    importScripts(pyodideUrl);
-    this._pyodide = await (self as any).loadPyodide({ indexURL: indexUrl });
+    if(pyodideUrl.endsWith(".mjs")){
+      let pyodideModule:any=await import(/* webpackIgnore: true */ pyodideUrl);
+      this._pyodide = await (pyodideModule as any).loadPyodide({ indexURL: indexUrl });       
+    }else{
+      importScripts(pyodideUrl);
+      this._pyodide = await (self as any).loadPyodide({ indexURL: indexUrl });
+    }
   }
 
   protected async initPackageManager(


### PR DESCRIPTION
If you build this as an es module with webpack, it breaks because importScripts doesn't work in ES modules, and the worker module is one. This change gives the option to pass a link to pyodide.mjs (the es module version of pyodide) which means the whole of jupyterlite can happily build as es modules.

I added a `webpackIgnore` comment because it is easier to leave pyodide as a completely external dependency and not have to mess around with adding it into the webpack. It would be possible to use NPM embedded pyodide, but that would up the build size of jupyterlite.

This doesn't fix anything in the current build, but it could reduce breakage in future when everything node / webpack etc. moves across to ES modules, because the current code in worker.ts is not a valid es module (because importScripts only works in non-module javascript).