### PR TITLE
Update `jupyterlite` dependencies and docs

### DIFF
--- a/.github/actions/build-dist/action.yml
+++ b/.github/actions/build-dist/action.yml
@@ -20,7 +20,6 @@ runs:
 
     - name: Install
       shell: bash
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: doit setup:js
 
     - name: Build (js)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,8 +198,6 @@ jobs:
         run: doit docs:sphinx
       - name: Check Built Artifacts
         run: doit check
-      - name: Test (py)
-        run: doit test:py:jupyterlite-core
       - name: Upload (reports)
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,8 +149,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Install (py)
         run: |
-          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
-          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite
+          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core 'jupyterlite-pyodide-kernel >=0.0.4'
+          ${{ matrix.python-command }} -m pip install --find-links --no-index dist jupyterlite
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,9 +149,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Install (py)
         run: |
-          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core pkginfo
-          ${{ matrix.python-command }} -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
-          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
+          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
+          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite_core --no-index
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,8 +198,6 @@ jobs:
             ${{ env.CACHE_EPOCH }}-docs-app-
       - name: Setup pip (docs)
         run: python3 -m pip install -r requirements-docs.txt
-      - name: Install
-        run: doit setup:js
       - name: Install (py)
         run: doit dev:py:jupyterlite-core
       - name: Docs (app)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,44 +169,9 @@ jobs:
         with:
           name: jupyterlite typedoc ${{ github.run_number }}
           path: ./docs/reference/api/ts
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-      - name: Cache (node_modules)
-        uses: actions/cache@v3
-        id: cache-node-modules
-        with:
-          path: node_modules/
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache (.yarn-packages)
-        uses: actions/cache@v3
-        id: cache-yarn-packages
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        with:
-          path: .yarn-packages
-          key: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
-      - name: Setup pip (base)
-        run: python3 -m pip install --user -U pip setuptools wheel
-      - name: Cache (pip)
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-docs-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-docs-
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Cache (docs extensions)
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install
         run: doit setup:js
       - name: Install (py)
-        run: doit dev:py:jupyterlite
+        run: doit dev:py:jupyterlite-core
       - name: Docs (app)
         run: doit docs:app:build
       - name: Docs (app archive)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,45 +36,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Setup pip (base)
-        run: python3 -m pip install --user -U pip setuptools wheel
-      - name: Cache (pip)
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-lint-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-lint-
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Setup pip (lint)
         run: python3 -m pip install -r requirements-lint.txt
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-      - name: Cache (node_modules)
-        uses: actions/cache@v3
-        id: cache-node-modules
-        with:
-          path: node_modules/
-          key: |
-            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
-      - name: Cache (.yarn-packages)
-        uses: actions/cache@v3
-        id: cache-yarn-packages
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        with:
-          path: .yarn-packages
-          key: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ env.CACHE_EPOCH }}-yarn-packages-
       - name: Install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: doit setup:js
       - name: Test (js)
         run: doit -n4 test:js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,8 @@ jobs:
         run: doit docs:sphinx
       - name: Check Built Artifacts
         run: doit check
+      - name: Test (py)
+        run: doit test:py:jupyterlite-core
       - name: Upload (reports)
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Install (py)
         run: |
-          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core 'jupyterlite-pyodide-kernel >=0.0.4'
+          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
+          ${{ matrix.python-command }} -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
           ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install
         run: doit setup:js
       - name: Install (py)
-        run: doit dev:py:jupyterlite-core
+        run: doit dev:py:jupyterlite-core:no-deps
       - name: Docs (app)
         run: doit docs:app:build
       - name: Docs (app archive)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Install
         run: doit setup:js
       - name: Install (py)
-        run: doit dev:py:jupyterlite-core
+        run: doit dev:py:jupyterlite
       - name: Docs (app)
         run: doit docs:app:build
       - name: Docs (app archive)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install (py)
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
-          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite_core --no-index
+          ${{ matrix.python-command }} -m pip install --find-links dist --no-index jupyterlite_core
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core pkginfo
           ${{ matrix.python-command }} -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
-          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index
+          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-docs-app-
       - name: Setup pip (docs)
-        run: python3 -m pip install -r requirements-docs.txt -r requirements-build.txt
+        run: python3 -m pip install -r requirements-docs.txt
       - name: Install
         run: doit setup:js
       - name: Install (py)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install (py)
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core 'jupyterlite-pyodide-kernel >=0.0.4'
-          ${{ matrix.python-command }} -m pip install --find-links --no-index --upgrade dist jupyterlite
+          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index --force-reinstall
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install (py)
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
-          ${{ matrix.python-command }} -m pip install --find-links dist --no-index jupyterlite
+          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install (py)
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core 'jupyterlite-pyodide-kernel >=0.0.4'
-          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index --force-reinstall
+          ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install
         run: doit setup:js
       - name: Install (py)
-        run: doit dev:py:jupyterlite-core:no-deps
+        run: doit dev:py:jupyterlite-core
       - name: Docs (app)
         run: doit docs:app:build
       - name: Docs (app archive)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,8 +170,6 @@ jobs:
           name: jupyterlite typedoc ${{ github.run_number }}
           path: ./docs/reference/api/ts
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Install
-        run: doit setup:js
       - name: Cache (docs extensions)
         uses: actions/cache@v3
         with:
@@ -182,6 +180,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-docs-app-
       - name: Setup pip (docs)
         run: python3 -m pip install -r requirements-docs.txt -r requirements-build.txt
+      - name: Install
+        run: doit setup:js
       - name: Install (py)
         run: doit dev:py:jupyterlite-core
       - name: Docs (app)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install (py)
         run: |
           ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core 'jupyterlite-pyodide-kernel >=0.0.4'
-          ${{ matrix.python-command }} -m pip install --find-links --no-index dist jupyterlite
+          ${{ matrix.python-command }} -m pip install --find-links --no-index --upgrade dist jupyterlite
           ${{ matrix.python-command }} -m pip check
       - name: Prepare smoke test folder
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_EPOCH }}-docs-app-
       - name: Setup pip (docs)
-        run: python3 -m pip install -r requirements-docs.txt
+        run: python3 -m pip install -r requirements-docs.txt -r requirements-build.txt
       - name: Install (py)
         run: doit dev:py:jupyterlite-core
       - name: Docs (app)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Cache (pip)
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-lint-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-lint-
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Setup pip (lint)
         run: python3 -m pip install -r requirements-lint.txt
       - name: Install
@@ -170,6 +179,15 @@ jobs:
           name: jupyterlite typedoc ${{ github.run_number }}
           path: ./docs/reference/api/ts
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Cache (pip)
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-docs-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-docs-
+            ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Cache (docs extensions)
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.7', '3.10', 'pypy-3.7']
+        python-version: ['3.8', '3.10', 'pypy-3.8']
         include:
           # OS-specifics for running pip
           - os: ubuntu
@@ -113,17 +113,17 @@ jobs:
             pip-cache: ~\AppData\Local\pip\Cache
             python-command: python
           # python-specifics for tests
-          - python-version: '3.7'
+          - python-version: '3.8'
             pytest-args: '[]'
           - python-version: '3.10'
             pytest-args: '[]'
-          - python-version: 'pypy-3.7'
+          - python-version: 'pypy-3.8'
             # TODO: some instability with libarchive, might be better with pypy-3.8
             # after https://github.com/cloudpipe/cloudpickle/pull/461
             pytest-args: '["-k", "not _archive_is_"]'
         exclude:
           - os: windows
-            python-version: pypy-3.7
+            python-version: pypy-3.8
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ runner.os }}-pip-
       - name: Install (py)
         run: |
-          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core
+          ${{ matrix.python-command }} -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core pkginfo
           ${{ matrix.python-command }} -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
           ${{ matrix.python-command }} -m pip install --find-links dist jupyterlite --no-index
           ${{ matrix.python-command }} -m pip check

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Install JupyterLite
         run: |
-          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2
-          python3 -m pip install --find-links dist jupyterlite jupyterlite_core
+          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 'jupyterlite-pyodide-kernel >=0.0.4'
+          python3 -m pip install --find-links dist --no-index jupyterlite jupyterlite_core
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install JupyterLite
         run: |
           python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 'jupyterlite-pyodide-kernel >=0.0.4'
-          python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index --force-reinstall
+          python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Install JupyterLite
         run: |
-          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 'jupyterlite-pyodide-kernel >=0.0.4'
+          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 
+          python3 -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
           python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
 
       - name: Build JupyterLite

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install JupyterLite
         run: |
           python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2
-          python3 -m pip install --find-links dist --no-index jupyterlite jupyterlite_core
+          python3 -m pip install --find-links dist jupyterlite jupyterlite_core
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install JupyterLite
         run: |
           python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 'jupyterlite-pyodide-kernel >=0.0.4'
-          python3 -m pip install --find-links dist --no-index jupyterlite jupyterlite_core
+          python3 -m pip install --find-links dist --no-index --upgrade jupyterlite jupyterlite_core
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install JupyterLite
         run: |
           python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 'jupyterlite-pyodide-kernel >=0.0.4'
-          python3 -m pip install --find-links dist --no-index --upgrade jupyterlite jupyterlite_core
+          python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index --force-reinstall
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install JupyterLite
         run: |
           python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2
-          python3 -m pip install --find-links dist jupyterlite_core --no-index
+          python3 -m pip install --find-links dist --no-index jupyterlite_core
 
       - name: Build JupyterLite
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install JupyterLite
         run: |
-          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 
+          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 pkginfo
           python3 -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
           python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,9 +16,8 @@ jobs:
 
       - name: Install JupyterLite
         run: |
-          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2 pkginfo
-          python3 -m pip install --no-deps 'jupyterlite-pyodide-kernel >=0.0.4'
-          python3 -m pip install --find-links dist jupyterlite jupyterlite_core --no-index
+          python3 -m pip install importlib_metadata 'doit >=0.34,<1' jupyter_core jupyterlab~=3.2
+          python3 -m pip install --find-links dist jupyterlite_core --no-index
 
       - name: Build JupyterLite
         run: |

--- a/docs/howto/configure/advanced/extensions.md
+++ b/docs/howto/configure/advanced/extensions.md
@@ -33,18 +33,15 @@ site from an environment with already installed extensions.
 All third-party extensions, and some provided by JupyterLite and JupyterLab, can be
 disabled for one or all apps deployed in a site with the `disabledExtensions` option.
 
-For example, a site that doesn't use the Pyodide-based kernel can disable the
-[`ServiceWorker`](./service-worker.md) and the [Pyodide](../../python/pyodide.md) kernel
-with the following `jupyter-lite.json`:
+For example, a site that doesn't need the content to be available from the Python kernel
+can disable the [`ServiceWorker`](./service-worker.md) plugin with the following
+`jupyter-lite.json`:
 
 ```json
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
-    "disabledExtensions": [
-      "@jupyterlite/pyodide-kernel-extension:kernel",
-      "@jupyterlite/server-extension:service-worker"
-    ]
+    "disabledExtensions": ["@jupyterlite/server-extension:service-worker"]
   }
 }
 ```
@@ -82,7 +79,7 @@ If detected, [`libarchive-c`](https://pypi.org/project/libarchive-c) will be use
 better performance, especially when working with archives with many/large assets,
 espcially [pyodide](../../python/pyodide.md).
 
-If not `libarchive-c` is not detected, python's built-in `zipfile` and `tarfile` modules
+If `libarchive-c` is not detected, Python's built-in `zipfile` and `tarfile` modules
 will be used.
 
 ```{warning}

--- a/docs/howto/configure/advanced/iframe.md
+++ b/docs/howto/configure/advanced/iframe.md
@@ -150,10 +150,10 @@ loaded in the environment:
 jupyter labextension list
 ```
 
-Now, create the JupyterLite extension. Install jupyterlite:
+Now, create the JupyterLite extension. Install the JupyterLite CLI:
 
 ```bash
-pip install jupyterlite
+pip install jupyterlite-core
 ```
 
 Move to a directory where the extension should be tested and run the build of this

--- a/docs/howto/configure/advanced/offline.md
+++ b/docs/howto/configure/advanced/offline.md
@@ -28,7 +28,8 @@ and JS APIs are still changing frequently on both sides of the dependency.
 By default Mathjax is fetched from a CDN.
 
 To retrieve the static asssets at built time and serve them alongside the main website
-assets, make sure to install `jupyterlite` with `pip install jupyterlite[mathjax]`.
+assets, make sure to install `jupyterlite-core` with
+`pip install jupyterlite-core[mathjax]`.
 
 ## Configure the piplite wheels
 

--- a/docs/howto/configure/advanced/service-worker.md
+++ b/docs/howto/configure/advanced/service-worker.md
@@ -16,7 +16,7 @@ A `ServiceWorker` will only be created and used if all of the following are true
 
 - the extension has not been [disabled](extensions.md#disabling-extensions-at-runtime)
 - the user's current browser session supports the `ServiceWorker` API
-  - see [supported browsers][caniuse-sw]
+  - see [supported browsers][sw]
   - _Private Browsing_ in Firefox is [**known** to not work][ff-private-bug]
 - the HTTP server's URL starts with one of:
   - `https://`

--- a/docs/howto/configure/simple_extensions.md
+++ b/docs/howto/configure/simple_extensions.md
@@ -13,7 +13,7 @@ also work with JupyterLite.
 
 ### Creating a new environment
 
-The easiest way to add new extensions is to use the `jupyterlite` CLI in a Python
+The easiest way to add new extensions is to use the `jupyterlite-core` CLI in a Python
 environment where extensions have already been installed.
 
 You can choose the tool of your choice to manage these dependencies, such as `pip`,

--- a/docs/howto/configure/simple_extensions.md
+++ b/docs/howto/configure/simple_extensions.md
@@ -13,7 +13,7 @@ also work with JupyterLite.
 
 ### Creating a new environment
 
-The easiest way to add new extensions is to use the JupyterLite CLI in a Python
+The easiest way to add new extensions is to use the `jupyterlite-core` CLI in a Python
 environment where extensions have already been installed.
 
 You can choose the tool of your choice to manage these dependencies, such as `pip`,

--- a/docs/howto/configure/simple_extensions.md
+++ b/docs/howto/configure/simple_extensions.md
@@ -13,7 +13,7 @@ also work with JupyterLite.
 
 ### Creating a new environment
 
-The easiest way to add new extensions is to use the `jupyterlite-core` CLI in a Python
+The easiest way to add new extensions is to use the JupyterLite CLI in a Python
 environment where extensions have already been installed.
 
 You can choose the tool of your choice to manage these dependencies, such as `pip`,

--- a/docs/howto/deployment/gitlab.md
+++ b/docs/howto/deployment/gitlab.md
@@ -13,7 +13,7 @@ image: python
 pages:
   stage: deploy
   before_script:
-    - python -m pip install jupyterlite
+    - python -m pip install jupyterlite-core jupyterlite-pyodide-kernel
   script:
     - jupyter lite build --contents content --output-dir public
   artifacts:

--- a/docs/howto/deployment/vercel-netlify.md
+++ b/docs/howto/deployment/vercel-netlify.md
@@ -49,7 +49,8 @@ dependencies if needed:
 
 ```text
 jupyterlab~=3.4
-jupyterlite
+jupyterlite-core
+jupyterlite-pyodide-kernel
 ```
 
 Then create a new `deploy.sh` file with the following content:

--- a/docs/howto/extensions/frontend.md
+++ b/docs/howto/extensions/frontend.md
@@ -82,7 +82,7 @@ If you iterate and make new changes to the extension:
   https://user-images.githubusercontent.com/591645/171583522-f5677259-b91a-4ab0-8812-9770807a088e.gif
 
 ```{note}
-The `jupyterlite-core` package does not install any kernel by default.
+By default the `jupyterlite-core` package only includes a JavaScript kernel running in a Web Worker.
 If you would like to have a Python kernel available in your test JupyterLite deployment, you can install the `jupyterlite-pyodide-kernel` package with `pip`, or add it to your list of dependencies.
 ```
 

--- a/docs/howto/extensions/frontend.md
+++ b/docs/howto/extensions/frontend.md
@@ -51,9 +51,10 @@ JupyterLab.
 By default JupyterLite is able to find JupyterLab extensions installed in the same
 environment under `PREFIX/share/labextensions`.
 
-The `jupyterlite` CLI does this automatically by default. In your local environment:
+The `jupyterlite-core` CLI does this automatically by default. In your local
+environment:
 
-1. Install the `jupyterlite` CLI with: `pip install jupyterlite`
+1. Install the `jupyter lite` CLI with: `pip install jupyterlite-core`
 2. Build the website: `jupyter lite build`. In the build logs you should see something
    like the following that indicates the extension was correctly found and copied:
 
@@ -79,6 +80,11 @@ If you iterate and make new changes to the extension:
 
 [apod-tutorial]:
   https://user-images.githubusercontent.com/591645/171583522-f5677259-b91a-4ab0-8812-9770807a088e.gif
+
+```{note}
+The `jupyterlite-core` package does not install any kernel by default.
+If you would like to have a Python kernel available in your test JupyterLite deployment, you can install the `jupyterlite-pyodide-kernel` package with `pip`, or add it to your list of dependencies.
+```
 
 ## Publishing the extension
 

--- a/docs/howto/extensions/frontend.md
+++ b/docs/howto/extensions/frontend.md
@@ -82,7 +82,7 @@ If you iterate and make new changes to the extension:
   https://user-images.githubusercontent.com/591645/171583522-f5677259-b91a-4ab0-8812-9770807a088e.gif
 
 ```{note}
-By default the `jupyterlite-core` package only includes a JavaScript kernel running in a Web Worker.
+The `jupyterlite-core` package does not install any kernel by default.
 If you would like to have a Python kernel available in your test JupyterLite deployment, you can install the `jupyterlite-pyodide-kernel` package with `pip`, or add it to your list of dependencies.
 ```
 

--- a/docs/howto/extensions/server.md
+++ b/docs/howto/extensions/server.md
@@ -27,13 +27,13 @@ First create a new development environment with:
 
 ```bash
 # create the environment
-mamba create -n myliteextension -c conda-forge python nodejs jupyterlab jupyter-packaging cookiecutter -y
+mamba create -n myliteextension -c conda-forge python nodejs jupyterlab cookiecutter -y
 
 # activate the environment
 conda activate myliteextension
 
-# install the jupyterlite CLI tool
-python -m pip install jupyterlite
+# install the jupyterlite-core CLI tool
+python -m pip install jupyterlite-core
 ```
 
 ```{note}
@@ -118,7 +118,7 @@ python -m pip install myliteextension
 In most cases, this would mean adding the extension to a `requirements.txt` file:
 
 ```
-jupyterlite
+jupyterlite-core
 myliteextension
 ```
 

--- a/docs/quickstart/deploy.md
+++ b/docs/quickstart/deploy.md
@@ -62,7 +62,7 @@ See this [blog post](https://github.blog/2009-12-29-bypassing-jekyll-on-github-p
 
 ## Deploy a new version of JupyterLite
 
-To change the version of the prebuilt JupyterLite assets, update the `jupyterlite`
+To change the version of the prebuilt JupyterLite assets, update the `jupyterlite-core`
 package version in the `requirements.txt` file.
 
 Commit and push the changes. The site will be deployed on the next push to the `main`

--- a/docs/quickstart/standalone.md
+++ b/docs/quickstart/standalone.md
@@ -3,7 +3,7 @@
 Deploying a JupyterLite site requires:
 
 - a copy of the JupyterLite site assets
-  - often provided by the `pip`-installable python package `jupyterlite`
+  - often provided by the `pip`-installable python package `jupyterlite-core`
 - an option set of configurations for the site and different apps
   - different options offer trade-offs between reproducibility, build speed, deployment
     size, and end-user performance, privacy, and security
@@ -22,11 +22,11 @@ To get the [Python CLI](../reference/cli.ipynb) and [API](../reference/api/index
 from [PyPI]:
 
 ```bash
-python -m pip install --pre jupyterlite
+python -m pip install --pre jupyterlite-core
 ```
 
 ```{note}
-`jupyterlite` will soon be available on [conda forge]
+`jupyterlite-core` will soon be available on [conda forge]
 ```
 
 To build an empty site (just the JupyterLite static assets):
@@ -41,6 +41,16 @@ specific a different with `--output-dir` parameter. For instance:
 ```bash
 jupyter lite build --output-dir dist
 ```
+
+````{note}
+The `jupyterlite-core` package provides the **base** static assets and the CLI for building JupyterLite website.
+If you would like your deployment to also include a default Python kernel and other useful extensions by default, you
+can install the `jupyterlite` package:
+
+```bash
+python -m pip install --pre jupyterlite
+```
+````
 
 ## Standalone Servers
 

--- a/docs/reference/cli.ipynb
+++ b/docs/reference/cli.ipynb
@@ -114,7 +114,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install jupyterlite[all]"
+    "!pip install jupyterlite-core[all]"
    ]
   },
   {

--- a/docs/reference/cli.ipynb
+++ b/docs/reference/cli.ipynb
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install jupyterlite\n",
+    "!pip install jupyterlite-core\n",
     "!jupyter lite --version"
    ]
   },
@@ -88,17 +88,17 @@
     "Some extra features of different _addons_ have additional dependencies.\n",
     "\n",
     "```bash\n",
-    "pip install jupyterlite[contents] # jupyter_server for contents API indexing\n",
-    "pip install jupyterlite[serve]    # tornado for better local previewing with `serve`\n",
-    "pip install jupyterlite[mathjax]  # reuse the MathJax assets from jupyter-server-mathjax\n",
-    "pip install jupyterlite[check]    # validate more data with jsonschema\n",
-    "pip install jupyterlite[lab]      # a known-compatible jupyterlab (entails `contents`, `serve`, `check`)\n",
+    "pip install jupyterlite-core[contents] # jupyter_server for contents API indexing\n",
+    "pip install jupyterlite-core[serve]    # tornado for better local previewing with `serve`\n",
+    "pip install jupyterlite-core[mathjax]  # reuse the MathJax assets from jupyter-server-mathjax\n",
+    "pip install jupyterlite-core[check]    # validate more data with jsonschema\n",
+    "pip install jupyterlite-core[lab]      # a known-compatible jupyterlab (entails `contents`, `serve`, `check`)\n",
     "```\n",
     "\n",
     "...or, for everything:\n",
     "\n",
     "```bash\n",
-    "pip install jupyterlite[all]      # all of the above!\n",
+    "pip install jupyterlite-core[all]      # all of the above!\n",
     "```"
    ]
   },
@@ -115,6 +115,27 @@
    "outputs": [],
    "source": [
     "!pip install jupyterlite[all]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "528521f0",
+   "metadata": {},
+   "source": [
+    "### Installing a kernel\n",
+    "\n",
+    "The `jupyterlite-core` package provides the core functionality for building JupyterLite\n",
+    "websites and does not install any kernel by default.\n",
+    "\n",
+    "If you would like to include a kernel in your JupyterLite deployment you need to install\n",
+    "it before building the site.\n",
+    "\n",
+    "For example to also include the Python kernel based on Pyodide:\n",
+    "\n",
+    "```bash\n",
+    "pip install jupyterlite-pyodide-kernel\n",
+    "```"
    ]
   },
   {

--- a/dodo.py
+++ b/dodo.py
@@ -415,48 +415,15 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    args = []
-    if C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
-        args = [
-            *C.PYM,
-            "pip",
-            "install",
-            "-vv",
-            "--no-index",
-            "--find-links",
-            B.DIST,
-        ]
-        core_args = args + [C.CORE_NAME]
-        yield dict(
-            name="py:jupyterlite-core",
-            actions=[U.do(*core_args, cwd=P.ROOT)],
-            file_dep=[
-                B.DIST
-                / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
-            ],
-        )
-
-        meta_args = args + [C.NAME, "--no-deps"]
-        yield dict(
-            task_dep=["dev:py:jupyterlite-core"],
-            name="py:jupyterlite",
-            actions=[U.do(*meta_args, cwd=P.ROOT)],
-            file_dep=[
-                B.DIST / f"""{C.NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
-            ],
-        )
-    else:
-        for py_name in [C.NAME, C.CORE_NAME]:
-            py_name_pkg = py_name.replace("-", "_")
-            cwd = P.PY_SETUP_PY[py_name].parent
-            file_dep = [cwd / "src" / py_name_pkg / B.APP_PACK.name]
-            args = [*C.FLIT, "install", "--pth-file", "--deps=none"]
-
-        yield dict(
-            name=f"py:{py_name}",
-            actions=[U.do(*args, cwd=cwd)],
-            file_dep=file_dep,
-        )
+    args = [*C.PYM, "pip", "install", "-r", "requirements-editable.txt"]
+    yield dict(
+        name="py:jupyterlite-core",
+        actions=[U.do(*args, cwd=P.ROOT)],
+        file_dep=[
+            B.DIST
+            / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
+        ],
+    )
 
 
 def task_docs():

--- a/dodo.py
+++ b/dodo.py
@@ -418,6 +418,7 @@ def task_dev():
     core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
     yield dict(
         name="py:jupyterlite-core",
+        task_dep=[f"build:py:{C.CORE_NAME}:pre:app"],
         actions=[U.do(*core_args, cwd=P.ROOT)],
     )
 

--- a/dodo.py
+++ b/dodo.py
@@ -422,7 +422,7 @@ def task_dev():
             "pip",
             "install",
             "-vv",
-            # "--no-index",
+            "--no-index",
             "--find-links",
             B.DIST,
         ]

--- a/dodo.py
+++ b/dodo.py
@@ -416,6 +416,7 @@ def task_dist():
 def task_dev():
     """setup up local packages for interactive development"""
     if C.DOCS_IN_CI or C.TESTING_IN_CI:
+        py_name = C.CORE_NAME.replace("-", "_")
         args = [
             *C.PYM,
             "pip",
@@ -424,13 +425,13 @@ def task_dev():
             "--no-index",
             "--find-links",
             B.DIST,
-            C.CORE_NAME.replace("-", "_"),
+            py_name,
         ]
 
         yield dict(
             name="py:jupyterlite-core",
             actions=[U.do(*args, cwd=P.ROOT)],
-            file_dep=[B.DIST / f"""{C.CORE_NAME}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
+            file_dep=[B.DIST / f"""{py_name}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
         )
     else:
         core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]

--- a/dodo.py
+++ b/dodo.py
@@ -427,7 +427,7 @@ def task_dev():
             B.DIST,
         ]
         file_dep = []
-        for py_name in [C.CORE_NAME, C.NAME]:
+        for py_name in [C.NAME, C.CORE_NAME]:
             py_name_pkg = py_name.replace("-", "_")
             file_dep += [B.DIST / f"""{py_name_pkg}-{D.PY_VERSION}-{C.NOARCH_WHL}"""]
             args += [py_name]
@@ -1390,7 +1390,6 @@ class U:
 
             args += C.LITE_ARGS
 
-            print(args)
             subprocess.check_call(list(map(str, args)), cwd=str(P.EXAMPLES))
 
     def hashfile(path):

--- a/dodo.py
+++ b/dodo.py
@@ -415,7 +415,7 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    if C.DOCS_IN_CI:
+    if C.DOCS_IN_CI or C.TESTING_IN_CI:
         args = [
             *C.PYM,
             "pip",

--- a/dodo.py
+++ b/dodo.py
@@ -422,7 +422,7 @@ def task_dev():
             "pip",
             "install",
             "-vv",
-            "--no-index",
+            # "--no-index",
             "--find-links",
             B.DIST,
         ]

--- a/dodo.py
+++ b/dodo.py
@@ -427,7 +427,8 @@ def task_dev():
             B.DIST,
         ]
         file_dep = []
-        for py_name in [C.NAME, C.CORE_NAME]:
+        # for py_name in [C.NAME, C.CORE_NAME]:
+        for py_name in [C.CORE_NAME]:
             py_name_pkg = py_name.replace("-", "_")
             file_dep += [B.DIST / f"""{py_name_pkg}-{D.PY_VERSION}-{C.NOARCH_WHL}"""]
             args += [py_name]

--- a/dodo.py
+++ b/dodo.py
@@ -416,7 +416,7 @@ def task_dist():
 def task_dev():
     """setup up local packages for interactive development"""
     args = []
-    if C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
+    if True or C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
         args = [
             *C.PYM,
             "pip",
@@ -426,16 +426,19 @@ def task_dev():
             "--find-links",
             B.DIST,
         ]
-        file_dep = []
-        for py_name in [C.NAME, C.CORE_NAME]:
-            py_name_pkg = py_name.replace("-", "_")
-            file_dep += [B.DIST / f"""{py_name_pkg}-{D.PY_VERSION}-{C.NOARCH_WHL}"""]
-            args += [py_name]
-
+        core_args = args + [C.CORE_NAME]
         yield dict(
             name="py:jupyterlite-core",
-            actions=[U.do(*args, cwd=P.ROOT)],
-            file_dep=file_dep,
+            actions=[U.do(*core_args, cwd=P.ROOT)],
+            file_dep=[B.DIST / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
+        )
+
+        meta_args = args + [C.NAME, "--no-deps"]
+        yield dict(
+            task_dep=["dev:py:jupyterlite-core"],
+            name="py:jupyterlite",
+            actions=[U.do(*meta_args, cwd=P.ROOT)],
+            file_dep=[B.DIST / f"""{C.NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
         )
     else:
         for py_name in [C.NAME, C.CORE_NAME]:

--- a/dodo.py
+++ b/dodo.py
@@ -416,7 +416,7 @@ def task_dist():
 def task_dev():
     """setup up local packages for interactive development"""
     args = []
-    if True or C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
+    if C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
         args = [
             *C.PYM,
             "pip",

--- a/dodo.py
+++ b/dodo.py
@@ -415,14 +415,21 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    args = [*C.PYM, "pip", "install", "-r", "requirements-editable.txt"]
+    file_dep = [
+        B.DIST / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
+    ]
+    core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
     yield dict(
         name="py:jupyterlite-core",
-        actions=[U.do(*args, cwd=P.ROOT)],
-        file_dep=[
-            B.DIST
-            / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
-        ],
+        actions=[U.do(*core_args, cwd=P.ROOT)],
+        file_dep=file_dep,
+    )
+
+    metapackage_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite", "--no-deps"]
+    yield dict(
+        name="py:jupyterlite",
+        actions=[U.do(*metapackage_args, cwd=P.ROOT)],
+        file_dep=file_dep,
     )
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -415,18 +415,42 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
-    yield dict(
-        name="py:jupyterlite-core",
-        task_dep=[f"build:py:{C.CORE_NAME}:pre:app"],
-        actions=[U.do(*core_args, cwd=P.ROOT)],
-    )
+    if C.DOCS_IN_CI:
+        args = [
+            *C.PYM,
+            "pip",
+            "install",
+            "-vv",
+            "--no-index",
+            "--find-links",
+            B.DIST,
+            C.CORE_NAME.replace("-", "_"),
+        ]
 
-    metapackage_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite", "--no-deps"]
-    yield dict(
-        name="py:jupyterlite",
-        actions=[U.do(*metapackage_args, cwd=P.ROOT)],
-    )
+        yield dict(
+            name="py:jupyterlite-core",
+            actions=[U.do(*args, cwd=P.ROOT)],
+            file_dep=[B.DIST / f"""{C.CORE_NAME}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
+        )
+    else:
+        core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
+        yield dict(
+            name="py:jupyterlite-core",
+            actions=[U.do(*core_args, cwd=P.ROOT)],
+        )
+
+        metapackage_args = [
+            *C.PYM,
+            "pip",
+            "install",
+            "-e",
+            "./py/jupyterlite",
+            "--no-deps",
+        ]
+        yield dict(
+            name="py:jupyterlite",
+            actions=[U.do(*metapackage_args, cwd=P.ROOT)],
+        )
 
 
 def task_docs():

--- a/dodo.py
+++ b/dodo.py
@@ -415,8 +415,8 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    args = []
-    if C.TESTING_IN_CI or C.DOCS_IN_CI or C.LINTING_IN_CI:
+    if C.DOCS_IN_CI or C.TESTING_IN_CI:
+        py_name = C.CORE_NAME.replace("-", "_")
         args = [
             *C.PYM,
             "pip",
@@ -425,29 +425,32 @@ def task_dev():
             "--no-index",
             "--find-links",
             B.DIST,
+            py_name,
         ]
-        file_dep = []
-        for py_name in [C.NAME, C.CORE_NAME]:
-            py_name_pkg = py_name.replace("-", "_")
-            file_dep += [B.DIST / f"""{py_name_pkg}-{D.PY_VERSION}-{C.NOARCH_WHL}"""]
-            args += [py_name]
 
         yield dict(
             name="py:jupyterlite-core",
             actions=[U.do(*args, cwd=P.ROOT)],
-            file_dep=file_dep,
+            file_dep=[B.DIST / f"""{py_name}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
         )
     else:
-        for py_name in [C.NAME, C.CORE_NAME]:
-            py_name_pkg = py_name.replace("-", "_")
-            cwd = P.PY_SETUP_PY[py_name].parent
-            file_dep = [cwd / "src" / py_name_pkg / B.APP_PACK.name]
-            args = [*C.FLIT, "install", "--pth-file", "--deps=none"]
-
+        core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
         yield dict(
-            name=f"py:{py_name}",
-            actions=[U.do(*args, cwd=cwd)],
-            file_dep=file_dep,
+            name="py:jupyterlite-core",
+            actions=[U.do(*core_args, cwd=P.ROOT)],
+        )
+
+        metapackage_args = [
+            *C.PYM,
+            "pip",
+            "install",
+            "-e",
+            "./py/jupyterlite",
+            "--no-deps",
+        ]
+        yield dict(
+            name="py:jupyterlite",
+            actions=[U.do(*metapackage_args, cwd=P.ROOT)],
         )
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -430,7 +430,10 @@ def task_dev():
         yield dict(
             name="py:jupyterlite-core",
             actions=[U.do(*core_args, cwd=P.ROOT)],
-            file_dep=[B.DIST / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
+            file_dep=[
+                B.DIST
+                / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
+            ],
         )
 
         meta_args = args + [C.NAME, "--no-deps"]
@@ -438,7 +441,9 @@ def task_dev():
             task_dep=["dev:py:jupyterlite-core"],
             name="py:jupyterlite",
             actions=[U.do(*meta_args, cwd=P.ROOT)],
-            file_dep=[B.DIST / f"""{C.NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""],
+            file_dep=[
+                B.DIST / f"""{C.NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
+            ],
         )
     else:
         for py_name in [C.NAME, C.CORE_NAME]:

--- a/dodo.py
+++ b/dodo.py
@@ -427,8 +427,7 @@ def task_dev():
             B.DIST,
         ]
         file_dep = []
-        # for py_name in [C.NAME, C.CORE_NAME]:
-        for py_name in [C.CORE_NAME]:
+        for py_name in [C.CORE_NAME, C.NAME]:
             py_name_pkg = py_name.replace("-", "_")
             file_dep += [B.DIST / f"""{py_name_pkg}-{D.PY_VERSION}-{C.NOARCH_WHL}"""]
             args += [py_name]
@@ -1391,6 +1390,7 @@ class U:
 
             args += C.LITE_ARGS
 
+            print(args)
             subprocess.check_call(list(map(str, args)), cwd=str(P.EXAMPLES))
 
     def hashfile(path):

--- a/dodo.py
+++ b/dodo.py
@@ -415,21 +415,16 @@ def task_dist():
 
 def task_dev():
     """setup up local packages for interactive development"""
-    file_dep = [
-        B.DIST / f"""{C.CORE_NAME.replace("-", "_")}-{D.PY_VERSION}-{C.NOARCH_WHL}"""
-    ]
     core_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite-core[test]"]
     yield dict(
         name="py:jupyterlite-core",
         actions=[U.do(*core_args, cwd=P.ROOT)],
-        file_dep=file_dep,
     )
 
     metapackage_args = [*C.PYM, "pip", "install", "-e", "./py/jupyterlite", "--no-deps"]
     yield dict(
         name="py:jupyterlite",
         actions=[U.do(*metapackage_args, cwd=P.ROOT)],
-        file_dep=file_dep,
     )
 
 

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -22,7 +22,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.5-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl",
-      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.0.3/jupyterlite_pyodide_kernel-0.0.3-py3-none-any.whl"
+      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.0.4/jupyterlite_pyodide_kernel-0.0.4-py3-none-any.whl"
     ],
     "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "output_dir": "../build/docs-app"

--- a/py/jupyterlite-core/src/jupyterlite_core/tests/test_cli.py
+++ b/py/jupyterlite-core/src/jupyterlite_core/tests/test_cli.py
@@ -15,7 +15,7 @@ IS_PYPY = "pypy" in PY_IMPL.lower()
 LITE_INVOCATIONS = [
     ["jupyter-lite"],
     ["jupyter", "lite"],
-    # ["python", "-m", "jupyterlite"],
+    ["python", "-m", "jupyterlite_core"],
 ]
 
 # nothing we can do about this, at present

--- a/py/jupyterlite-core/src/jupyterlite_core/tests/test_cli.py
+++ b/py/jupyterlite-core/src/jupyterlite_core/tests/test_cli.py
@@ -15,7 +15,7 @@ IS_PYPY = "pypy" in PY_IMPL.lower()
 LITE_INVOCATIONS = [
     ["jupyter-lite"],
     ["jupyter", "lite"],
-    ["python", "-m", "jupyterlite"],
+    # ["python", "-m", "jupyterlite"],
 ]
 
 # nothing we can do about this, at present

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -8,10 +8,8 @@ authors = [
     {name = "JupyterLite Contributors"},
 ]
 dependencies = [
-    "jupyterlite-core",
-    # TODO
-    # "jupyterlite-core[lab]",
-    # "jupyterlite-pyodide-kernel",
+    "jupyterlite-core[lab]",
+    "jupyterlite-pyodide-kernel",
 ]
 keywords = [
     "browser",

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "JupyterLite Contributors"},
 ]
 dependencies = [
-    "jupyterlite-core[lab]",
+    "jupyterlite-core",
     "jupyterlite-pyodide-kernel >=0.0.4",
 ]
 keywords = [

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "jupyterlite-core[lab]",
-    "jupyterlite-pyodide-kernel",
+    "jupyterlite-pyodide-kernel >=0.0.4",
 ]
 keywords = [
     "browser",

--- a/requirements-editable.txt
+++ b/requirements-editable.txt
@@ -1,0 +1,2 @@
+-e py/jupyterlite_core[test]
+-e py/jupyterlite

--- a/requirements-editable.txt
+++ b/requirements-editable.txt
@@ -1,2 +1,2 @@
--e py/jupyterlite_core[test]
--e py/jupyterlite
+-e ./py/jupyterlite-core[test]
+-e ./py/jupyterlite

--- a/requirements-editable.txt
+++ b/requirements-editable.txt
@@ -1,2 +1,0 @@
--e ./py/jupyterlite-core[test]
--e ./py/jupyterlite

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -9,7 +9,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.1.0-pyhd8ed1ab_1.tar.bz2",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl",
-      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.0.3/jupyterlite_pyodide_kernel-0.0.3-py3-none-any.whl"
+      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.0.4/jupyterlite_pyodide_kernel-0.0.4-py3-none-any.whl"
     ],
     "output_dir": "ui-tests-app",
     "ignore_sys_prefix": ["federated_extensions"]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Update the dependencies for the `jupyterlite` metapackage.

Follow-up to https://github.com/jupyterlite/jupyterlite/pull/994.

Part of #993 

This will be a follow-up to https://github.com/jupyterlite/pyodide-kernel/pull/23.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Update `jupyterlite-core` dependency
- [x] Depend on `jupyterlite-pyodide-kernel`
- [x] Streamline more CI with `jupyterlab/maintainer-tools/.github/actions/base-setup@v1` (remove some logic already handled by the action)
- [x] Test on Python 3.8
- [x] Update docs to mention `jupyterlite-core` and how to install the Pyodide kernel

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This will ensure end users depending on `jupyterlite` will still get the Pyodide kernel by default for now.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
