### PR TITLE
Default docs back to `latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/jupyterlite/jupyterlite/main?urlpath=lab
 [docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=0.1.0-beta
-[docs]: https://jupyterlite.readthedocs.io/en/0.1.0-beta/?badge=0.1.0-beta
+[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=0.1.0-beta
 
 JupyterLite is a JupyterLab distribution that **runs entirely in the browser** built
 from the ground-up using JupyterLab components and extensions.
@@ -23,8 +23,8 @@ Not all the usual features available in JupyterLab and the Classic Notebook will
 with JupyterLite, but many already do!
 
 Don't hesitate to check out the
-[documentation](https://jupyterlite.readthedocs.io/en/0.1.0-beta/howto/index.html) for
-more information and project updates.
+[documentation](https://jupyterlite.readthedocs.io/en/latest/howto/index.html) for more
+information and project updates.
 
 ## ✨ Try it in your browser ✨
 
@@ -48,8 +48,8 @@ You can build your own JupyterLite website in a couple of minutes, with custom
 extensions and packages.
 
 See the
-[documentation](https://jupyterlite.readthedocs.io/en/0.1.0-beta/quickstart/deploy.html)
-for more details.
+[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html) for
+more details.
 
 ### Browser-based Interactive Computing
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [ci]: https://github.com/jupyterlite/jupyterlite/actions?query=branch%3Amain
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/jupyterlite/jupyterlite/main?urlpath=lab
-[docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=0.1.0-beta
-[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=0.1.0-beta
+[docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=latest
+[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=latest
 
 JupyterLite is a JupyterLab distribution that **runs entirely in the browser** built
 from the ground-up using JupyterLab components and extensions.

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -9,7 +9,7 @@
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/jupyterlite/jupyterlite/main?urlpath=lab
 [docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=0.1.0-beta
-[docs]: https://jupyterlite.readthedocs.io/en/0.1.0-beta/?badge=0.1.0-beta
+[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=0.1.0-beta
 
 JupyterLite is a JupyterLab distribution that **runs entirely in the browser** built
 from the ground-up using JupyterLab components and extensions.
@@ -23,8 +23,8 @@ Not all the usual features available in JupyterLab and the Classic Notebook will
 with JupyterLite, but many already do!
 
 Don't hesitate to check out the
-[documentation](https://jupyterlite.readthedocs.io/en/0.1.0-beta/howto/index.html) for
-more information and project updates.
+[documentation](https://jupyterlite.readthedocs.io/en/latest/howto/index.html) for more
+information and project updates.
 
 ## ✨ Try it in your browser ✨
 
@@ -48,8 +48,8 @@ You can build your own JupyterLite website in a couple of minutes, with custom
 extensions and packages.
 
 See the
-[documentation](https://jupyterlite.readthedocs.io/en/0.1.0-beta/quickstart/deploy.html)
-for more details.
+[documentation](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html) for
+more details.
 
 ### Browser-based Interactive Computing
 

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -8,8 +8,8 @@
 [ci]: https://github.com/jupyterlite/jupyterlite/actions?query=branch%3Amain
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/jupyterlite/jupyterlite/main?urlpath=lab
-[docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=0.1.0-beta
-[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=0.1.0-beta
+[docs-badge]: https://readthedocs.org/projects/jupyterlite/badge/?version=latest
+[docs]: https://jupyterlite.readthedocs.io/en/latest/?badge=latest
 
 JupyterLite is a JupyterLab distribution that **runs entirely in the browser** built
 from the ground-up using JupyterLab components and extensions.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Revert #997 

Follow-up to https://github.com/jupyterlite/jupyterlite/pull/1001

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the links to documentation to point back to `latest`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users will see the latest docs like before.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
