### PR TITLE
Serves Python server instead of Nodejs

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -652,7 +652,7 @@ def task_serve():
         name="core:py",
         doc="serve the core app (no extensions) with python",
         uptodate=[lambda: False],
-        actions=[U.do("yarn", "serve")],
+        actions=[U.do("yarn", "serve:py")],
         file_dep=app_indexes,
     )
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier:fix": "prettier --list-different --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
     "publish": "yarn clean && yarn build && lerna publish",
     "serve": "node scripts/serve.js",
-    "serve:py": "cd app && python -m http.server -b 127.0.0.1 8000 && echo \nServing at http://127.0.0.1:8000",
+    "serve:py": "cd app && python -m http.server -b 127.0.0.1 8000",
     "test": "lerna run test",
     "update:dependency": "node ./node_modules/@jupyterlab/buildutils/lib/update-dependency.js --lerna",
     "watch": "run-p watch:lib watch:app",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier:fix": "prettier --list-different --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
     "publish": "yarn clean && yarn build && lerna publish",
     "serve": "node scripts/serve.js",
-    "serve:py": "cd app && python -m http.server -b 127.0.0.1",
+    "serve:py": "cd app && python -m http.server -b 127.0.0.1 8000 && echo \nServing at http://127.0.0.1:8000",
     "test": "lerna run test",
     "update:dependency": "node ./node_modules/@jupyterlab/buildutils/lib/update-dependency.js --lerna",
     "watch": "run-p watch:lib watch:app",


### PR DESCRIPTION

## References
Addresses the Issue https://github.com/jupyterlite/jupyterlite/issues/723

## Code changes

yarn runs `serve:py` instead of `serve` when choosing python to serve the app. It also displays the URL in the console for the developers to access the App in the browser easily.

