### PR TITLE
Add JupyterLab-github to the federated extensions

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -21,6 +21,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-1.1.0-pyhd8ed1ab_0.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.8.2-pyhd8ed1ab_0.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
+      "https://files.pythonhosted.org/packages/py3/j/jupyterlab_github/jupyterlab_github-3.0.1-py3-none-any.whl",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
     "ignore_sys_prefix": ["federated_extensions", "mathjax"],

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -8,7 +8,8 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-1.0.2-pyhd8ed1ab_0.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.1.0-pyhd8ed1ab_1.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
-      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
+      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/py3/j/jupyterlab_github/jupyterlab_github-3.0.1-py3-none-any.whl"
     ],
     "output_dir": "ui-tests-app",
     "ignore_sys_prefix": ["federated_extensions"]

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -8,8 +8,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-1.0.2-pyhd8ed1ab_0.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.1.0-pyhd8ed1ab_1.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
-      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl",
-      "https://files.pythonhosted.org/packages/py3/j/jupyterlab_github/jupyterlab_github-3.0.1-py3-none-any.whl"
+      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
     ],
     "output_dir": "ui-tests-app",
     "ignore_sys_prefix": ["federated_extensions"]


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The github extension pairs powerfully with jupyterlite to let people easily work on existing content on github, like tutorials, notebooks in package source repos, books on github, etc.

A motivation for this, for example, is the jupyter widgets tutorial at scipy, which may work really nicely with this github extension.

## User-facing changes

Adds a github file browser.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
