### PR TITLE
Condition all addon tasks for well-formedness 

### DIFF
--- a/py/jupyterlite/src/jupyterlite/addons/archive.py
+++ b/py/jupyterlite/src/jupyterlite/addons/archive.py
@@ -25,7 +25,7 @@ class ArchiveAddon(BaseAddon):
 
     def status(self, manager):
         tarball = manager.output_archive
-        yield dict(
+        yield self.task(
             name="archive",
             actions=[(self.log_archive, [tarball])],
         )
@@ -40,7 +40,7 @@ class ArchiveAddon(BaseAddon):
             p for p in output_dir.rglob("*") if not p.is_dir() and p not in [tarball]
         ]
 
-        yield dict(
+        yield self.task(
             name=f"archive:{tarball.name}",
             doc="generate a new app archive",
             file_dep=file_dep,

--- a/py/jupyterlite/src/jupyterlite/addons/base.py
+++ b/py/jupyterlite/src/jupyterlite/addons/base.py
@@ -44,6 +44,15 @@ class BaseAddon(LoggingConfigurable):
     def log(self):
         return self.manager.log
 
+    def task(self, **task):
+        """Ensure a ``doit`` task is well-formed.
+
+        - Task names may not include the ``=`` character
+          - arbitrarily replace with ``--``
+        """
+        task["name"] = task["name"].replace("=", "--")
+        return task
+
     def copy_one(self, src, dest):
         """copy one Path (a file or folder)"""
         if self.manager.no_sourcemaps and self.is_ignored_sourcemap(src.name):

--- a/py/jupyterlite/src/jupyterlite/addons/contents.py
+++ b/py/jupyterlite/src/jupyterlite/addons/contents.py
@@ -16,7 +16,7 @@ class ContentsAddon(BaseAddon):
 
     def status(self, manager):
         """yield some status information about the state of contents"""
-        yield dict(
+        yield self.task(
             name="contents",
             actions=[
                 lambda: self.log.debug(
@@ -38,7 +38,7 @@ class ContentsAddon(BaseAddon):
         for src_file, dest_file in contents:
             all_dest_files += [dest_file]
             rel = dest_file.relative_to(output_files_dir)
-            yield dict(
+            yield self.task(
                 name=f"copy:{rel}",
                 doc=f"copy {src_file} to {rel}",
                 file_dep=[src_file],
@@ -49,7 +49,7 @@ class ContentsAddon(BaseAddon):
             )
 
         if manager.source_date_epoch is not None:
-            yield dict(
+            yield self.task(
                 name="timestamp",
                 file_dep=all_dest_files,
                 actions=[
@@ -69,7 +69,7 @@ class ContentsAddon(BaseAddon):
             stem = output_file_dir.relative_to(self.output_files_dir)
             api_path = self.api_dir / stem / ALL_JSON
 
-            yield dict(
+            yield self.task(
                 name=f"contents:{stem}",
                 doc=f"create a Jupyter Contents API response for {stem}",
                 actions=[
@@ -84,7 +84,7 @@ class ContentsAddon(BaseAddon):
         """verify that all Contents API is valid (sorta)"""
         for all_json in self.api_dir.rglob(ALL_JSON):
             stem = all_json.relative_to(self.api_dir)
-            yield dict(
+            yield self.task(
                 name=f"validate:{stem}",
                 doc=f"(eventually) validate {stem} with the Jupyter Contents API",
                 file_dep=[all_json],

--- a/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
+++ b/py/jupyterlite/src/jupyterlite/addons/federated_extensions.py
@@ -87,7 +87,7 @@ class FederatedExtensionAddon(BaseAddon):
         ]
         targets = [dest / p.relative_to(pkg_path) for p in file_dep]
 
-        yield dict(
+        yield self.task(
             name=f"copy:ext:{stem}",
             file_dep=file_dep,
             targets=targets,
@@ -102,7 +102,7 @@ class FederatedExtensionAddon(BaseAddon):
             dest = self.ext_cache / name
             if init:
                 if not dest.exists():
-                    yield dict(
+                    yield self.task(
                         name=f"fetch:{name}",
                         actions=[(self.fetch_one, [path_or_url, dest])],
                         targets=[dest],
@@ -188,7 +188,7 @@ class FederatedExtensionAddon(BaseAddon):
                     zf.extractall(td, members)
                 self.copy_one(Path(td) / pkg_root_with_slash, dest)
 
-        yield dict(
+        yield self.task(
             name=f"extract:wheel:{stem}",
             file_dep=[wheel],
             targets=targets,
@@ -248,7 +248,7 @@ class FederatedExtensionAddon(BaseAddon):
                     zf.extractall(td, _filter_members(zf.getmembers()))
                 self.copy_one(Path(td) / pkg_root_with_slash, dest)
 
-        yield dict(
+        yield self.task(
             name=f"extract:conda:{stem}",
             file_dep=[conda_pkg],
             targets=targets,
@@ -268,7 +268,7 @@ class FederatedExtensionAddon(BaseAddon):
         lab_extensions_root = manager.output_dir / LAB_EXTENSIONS
         lab_extensions = self.env_extensions(lab_extensions_root)
 
-        yield dict(
+        yield self.task(
             name="patch",
             doc=f"ensure {JUPYTERLITE_JSON} includes the federated_extensions",
             file_dep=[*lab_extensions, jupyterlite_json],
@@ -294,7 +294,7 @@ class FederatedExtensionAddon(BaseAddon):
             )
             dest = app_themes / stem
             targets = [dest / p.relative_to(theme_dir) for p in file_dep]
-            yield dict(
+            yield self.task(
                 name=f"copy:theme:{stem}",
                 doc=f"copy theme asset for {pkg}",
                 file_dep=file_dep,

--- a/py/jupyterlite/src/jupyterlite/addons/lite.py
+++ b/py/jupyterlite/src/jupyterlite/addons/lite.py
@@ -16,7 +16,7 @@ class LiteAddon(BaseAddon):
     __all__ = ["build", "check", "status"]
 
     def status(self, manager):
-        yield dict(
+        yield self.task(
             name=JUPYTERLITE_JSON,
             actions=[
                 lambda: self.log.debug(
@@ -36,7 +36,7 @@ class LiteAddon(BaseAddon):
         for jupyterlite_file in self.lite_files:
             rel = jupyterlite_file.relative_to(lite_dir)
             dest = output_dir / rel
-            yield dict(
+            yield self.task(
                 name=f"patch:{rel}",
                 file_dep=[jupyterlite_file],
                 actions=[
@@ -65,7 +65,7 @@ class LiteAddon(BaseAddon):
                 if lite_file.name == JUPYTERLITE_JSON
                 else ["metadata", JUPYTERLITE_METADATA]
             )
-            yield dict(
+            yield self.task(
                 name=f"validate:{stem}",
                 file_dep=[schema, lite_file],
                 actions=[

--- a/py/jupyterlite/src/jupyterlite/addons/mathjax.py
+++ b/py/jupyterlite/src/jupyterlite/addons/mathjax.py
@@ -52,7 +52,7 @@ class MathjaxAddon(BaseAddon):
 
     def status(self, manager):
         """Report MathJax status"""
-        yield dict(
+        yield self.task(
             name="status",
             doc="Get information about offline MathJax",
             actions=[self.log_status],
@@ -63,7 +63,7 @@ class MathjaxAddon(BaseAddon):
         if not self.mathjax_path:
             return
 
-        yield dict(
+        yield self.task(
             name="copy",
             doc="copy MathJax into the output dir",
             file_dep=[self.mathjax_path / MATHJAX_JS],
@@ -79,7 +79,7 @@ class MathjaxAddon(BaseAddon):
 
         jupyterlite_json = manager.output_dir / JUPYTERLITE_JSON
 
-        yield dict(
+        yield self.task(
             name="patch",
             doc=f"ensure {JUPYTERLITE_JSON} includes the mathjax url",
             file_dep=[jupyterlite_json],
@@ -90,7 +90,7 @@ class MathjaxAddon(BaseAddon):
         """Check if the MathJax paths are consistent"""
         jupyterlite_json = manager.output_dir / JUPYTERLITE_JSON
 
-        yield dict(
+        yield self.task(
             name="config",
             file_dep=[jupyterlite_json],
             actions=[(self.check_config_paths, [jupyterlite_json])],

--- a/py/jupyterlite/src/jupyterlite/addons/mimetypes.py
+++ b/py/jupyterlite/src/jupyterlite/addons/mimetypes.py
@@ -20,7 +20,7 @@ class MimetypesAddon(BaseAddon):
 
     def status(self, manager):
         """Yield status about file types."""
-        yield dict(
+        yield self.task(
             name=JUPYTERLITE_JSON,
             actions=[
                 lambda: print(f"""    filetypes:         {len(self.file_types)} """),
@@ -39,7 +39,7 @@ class MimetypesAddon(BaseAddon):
         """Yield ``doit`` tasks to update with file type config."""
         jupyterlite_json = manager.output_dir / JUPYTERLITE_JSON
 
-        yield dict(
+        yield self.task(
             name="patch",
             uptodate=[
                 doit.tools.config_changed(

--- a/py/jupyterlite/src/jupyterlite/addons/piplite.py
+++ b/py/jupyterlite/src/jupyterlite/addons/piplite.py
@@ -76,7 +76,7 @@ class PipliteAddon(BaseAddon):
         for wheel in wheels:
             whl_meta = self.wheel_cache / f"{wheel.name}.meta.json"
             whl_metas += [whl_meta]
-            yield dict(
+            yield self.task(
                 name=f"meta:{whl_meta.name}",
                 doc=f"ensure {wheel} metadata",
                 file_dep=[wheel],
@@ -90,7 +90,7 @@ class PipliteAddon(BaseAddon):
         if whl_metas:
             whl_index = self.manager.output_dir / PYPI_WHEELS / ALL_JSON
 
-            yield dict(
+            yield self.task(
                 name="patch",
                 doc=f"ensure {JUPYTERLITE_JSON} includes any piplite wheels",
                 file_dep=[*whl_metas, jupyterlite_json],
@@ -127,7 +127,7 @@ class PipliteAddon(BaseAddon):
             if not path.exists():
                 continue
 
-            yield dict(
+            yield self.task(
                 name=f"validate:{wheel_index_url}",
                 doc=f"validate {wheel_index_url} with the piplite API schema",
                 file_dep=[path],
@@ -150,7 +150,7 @@ class PipliteAddon(BaseAddon):
             dest = self.wheel_cache / name
             local_path = dest
             if not dest.exists():
-                yield dict(
+                yield self.task(
                     name=f"fetch:{name}",
                     doc=f"fetch the wheel {name}",
                     actions=[(self.fetch_one, [path_or_url, dest])],
@@ -177,7 +177,7 @@ class PipliteAddon(BaseAddon):
         dest = self.output_wheels / wheel.name
         if dest == wheel:  # pragma: no cover
             return
-        yield dict(
+        yield self.task(
             name=f"copy:whl:{wheel.name}",
             file_dep=[wheel],
             targets=[dest],

--- a/py/jupyterlite/src/jupyterlite/addons/pyodide.py
+++ b/py/jupyterlite/src/jupyterlite/addons/pyodide.py
@@ -48,7 +48,7 @@ class PyodideAddon(BaseAddon):
 
     def status(self, manager):
         """report on the status of pyodide"""
-        yield dict(
+        yield self.task(
             name="pyodide",
             actions=[
                 lambda: print(
@@ -91,7 +91,7 @@ class PyodideAddon(BaseAddon):
             if not (p.is_dir() or self.is_ignored_sourcemap(p.name))
         ]
 
-        yield dict(
+        yield self.task(
             name="copy:pyodide",
             file_dep=file_dep,
             targets=[
@@ -109,7 +109,7 @@ class PyodideAddon(BaseAddon):
 
         output_js = self.output_pyodide / PYODIDE_JS
 
-        yield dict(
+        yield self.task(
             name=f"patch:{JUPYTERLITE_JSON}",
             doc=f"ensure {JUPYTERLITE_JSON} includes any piplite wheels",
             file_dep=[output_js],
@@ -125,7 +125,7 @@ class PyodideAddon(BaseAddon):
         """ensure the pyodide configuration is sound"""
         jupyterlite_json = manager.output_dir / JUPYTERLITE_JSON
 
-        yield dict(
+        yield self.task(
             name="config",
             file_dep=[jupyterlite_json],
             actions=[(self.check_config_paths, [jupyterlite_json])],
@@ -172,7 +172,7 @@ class PyodideAddon(BaseAddon):
             dest = self.pyodide_cache / name
             local_path = dest
             if not dest.exists():
-                yield dict(
+                yield self.task(
                     name=f"fetch:{name}",
                     doc=f"fetch the pyodide distribution {name}",
                     actions=[(self.fetch_one, [path_or_url, dest])],
@@ -186,7 +186,7 @@ class PyodideAddon(BaseAddon):
 
         if local_path.is_dir():
             all_paths = sorted([p for p in local_path.rglob("*") if not p.is_dir()])
-            yield dict(
+            yield self.task(
                 name=f"copy:pyodide:{local_path.name}",
                 file_dep=[*all_paths],
                 targets=[dest / p.relative_to(local_path) for p in all_paths],
@@ -212,7 +212,7 @@ class PyodideAddon(BaseAddon):
                     zf.extractall(td)
                 self.copy_one(Path(td), dest)
 
-        task = dict(
+        yield self.task(
             name="extract:pyodide",
             file_dep=[local_path],
             uptodate=[
@@ -227,5 +227,3 @@ class PyodideAddon(BaseAddon):
             ],
             actions=[_extract],
         )
-
-        yield task

--- a/py/jupyterlite/src/jupyterlite/addons/report.py
+++ b/py/jupyterlite/src/jupyterlite/addons/report.py
@@ -29,7 +29,7 @@ class ReportAddon(BaseAddon):
 
         all_output_files = self.all_output_files
 
-        yield dict(
+        yield self.task(
             name=SHA256SUMS,
             doc="hash all of the files",
             actions=[

--- a/py/jupyterlite/src/jupyterlite/addons/serve.py
+++ b/py/jupyterlite/src/jupyterlite/addons/serve.py
@@ -29,7 +29,7 @@ class ServeAddon(BaseAddon):
             return False
 
     def status(self, manager):
-        yield dict(name="contents", actions=[self._print_status])
+        yield self.task(name="contents", actions=[self._print_status])
 
     def _print_status(self):
         print(
@@ -55,7 +55,7 @@ class ServeAddon(BaseAddon):
             name = "stdlib"
             actions = [doit.tools.PythonInteractiveAction(self._serve_stdlib)]
 
-        yield dict(
+        yield self.task(
             name=name,
             doc=f"run server at {self.url} for {manager.output_dir}",
             uptodate=[lambda: False],

--- a/py/jupyterlite/src/jupyterlite/addons/settings.py
+++ b/py/jupyterlite/src/jupyterlite/addons/settings.py
@@ -29,7 +29,7 @@ class SettingsAddon(BaseAddon):
                 continue
             apps.append(overrides_json)
 
-        yield dict(
+        yield self.task(
             name="overrides",
             actions=[lambda: print(f"""    {OVERRIDES_JSON}: {len(apps)}""")],
         )
@@ -42,7 +42,7 @@ class SettingsAddon(BaseAddon):
             if not overrides_json.exists():
                 continue
             dest = app_output_dir / overrides_json.name
-            yield dict(
+            yield self.task(
                 name=f"""copy:{app or "root"}/""",
                 file_dep=[overrides_json],
                 targets=[dest],
@@ -58,7 +58,7 @@ class SettingsAddon(BaseAddon):
             if not overrides_json.exists():
                 continue
 
-            yield dict(
+            yield self.task(
                 name=f"patch:overrides:{app}",
                 file_dep=[overrides_json, jupyterlite_json],
                 actions=[
@@ -98,7 +98,7 @@ class SettingsAddon(BaseAddon):
 
             validator = self.get_validator(schema)
 
-            yield dict(
+            yield self.task(
                 name=f"overrides:{plugin_id}",
                 file_dep=[lite_file, schema],
                 actions=[(self.validate_one_json_file, [validator, None, defaults])],

--- a/py/jupyterlite/src/jupyterlite/addons/static.py
+++ b/py/jupyterlite/src/jupyterlite/addons/static.py
@@ -28,7 +28,7 @@ class StaticAddon(BaseAddon):
     __all__ = ["pre_init", "init", "post_init", "pre_status"]
 
     def pre_status(self, manager):
-        yield dict(
+        yield self.task(
             name=JUPYTERLITE_JSON,
             actions=[
                 lambda: print(
@@ -57,7 +57,7 @@ class StaticAddon(BaseAddon):
         """
         output_dir = manager.output_dir
 
-        yield dict(
+        yield self.task(
             name="output_dir",
             doc="clean out the lite directory",
             file_dep=[self.app_archive],
@@ -78,7 +78,7 @@ class StaticAddon(BaseAddon):
 
     def init(self, manager):
         """unpack and copy the tarball files into the output_dir"""
-        yield dict(
+        yield self.task(
             name="unpack",
             doc=f"unpack a 'gold master' JupyterLite from {self.app_archive.name}",
             actions=[(self._unpack_stdlib, [])],
@@ -109,7 +109,7 @@ class StaticAddon(BaseAddon):
             app_prune_task_dep = [
                 f"{self.manager.task_prefix}post_init:static:{shared_prune_name}"
             ]
-            yield dict(
+            yield self.task(
                 name=shared_prune_name,
                 actions=[
                     (self.prune_unused_shared_packages, [all_apps, apps_to_remove])
@@ -119,7 +119,7 @@ class StaticAddon(BaseAddon):
         for to_remove in apps_to_remove:
             app = output_dir / to_remove
             app_build = output_dir / "build" / to_remove
-            yield dict(
+            yield self.task(
                 task_dep=app_prune_task_dep,
                 name=f"prune:{app}",
                 actions=[(self.delete_one, [app, app_build])],

--- a/py/jupyterlite/src/jupyterlite/addons/translation.py
+++ b/py/jupyterlite/src/jupyterlite/addons/translation.py
@@ -15,7 +15,7 @@ class TranslationAddon(BaseAddon):
 
     def status(self, manager):
         """yield some status information about the state of the translation"""
-        yield dict(
+        yield self.task(
             name="translation",
             actions=[
                 lambda: self.log.debug(
@@ -35,7 +35,7 @@ class TranslationAddon(BaseAddon):
         targets = [api_path]
         targets += [self.get_language_pack_file(locale) for locale in packs.keys()]
 
-        yield dict(
+        yield self.task(
             name="copy",
             doc="create the translation data",
             uptodate=[doit.tools.config_changed(dict(metadata=metadata, packs=packs))],
@@ -51,7 +51,7 @@ class TranslationAddon(BaseAddon):
         """Check the translation data is valid"""
         for all_json in self.api_dir.rglob(ALL_JSON):
             stem = all_json.relative_to(self.api_dir)
-            yield dict(
+            yield self.task(
                 name=f"validate:translation:{stem}",
                 doc=f"Validate {stem} with the JupyterLab Translation API",
                 file_dep=[all_json],

--- a/py/jupyterlite/src/jupyterlite/tests/test_cli.py
+++ b/py/jupyterlite/src/jupyterlite/tests/test_cli.py
@@ -128,8 +128,8 @@ def test_cli_any_hook(lite_hook, an_empty_lite_dir, script_runner, a_simple_lite
         # some caching doesn't seep to work reliably
         assert duration_1 > duration_2
 
-    # force, detect a root file
-    readme = an_empty_lite_dir / "README.md"
+    # force, detect a root file with ``=`` in the name
+    readme = an_empty_lite_dir / "== README ==.md"
     readme.write_text("# hello world", encoding="utf-8")
 
     # ... and a nested folder
@@ -167,7 +167,7 @@ def test_cli_any_hook(lite_hook, an_empty_lite_dir, script_runner, a_simple_lite
         out = an_empty_lite_dir / "_output"
 
         # did the files make it...
-        expected_readme = out / "files/README.md"
+        expected_readme = out / "files/== README ==.md"
         assert expected_readme.exists()
         assert "world" in expected_readme.read_text(encoding="utf-8")
         expected_details = out / "files/details/README.md"


### PR DESCRIPTION
## References

- fixes #820

## Code changes

- normalize all addon-generated task names to not include `=` (replace with `--`)
  - this is due to:
    - > = is used to pass global variables through the command line.
      > https://github.com/pydoit/doit/issues/117
- leaves options open for future fixes

## User-facing changes

- files with `=` in the name (such as `contents` or `archive` or `federated_extensions`, etc) will not fail

## Backwards-incompatible changes

- n/a