### PR TITLE
Docs: fix path to `overrides.json`

### DIFF
--- a/docs/howto/configure/settings.md
+++ b/docs/howto/configure/settings.md
@@ -10,7 +10,7 @@ Let's say you would like to customize the behavior of the `REPL` app, and use th
 terminal interaction mode.
 
 You can create the following `overrides.json` file in
-`{output-dir}/repl/jupyter-lite.json`:
+`{output-dir}/repl/:
 
 ```json
 {

--- a/docs/howto/configure/settings.md
+++ b/docs/howto/configure/settings.md
@@ -1,8 +1,8 @@
 # Customizing Settings
 
-With the [CLI](../../reference/cli.ipynb), if you create an `{lite-dir}/overrides.json` 
-in either the root, or a specific `{lite-dir}/{app}/` directory, these will be merged into
-`{output-dir}/{app?/}jupyter-lite.json#/jupyter-config-data/settingsOverrides`
+With the [CLI](../../reference/cli.ipynb), if you create an `{lite-dir}/overrides.json`
+in either the root, or a specific `{lite-dir}/{app}/` directory, these will be merged
+into `{output-dir}/{app?/}jupyter-lite.json#/jupyter-config-data/settingsOverrides`
 
 ## Example
 

--- a/docs/howto/configure/settings.md
+++ b/docs/howto/configure/settings.md
@@ -1,16 +1,15 @@
 # Customizing Settings
 
-With the [CLI](../../reference/cli.ipynb), if you create an `overrides.json` in either
-the root, or a specific `app` directory, these will be merged into
-`{output-dir}/{app?}/jupyter-lite.json#/jupyter-config-data/settingsOverrides`
+With the [CLI](../../reference/cli.ipynb), if you create an `{lite-dir}/overrides.json` 
+in either the root, or a specific `{lite-dir}/{app}/` directory, these will be merged into
+`{output-dir}/{app?/}jupyter-lite.json#/jupyter-config-data/settingsOverrides`
 
 ## Example
 
 Let's say you would like to customize the behavior of the `REPL` app, and use the
 terminal interaction mode.
 
-You can create the following `overrides.json` file in
-`{output-dir}/repl/:
+You can create the following `overrides.json` in `{lite-dir}/repl/` before building:
 
 ```json
 {
@@ -21,4 +20,4 @@ You can create the following `overrides.json` file in
 ```
 
 One of the effects of using `terminal` for the `interactionMode` will be the switch from
-`Shift-Enter` to `Enter` for executing code.
+<kbd>Shift-Enter</kbd> to <kbd>Enter</kbd> for executing code.

--- a/docs/howto/configure/settings.md
+++ b/docs/howto/configure/settings.md
@@ -2,7 +2,7 @@
 
 With the [CLI](../../reference/cli.ipynb), if you create an `{lite-dir}/overrides.json`
 in either the root, or a specific `{lite-dir}/{app}/` directory, these will be merged
-into `{output-dir}/{app?/}jupyter-lite.json#/jupyter-config-data/settingsOverrides`
+into `{output-dir}/{app?/}jupyter-lite.json#/jupyter-config-data/settingsOverrides`.
 
 ## Example
 


### PR DESCRIPTION
This PR corrects (I believe) the path to the overrides file.