### PR TITLE
Update the p5 kernel on the demo site

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -900,7 +900,7 @@ class C:
     LITE_GH_ORG = f"{GH}/{NAME}"
     P5_GH_REPO = f"{LITE_GH_ORG}/p5-kernel"
     P5_MOD = "jupyterlite_p5_kernel"
-    P5_VERSION = "0.1.0a12"
+    P5_VERSION = "0.1.0"
     P5_RELEASE = f"{P5_GH_REPO}/releases/download/v{P5_VERSION}"
     P5_WHL_URL = f"{P5_RELEASE}/{P5_MOD}-{P5_VERSION}-{NOARCH_WHL}"
     PYTHON_HOSTED = "https://files.pythonhosted.org/packages"

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -21,7 +21,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.3.2-pyhd8ed1ab_0.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.5-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
-      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0a12/jupyterlite_p5_kernel-0.1.0a12-py3-none-any.whl"
+      "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl"
     ],
     "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "output_dir": "../build/docs-app"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #711 

The p5 kernel was updated to run in an IFrame so it has direct access to `window` and `document`: https://github.com/jupyterlite/p5-kernel/pull/11


## Code changes

Update the p5 kernel on the demo site.

## User-facing changes

The p5 kernel should work on the demo site.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None


<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
