### PR TITLE
Bugfix:Make input work again

### DIFF
--- a/packages/pyolite-kernel/src/worker.ts
+++ b/packages/pyolite-kernel/src/worker.ts
@@ -383,8 +383,8 @@ export class PyoliteRemoteKernel {
     this._interpreter.display_pub.update_display_data_callback =
       updateDisplayDataCallback;
     this._interpreter.displayhook.publish_execution_result = publishExecutionResult;
-    this._interpreter.input = this.input;
-    this._interpreter.getpass = this.getpass;
+    this._interpreter.input = this.input.bind(this);
+    this._interpreter.getpass = this.getpass.bind(this);
 
     const res = await this._kernel.run(content.code);
     const results = this.formatResult(res);


### PR DESCRIPTION
The input and getpass callbacks have become object methods, so they need to be passed as bound objects now. Otherwise calls to await input fail with undefined this errors. 

Try calling await input("hello") on the jupyterlite demo page. In Chrome it fails for me on current build (and any build since comlink came in).

<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
