### PR TITLE
Update to jupyterlite-pyodide-kernel==0.1.1 on RTD

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -24,7 +24,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.14.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/theme-darcula-3.1.1-pyh3684270_0.tar.bz2",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl",
-      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.1.0/jupyterlite_pyodide_kernel-0.1.0-py3-none-any.whl"
+      "https://github.com/jupyterlite/pyodide-kernel/releases/download/v0.1.1/jupyterlite_pyodide_kernel-0.1.1-py3-none-any.whl"
     ],
     "ignore_sys_prefix": ["federated_extensions", "mathjax"],
     "output_dir": "../build/docs-app"


### PR DESCRIPTION
# References
Update to jupyterlite-pyodide-kernel==0.1.1 on the demo site.

# Code changes
Update demo site config.

# User-facing changes
Newer version on the demo site: https://jupyterlite.readthedocs.io/en/latest/_static/lab/?path=intro.ipynb

# Backwards-incompatible changes
None