### PR TITLE
Fix chunk handling when uploading notebooks

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -425,7 +425,7 @@ export class Contents implements IContents {
     };
 
     if (options.content && options.format === 'base64') {
-      const lastChunk = chunk === -1;
+      const lastChunk = chunk ? chunk === -1 : true;
 
       if (ext === '.ipynb') {
         const content = this._handleChunk(options.content, originalContent, chunked);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1033

Follow-up to #1024 

## Code changes

Fix handling of the `chunk` option before storing a notebook.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should allow for uploading notebooks without error.

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
