### PR TITLE
Update no wheels found error message

### DIFF
--- a/py/jupyterlite/src/jupyterlite/app.py
+++ b/py/jupyterlite/src/jupyterlite/app.py
@@ -272,7 +272,7 @@ class PipliteIndex(DescribedMixin, JupyterApp):
         if not self.wheel_dir.exists():
             raise ValueError(f"{self.wheel_dir} does not exist")
         if not list_wheels(self.wheel_dir):
-            raise ValueError(f"no wheels found in {self.wheel_dir}")
+            raise ValueError(f"no supported wheels found in {self.wheel_dir}")
         from .addons.piplite import write_wheel_index
 
         write_wheel_index(self.wheel_dir)


### PR DESCRIPTION
## References

None.

## Code changes

`list_wheels` only returns supported wheels (`ALL_WHL` in `constants.py`). This error is (rightfully) raised when no supported wheels are present, even though there may be other wheels in the directory. In that case, this new error message is more descriptive.

## User-facing changes

```
ValueError: no wheels found in /dir
```

will be

```
ValueError: no supported wheels found in /dir
```

## Backwards-incompatible changes

None.
