### PR TITLE
DOC Make documentation about source maps more accurate

### DIFF
--- a/docs/howto/configure/advanced/optimizations.md
+++ b/docs/howto/configure/advanced/optimizations.md
@@ -25,9 +25,9 @@ application, and will not load with this setting.
 
 ## Removing Source Maps
 
-Provide `--no-sourcemaps`, or configure `no_sourcemaps` in a config file to prevent any
-`.map` files from being copied to the output folder. This creates a _drastically_
-smaller overall build.
+Provide `--no-sourcemaps`, or configure `LiteBuildConfig/no_sourcemaps` in a
+config file to prevent any `.map` files from being copied to the output folder.
+This creates a _drastically_ smaller overall build.
 
 ```{warning}
 Removing sourcemaps, in addition to making errors harder to debug, will _also_


### PR DESCRIPTION
## Code changes

I believe the correct config is something like below so I used `LiteBuildConfig/no_sourcemaps` similarly to no_unused_shared_packages above.

```json
{
    "LiteBuildConfig": {
        "no_sourcemaps": true
    }
}
```

The previous sentence led me to believe that the following would work (it doesn't):
```json
{
    "no_sourcemaps": true
}
```
