### PR TITLE
Document browser console error when no contents is provided

### DIFF
--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -21,6 +21,9 @@ Will be:
   - may have timestamps changed if `--source-date-epoch` is provided.
 - indexed to provide `{output-dir}/api/contents/{subdir?}/all.json`
 
+If no contents are provided when building jupyterlite this leads to an error message which can be safely ignored: 
+`Failed to load resource: the server responded with a status of 404 (File not found) :8000/api/contents/all.json:1`
+
 ## Server Contents and Local Contents
 
 When a user changes a server-hosted file, a copy will be made to the browser's storage,

--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -21,8 +21,14 @@ Will be:
   - may have timestamps changed if `--source-date-epoch` is provided.
 - indexed to provide `{output-dir}/api/contents/{subdir?}/all.json`
 
-If no contents are provided when building jupyterlite this leads to an error message which can be safely ignored: 
-`Failed to load resource: the server responded with a status of 404 (File not found) :8000/api/contents/all.json:1`
+````{note}
+If no contents are provided when building the JupyterLite website,
+the following error message might be logged in the browser console and can be safely ignored:
+
+```
+Failed to load resource: the server responded with a status of 404 (File not found) :8000/api/contents/all.json:1
+```
+````
 
 ## Server Contents and Local Contents
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

This addresses https://github.com/jupyterlite/jupyterlite/issues/770
This is purely a change to the documentation mentioning that the error

Failed to load resource: the server responded with a status of 404 (File not found) :8000/api/contents/all.json:1

if no contents are provided when building jupyterlite

## Code changes

none

## User-facing changes

none

## Backwards-incompatible changes

none
