### PR TITLE
Declare will_fetch early

### DIFF
--- a/py/jupyterlite/src/jupyterlite/addons/pyodide.py
+++ b/py/jupyterlite/src/jupyterlite/addons/pyodide.py
@@ -182,6 +182,7 @@ class PyodideAddon(BaseAddon):
         else:
             local_path = (self.manager.lite_dir / path_or_url).resolve()
             dest = self.pyodide_cache / local_path.name
+            will_fetch = False
 
         if local_path.is_dir():
             all_paths = sorted([p for p in local_path.rglob("*") if not p.is_dir()])


### PR DESCRIPTION
This prevents an error `UnboundLocalError: local variable 'will_fetch' referenced before assignment` when using a local `.bz2` file.

## References

#727 

## Code changes

Set `will_fetch = False` if not `https?` scheme.

## User-facing changes

\-

## Backwards-incompatible changes

\-
