### PR TITLE
Point to deploy doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 You can build your own JupyterLite website in a couple of minutes, with custom
 extensions and packages.
 
-See the [documentation](https://jupyterlite.rtfd.io) for more details.
+See the
+[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html)
+for more details.
 
 ### Browser-based Interactive Computing
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ You can build your own JupyterLite website in a couple of minutes, with custom
 extensions and packages.
 
 See the
-[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html)
-for more details.
+[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html) for
+more details.
 
 ### Browser-based Interactive Computing
 

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -47,7 +47,9 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 You can build your own JupyterLite website in a couple of minutes, with custom
 extensions and packages.
 
-See the [documentation](https://jupyterlite.rtfd.io) for more details.
+See the
+[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html) for
+more details.
 
 ### Browser-based Interactive Computing
 


### PR DESCRIPTION

## References

Fix #706. This points to the deploy doc rather than pointing to itself.


