### PR TITLE
Add a guide for opening a file from an external URL to the documentation

### DIFF
--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -4,6 +4,8 @@
 The third-party extension mentioned in this guide is not included in JupyterLite by default.
 There might other JupyterLab extensions that can achieve the same behavior that
 you might want to consider.
+This guide is provided as a reference and for convenience to show how you can enable such feature
+in your JupyterLite site.
 ```
 
 By default in JupyterLite it is not possible to open a file from an external URL.

--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -11,13 +11,13 @@ in your JupyterLite site.
 By default in JupyterLite it is not possible to open a file from an external URL.
 
 However you can install the
-[jupyterlite-open-url-parameter](https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter)
+[jupyterlab-open-url-parameter](https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter)
 extension to enable this feature.
 
 In your build environment, install the extension:
 
 ```shell
-pip install jupyterlite-open-url-parameter
+pip install jupyterlab-open-url-parameter
 ```
 
 Then build your JupyterLite site as usual:

--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -2,7 +2,7 @@
 
 ```{warning}
 The third-party extension mentioned in this guide is not included in JupyterLite by default.
-There might other JupyterLab extensions that can achieve the same behavior that
+There might be other JupyterLab extensions achieving the same behavior, that
 you might want to consider.
 This guide is provided as a reference and for convenience to show how you can enable such feature
 in your JupyterLite site.
@@ -47,6 +47,11 @@ http://your-jupyterlite.example.com/lab?fromURL=https://raw.githubusercontent.co
 ```
 
 ![a screenshot showing how to use the jupyterlab-open-url-parameter extension](https://user-images.githubusercontent.com/591645/230444694-5297f8b7-4558-4a9c-bb05-918e1cdde3bc.gif)
+
+```{note}
+For more information about the extension, check out the
+[jupyterlab-open-url-parameter](https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter) repository.
+```
 
 ## References
 

--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -1,4 +1,4 @@
-# Open a file from an external URL
+# Opening a file from an external URL
 
 ```{warning}
 The third-party extension mentioned in this guide is not included in JupyterLite by default.

--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -1,0 +1,46 @@
+# Open a file from an external URL
+
+By default in JupyterLite it is not possible to open a file from an external URL.
+
+However you can install the
+[jupyterlite-open-url-parameter](https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter)
+extension to enable this feature.
+
+In your build environment, install the extension:
+
+```shell
+pip install jupyterlite-open-url-parameter
+```
+
+Then build your JupyterLite site as usual:
+
+```shell
+jupyter lite build
+```
+
+The extension should be automatically enabled in your site.
+
+The extension will open a file passed via a URL parameter. The URL parameter is
+`fromURL`. It is possible to pass multiple files via the `fromURL` parameter. The files
+will be opened in the order they are passed.
+
+For example if you would like to open a notebook and a csv file:
+
+- https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/notebooks/Lorenz.ipynb
+- https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/data/iris.csv
+
+You can append the following to the URL of your JupyterLab instance:
+`?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/notebooks/Lorenz.ipynb&fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/data/iris.csv`
+
+Which will result in the following URL:
+
+```
+http://your-jupyterlite.example.com/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/data/iris.csv&fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/notebooks/Lorenz.ipynb
+```
+
+![a screenshot showing how to use the jupyterlab-open-url-parameter extension](https://user-images.githubusercontent.com/591645/230444694-5297f8b7-4558-4a9c-bb05-918e1cdde3bc.gif)
+
+## References
+
+Check out the [guide for adding extensions](../configure/simple_extensions.md) to learn
+more about how to add extensions to your JupyterLite site.

--- a/docs/howto/content/open-url-parameter.md
+++ b/docs/howto/content/open-url-parameter.md
@@ -1,5 +1,11 @@
 # Open a file from an external URL
 
+```{warning}
+The third-party extension mentioned in this guide is not included in JupyterLite by default.
+There might other JupyterLab extensions that can achieve the same behavior that
+you might want to consider.
+```
+
 By default in JupyterLite it is not possible to open a file from an external URL.
 
 However you can install the

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -33,6 +33,7 @@ configure/latex
 content/files
 content/python
 content/filesystem-access
+content/open-url-parameter
 content/share
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/430

Add a guide for opening a file from an external URL to the documentation.

## Code changes

Update the documentation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Site deployers can learn about additional extensions to load files from URLs: https://jupyterlite--1044.org.readthedocs.build/en/1044/howto/content/open-url-parameter.html

![image](https://user-images.githubusercontent.com/591645/230449929-744d135c-61b3-4c67-b855-e522399b50d6.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
