### PR TITLE
Alter parent settings to messages

### DIFF
--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -103,9 +103,10 @@ export abstract class BaseKernel implements IKernel {
   async handleMessage(msg: KernelMessage.IMessage): Promise<void> {
     this._busy(msg);
 
-    this._parent = msg;
-
     const msgType = msg.header.msg_type;
+    if(msgType=='execute_request'){
+      this._parent = msg;
+    }    
     switch (msgType) {
       case 'kernel_info_request':
         await this._kernelInfo(msg);


### PR DESCRIPTION
I don't understand quite how the parent message thing works, but setting the parent on every message breaks things. 

This is why the pyolite kernel breaks if you call await input twice, because it sets 'input_reply' as the parent message, rather than keeping the 'execute_request' there. With this fix, await input works fine.

I'm not convinced that this fix is perfect and that it doesn't need setting for other messages, but I thought it was worth throwing it out for discussion.
