### PR TITLE
do not signal `ready` until initialize completes

### DIFF
--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -63,6 +63,7 @@ export class Kernels implements IKernels {
 
       const processMsg = async (msg: KernelMessage.IMessage) => {
         await mutex.runExclusive(async () => {
+          await kernel.ready;
           await kernel.handleMessage(msg);
         });
       };
@@ -143,8 +144,6 @@ export class Kernels implements IKernels {
       name,
       location,
     });
-
-    await kernel.ready;
 
     this._kernels.set(kernelId, kernel);
     this._kernelClients.set(kernelId, new Set<string>());

--- a/packages/pyolite-kernel/src/kernel.ts
+++ b/packages/pyolite-kernel/src/kernel.ts
@@ -25,7 +25,6 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
     this._worker = this.initWorker(options);
     this._worker.onmessage = (e) => this._processWorkerMessage(e.data);
     this._remoteKernel = this.initRemote(options);
-    this._ready.resolve();
   }
 
   /**
@@ -45,7 +44,9 @@ export class PyoliteKernel extends BaseKernel implements IKernel {
   protected initRemote(options: PyoliteKernel.IOptions): IRemotePyoliteWorkerKernel {
     const remote: IRemotePyoliteWorkerKernel = wrap(this._worker);
     const remoteOptions = this.initRemoteOptions(options);
-    remote.initialize(remoteOptions);
+    remote.initialize(remoteOptions).then(() => {
+      this._ready.resolve();
+    });
     return remote;
   }
 


### PR DESCRIPTION
## References

Addresses issue: https://github.com/jupyterlite/jupyterlite/issues/897

## Code changes

Previously the `_ready` promise for the kernel was immediately resolved without awaiting the initialization promise to resolve, now the `_ready` promise resolved after initialization completes.

The effect of this on a frontend like thebe, is that the UI can better signal when the kernel is actually ready -- aligning with behaviour seen with normal jupyter server connections.

## User-facing changes

In jupyterlite apps and thebe, like kernel ready indicator appears later, and shows a status `initializing...` during the package load. Which is the expected user facing change 👍

## Backwards-incompatible changes

none expected
