### PR TITLE
update to pyodide 0.21.2

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -213,7 +213,7 @@
         "pyodideUrl": {
           "description": "The path to the main pyodide.js entry point",
           "type": "string",
-          "default": "https://cdn.jsdelivr.net/pyodide/v0.21.1/full/pyodide.js",
+          "default": "https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js",
           "format": "uri"
         },
         "disablePyPIFallback": {

--- a/dodo.py
+++ b/dodo.py
@@ -884,7 +884,7 @@ class C:
     PYPI_SRC = f"{PYPI}/packages/source"
     PYODIDE_GH = f"{GH}/pyodide/pyodide"
     PYODIDE_DOWNLOAD = f"{PYODIDE_GH}/releases/download"
-    PYODIDE_VERSION = "0.21.1"
+    PYODIDE_VERSION = "0.21.2"
     PYODIDE_JS = "pyodide.js"
     PYODIDE_ARCHIVE = f"pyodide-build-{PYODIDE_VERSION}.tar.bz2"
     PYODIDE_URL = os.environ.get(

--- a/packages/pyolite-kernel-extension/src/index.ts
+++ b/packages/pyolite-kernel-extension/src/index.ts
@@ -14,7 +14,7 @@ import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.21.1/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.21.2/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.


### PR DESCRIPTION
## References

- n/a

## Code changes

- [x] bump to `pyodide` 0.21.2

## User-facing changes

- some new packages are `piplite`-installable (`lzma`)
- some additional relative path options

## Backwards-incompatible changes

- n/a