### PR TITLE
New gitlab minimal example

### DIFF
--- a/docs/howto/deployment/gitlab.md
+++ b/docs/howto/deployment/gitlab.md
@@ -23,7 +23,8 @@ pages:
     - main # the branch you want to publish
 ```
 
-```{hint}
+````{hint}
 ""When you're looking for a JupyterLite GitLab template, there is a [minimal example](https://gitlab.gwdg.de/crc1456/livedocs/jupyterlite-minimal-example) and a [more involved example](https://gitlab.com/benabel/jupyterlite-template).""```
 
 [gitlab pages template]: https://gitlab.com/benabel/jupyterlite-template
+````

--- a/docs/howto/deployment/gitlab.md
+++ b/docs/howto/deployment/gitlab.md
@@ -24,7 +24,6 @@ pages:
 ```
 
 ```{hint}
-See the [gitlab pages template] for a more involved example.
-```
+""When you're looking for a JupyterLite GitLab template, there is a [minimal example](https://gitlab.gwdg.de/crc1456/livedocs/jupyterlite-minimal-example) and a [more involved example](https://gitlab.com/benabel/jupyterlite-template).""```
 
 [gitlab pages template]: https://gitlab.com/benabel/jupyterlite-template


### PR DESCRIPTION
This pull requests will add a new minimal example workflow for using JupyterLite with GitLab.

Here is the GitLab repo:https://gitlab.gwdg.de/crc1456/livedocs/jupyterlite-minimal-example
and here is the corresponding page: https://crc1456.pages.gwdg.de/livedocs/jupyterlite-minimal-example

Note that the minimal example still contains some debugging files that I used in https://github.com/jupyterlite/jupyterlite/issues/816 . These files are:
* https://gitlab.gwdg.de/crc1456/livedocs/jupyterlite-minimal-example/-/blob/main/gitlab-demo/content/numpy_scipy_bug_notebook.ipynb + the two .py files
* The `lib` folder https://gitlab.gwdg.de/crc1456/livedocs/jupyterlite-minimal-example/-/tree/main/gitlab-demo/content/lib

and I will delete them soon.

## References

Closes https://github.com/jupyterlite/jupyterlite/issues/799.
