### PR TITLE
DOC Fix typo in cli.ipynb

### DIFF
--- a/docs/reference/cli.ipynb
+++ b/docs/reference/cli.ipynb
@@ -796,7 +796,7 @@
     "my-lite-dir/\n",
     "  _output/\n",
     "    README.md\n",
-    "    b.md\n",
+    "    a.md\n",
     "```"
    ]
   },


### PR DESCRIPTION
## Code changes

It seems like the doc is wrong, by default `files` is going to be used and `files` has `a.md` (not `b.md`)
