### PR TITLE
Resolve the null getter issue in the _onMessage method

### DIFF
--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -59,7 +59,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     }
     const { _contents } = this;
     const request = event.data;
-    const { path } = request;
+    const path = request?.path;
 
     // many successful responses default to null
     let response: any = null;
@@ -67,7 +67,7 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
     // most requests will use a model
     let model: ServerContents.IModel;
 
-    switch (request.method) {
+    switch (request?.method) {
       case 'readdir':
         model = await _contents.get(path, { content: true });
         response = [];


### PR DESCRIPTION
## References
Fixes null getter error as can be seen below;
![image](https://github.com/jupyterlite/jupyterlite/assets/55690750/3a11150b-ddf1-47db-9101-3485caf3905f)
![image](https://github.com/jupyterlite/jupyterlite/assets/55690750/342ca6b2-aaf7-4947-a5e9-dabb811189d5)

## Code changes
Modify the sections of code in the _onMessage function that disregard the possibility of `event.data` being `undefined`.

## User-facing changes
This update doesn't bring about any visible changes for the regular user, it simply eliminates the error log that was previously visible, as depicted in the images above.

## Backwards-incompatible changes
None, as it only adds a nullish checks.
