### PR TITLE
Do not stub out the native WebSocket

### DIFF
--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -149,7 +149,7 @@ export class Kernels implements IKernels {
     this._kernelClients.set(kernelId, new Set<string>());
 
     // create the websocket server for the kernel
-    const wsServer = new WebSocketServer(kernelUrl);
+    const wsServer = new WebSocketServer(kernelUrl, { mock: false });
     wsServer.on('connection', (socket: WebSocketClient): void => {
       const url = new URL(socket.url);
       const clientId = url.searchParams.get('session_id') ?? '';


### PR DESCRIPTION
## References
Fixes https://github.com/jupyterlite/jupyterlite/issues/559
## Code changes

add `{ mock: false }` when starting the websocket server as suggested here: https://github.com/thoov/mock-socket/issues/308

## User-facing changes

None

## Backwards-incompatible changes
None

~~Note that I haven't tested it locally, see if we pass the CI first.~~
I tested with the ReadTheDocs link, and the native websocket is preserved, the jupyterlite seems normal.