### PR TITLE
Service worker configuration options in jupyter-lite.json

### DIFF
--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -24,6 +24,7 @@ import {
   Router,
   IServiceWorkerRegistrationWrapper,
   ServiceWorkerRegistrationWrapper,
+  ServiceWorker,
 } from '@jupyterlite/server';
 
 import { ISessions, Sessions } from '@jupyterlite/session';
@@ -199,13 +200,18 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
 /**
  * A plugin installing the service worker.
  */
+const serviceWorkerPluginID = '@jupyterlite/server-extension:service-worker';
 const serviceWorkerPlugin: JupyterLiteServerPlugin<IServiceWorkerRegistrationWrapper> =
   {
-    id: '@jupyterlite/server-extension:service-worker',
+    id: serviceWorkerPluginID,
     autoStart: true,
     provides: IServiceWorkerRegistrationWrapper,
     activate: (app: JupyterLiteServer) => {
-      return new ServiceWorkerRegistrationWrapper();
+      const config: ServiceWorker.IConfig =
+        JSON.parse(PageConfig.getOption('litePluginSettings') || '{}')[
+          serviceWorkerPluginID
+        ] || {};
+      return new ServiceWorkerRegistrationWrapper(config);
     },
   };
 

--- a/packages/server/src/serviceworker.ts
+++ b/packages/server/src/serviceworker.ts
@@ -43,13 +43,6 @@ export class ServiceWorkerRegistrationWrapper
       this.setRegistration(null);
     }
 
-    if (!('serviceWorker' in navigator)) {
-      console.error(
-        'ServiceWorker registration failed: Service Workers not supported in this browser'
-      );
-      this.setRegistration(null);
-    }
-
     if (navigator.serviceWorker.controller) {
       const registration = await navigator.serviceWorker.getRegistration(
         navigator.serviceWorker.controller.scriptURL


### PR DESCRIPTION
I added a couple of options to the serviceworker plugin, to allow you to 

a) Point it at somewhere else in the case that you want to host jupyterlite files in a subfolder of your site, but want the service worker to be able to handle things at that level.
b) Disable the service worker (deleting the services.js script isn't enough, because if you use your own service worker, jupyterlite clobbers it every time you load the page, even if the script is missing)