### PR TITLE
Only handle broadcasted messages meant to be received

### DIFF
--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -54,6 +54,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
 
   /** Handle a message received on the BroadcastChannel */
   protected _onMessage = async (event: MessageEvent<IDriveRequest>): Promise<void> => {
+    console.log('Got message event ', event);
     if (!this._channel || event.data?.sender === 'broadcast.ts') {
       return;
     }

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -54,12 +54,13 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
 
   /** Handle a message received on the BroadcastChannel */
   protected _onMessage = async (event: MessageEvent<IDriveRequest>): Promise<void> => {
-    if (!this._channel) {
+    if (!this._channel || event.data?.sender === 'broadcast.ts') {
       return;
     }
     const { _contents } = this;
     const request = event.data;
-    const path = request?.path;
+
+    const { path } = request;
 
     // many successful responses default to null
     let response: any = null;
@@ -67,7 +68,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     // most requests will use a model
     let model: ServerContents.IModel;
 
-    switch (request?.method) {
+    switch (request.method) {
       case 'readdir':
         model = await _contents.get(path, { content: true });
         response = [];
@@ -154,7 +155,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         break;
     }
 
-    this._channel.postMessage(response);
+    this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
   };
 
   protected _channel: BroadcastChannel | null = null;

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -54,14 +54,13 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
 
   /** Handle a message received on the BroadcastChannel */
   protected _onMessage = async (event: MessageEvent<IDriveRequest>): Promise<void> => {
-    console.log('Got message event ', event);
     if (!this._channel || event.data?.sender === 'broadcast.ts') {
       return;
     }
     const { _contents } = this;
     const request = event.data;
 
-    const { path } = request;
+    const path = request?.path;
 
     // many successful responses default to null
     let response: any = null;
@@ -69,7 +68,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     // most requests will use a model
     let model: ServerContents.IModel;
 
-    switch (request.method) {
+    switch (request?.method) {
       case 'readdir':
         model = await _contents.get(path, { content: true });
         response = [];
@@ -156,7 +155,11 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         break;
     }
 
-    this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
+    if (Array.isArray(response)) {
+      this._channel.postMessage(response);
+    } else {
+      this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
+    }
   };
 
   protected _channel: BroadcastChannel | null = null;

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -63,7 +63,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     const path = request?.path;
 
     // many successful responses default to null
-    let response: any = null;
+    let response: { [key: string]: any } | null = null;
 
     // most requests will use a model
     let model: ServerContents.IModel;
@@ -71,9 +71,13 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     switch (request?.method) {
       case 'readdir':
         model = await _contents.get(path, { content: true });
-        response = [];
+        response = {
+          contents: [],
+        };
         if (model.type === 'directory' && model.content) {
-          response = model.content.map((subcontent: IModel) => subcontent.name);
+          response.contents = model.content.map(
+            (subcontent: IModel) => subcontent.name
+          );
         }
         break;
       case 'rmdir':
@@ -85,9 +89,9 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
       case 'getmode':
         model = await _contents.get(path);
         if (model.type === 'directory') {
-          response = DIR_MODE;
+          response = { mode: DIR_MODE };
         } else {
-          response = FILE_MODE;
+          response = { mode: FILE_MODE };
         }
         break;
       case 'lookup':
@@ -155,10 +159,10 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         break;
     }
 
-    if (Array.isArray(response)) {
-      this._channel.postMessage(response);
-    } else {
+    if (typeof response === 'object') {
       this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
+    } else {
+      this._channel.postMessage(response);
     }
   };
 

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -159,7 +159,11 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         break;
     }
 
-    this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
+    if (typeof response === 'object') {
+      this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
+    } else {
+      this._channel.postMessage(response);
+    }
   };
 
   protected _channel: BroadcastChannel | null = null;

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -159,11 +159,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         break;
     }
 
-    if (typeof response === 'object') {
-      this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
-    } else {
-      this._channel.postMessage(response);
-    }
+    this._channel.postMessage({ ...response, sender: 'broadcast.ts' });
   };
 
   protected _channel: BroadcastChannel | null = null;

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -39,6 +39,8 @@ export type TDriveMethod =
   | 'get'
   | 'put';
 
+const SENDER = 'drivefs.ts';
+
 /**
  * Interface of a request on the /api/drive endpoint
  */
@@ -47,6 +49,11 @@ export interface IDriveRequest {
    * The method of the request (rmdir, readdir etc)
    */
   method: TDriveMethod;
+
+  /**
+   * The sender of the request ('drivefs.ts' or 'broadcast.ts')
+   */
+  sender: 'drivefs.ts' | 'broadcast.ts';
 
   /**
    * The path to the file/directory for which the request was sent
@@ -301,7 +308,6 @@ export class ContentsAPI {
   request(data: IDriveRequest): any {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', encodeURI(this.endpoint), false);
-
     try {
       xhr.send(JSON.stringify(data));
     } catch (e) {
@@ -316,17 +322,26 @@ export class ContentsAPI {
   }
 
   lookup(path: string): DriveFS.ILookup {
-    return this.request({ method: 'lookup', path: this.normalizePath(path) });
+    return this.request({
+      sender: SENDER,
+      method: 'lookup',
+      path: this.normalizePath(path),
+    });
   }
 
   getmode(path: string): number {
     return Number.parseInt(
-      this.request({ method: 'getmode', path: this.normalizePath(path) })
+      this.request({
+        sender: SENDER,
+        method: 'getmode',
+        path: this.normalizePath(path),
+      })
     );
   }
 
   mknod(path: string, mode: number) {
     return this.request({
+      sender: SENDER,
       method: 'mknod',
       path: this.normalizePath(path),
       data: { mode },
@@ -335,6 +350,7 @@ export class ContentsAPI {
 
   rename(oldPath: string, newPath: string): void {
     return this.request({
+      sender: SENDER,
       method: 'rename',
       path: this.normalizePath(oldPath),
       data: { newPath: this.normalizePath(newPath) },
@@ -343,6 +359,7 @@ export class ContentsAPI {
 
   readdir(path: string): string[] {
     const dirlist = this.request({
+      sender: SENDER,
       method: 'readdir',
       path: this.normalizePath(path),
     });
@@ -352,11 +369,19 @@ export class ContentsAPI {
   }
 
   rmdir(path: string): void {
-    return this.request({ method: 'rmdir', path: this.normalizePath(path) });
+    return this.request({
+      sender: SENDER,
+      method: 'rmdir',
+      path: this.normalizePath(path),
+    });
   }
 
   get(path: string): DriveFS.IFile {
-    const response = this.request({ method: 'get', path: this.normalizePath(path) });
+    const response = this.request({
+      sender: SENDER,
+      method: 'get',
+      path: this.normalizePath(path),
+    });
 
     const serializedContent = response.content;
     const format: 'json' | 'text' | 'base64' | null = response.format;
@@ -390,6 +415,7 @@ export class ContentsAPI {
       case 'json':
       case 'text':
         return this.request({
+          sender: SENDER,
           method: 'put',
           path: this.normalizePath(path),
           data: {
@@ -403,6 +429,7 @@ export class ContentsAPI {
           binary += String.fromCharCode(value.data[i]);
         }
         return this.request({
+          sender: SENDER,
           method: 'put',
           path: this.normalizePath(path),
           data: {
@@ -416,6 +443,7 @@ export class ContentsAPI {
 
   getattr(path: string): IStats {
     const stats: IStats = this.request({
+      sender: SENDER,
       method: 'getattr',
       path: this.normalizePath(path),
     });

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -330,13 +330,13 @@ export class ContentsAPI {
   }
 
   getmode(path: string): number {
-    return Number.parseInt(
-      this.request({
-        sender: SENDER,
-        method: 'getmode',
-        path: this.normalizePath(path),
-      })
-    );
+    const { mode } = this.request({
+      sender: SENDER,
+      method: 'getmode',
+      path: this.normalizePath(path),
+    });
+
+    return Number.parseInt(mode);
   }
 
   mknod(path: string, mode: number) {
@@ -358,14 +358,14 @@ export class ContentsAPI {
   }
 
   readdir(path: string): string[] {
-    const dirlist = this.request({
+    const { contents } = this.request({
       sender: SENDER,
       method: 'readdir',
       path: this.normalizePath(path),
     });
-    dirlist.push('.');
-    dirlist.push('..');
-    return dirlist;
+    contents.push('.');
+    contents.push('..');
+    return contents;
   }
 
   rmdir(path: string): void {

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -309,6 +309,7 @@ export class ContentsAPI {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', encodeURI(this.endpoint), false);
     try {
+      console.log('drive.fs will send a message: ', JSON.stringify(data));
       xhr.send(JSON.stringify(data));
     } catch (e) {
       console.error(e);

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -309,7 +309,6 @@ export class ContentsAPI {
     const xhr = new XMLHttpRequest();
     xhr.open('POST', encodeURI(this.endpoint), false);
     try {
-      console.log('drive.fs will send a message: ', JSON.stringify(data));
       xhr.send(JSON.stringify(data));
     } catch (e) {
       console.error(e);

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -127,6 +127,9 @@ async function broadcastOne(request: Request): Promise<Response> {
   });
 
   const message = await request.json();
+  // Mark message as being for broadcast.ts
+  // This makes sure we won't get problems with messages
+  // across tabs with multiple notebook tabs open
   message.receiver = 'broadcast.ts';
   broadcast.postMessage(message);
 

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -126,7 +126,9 @@ async function broadcastOne(request: Request): Promise<Response> {
     };
   });
 
-  broadcast.postMessage(await request.json());
+  const message = await request.json();
+  message.receiver = 'broadcast.ts';
+  broadcast.postMessage(message);
 
   return await promise;
 }


### PR DESCRIPTION
## References

Attempt to solve https://github.com/jupyterlite/jupyterlite/issues/1074 (also https://github.com/jupyterlite/jupyterlite/issues/1126 and https://github.com/jupyterlite/jupyterlite/issues/1089)

## Code changes

Ref https://github.com/jupyterlite/jupyterlite/issues/1074, sometimes `_onMessage` in [broadcast.ts](https://github.com/jupyterlite/jupyterlite/blob/main/packages/contents/src/broadcast.ts#L61) gets a message that does not meet the expected structure of the function. This PR makes sure these messages are ignored by this receiever.