### PR TITLE
Remove "Releasing" section from the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,11 +375,6 @@ page, including:
 
 [actions]: https://github.com/jupyterlite/jupyterlite/actions
 
-### Releasing
-
-> TBD: See [#121].
-
-[#121]: https://github.com/jupyterlite/jupyterlite/issues/121
 [issues]: https://github.com/jupyterlite/jupyterlite/issues
 [new issue]: https://github.com/jupyterlite/jupyterlite/issues/new
 [pull requests]: https://github.com/jupyterlite/jupyterlite/pulls


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Remove the following section from the docs:

![image](https://user-images.githubusercontent.com/591645/225730696-aa919644-4db3-4bdf-8843-6c6a0f30e2c6.png)

Since we are using the jupyter releaser and it is now covered in https://github.com/jupyterlite/jupyterlite/blob/main/RELEASE.md

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
