### PR TITLE
[0.1.x] Add bounds to the `jupyterlite-core` dependency

### DIFF
--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "jupyterlite-core >=0.1.2,<0.2.0",
     "jupyterlite-pyodide-kernel >=0.1.1",
-    "jupyterlite-javascript-kernel",
+    "jupyterlite-javascript-kernel >=0.1.1",
 ]
 keywords = [
     "browser",

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "jupyterlite-core >=0.1.2,<0.2.0",
-    "jupyterlite-pyodide-kernel >=0.0.4",
+    "jupyterlite-pyodide-kernel >=0.1.1",
     "jupyterlite-javascript-kernel",
 ]
 keywords = [

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "JupyterLite Contributors"},
 ]
 dependencies = [
-    "jupyterlite-core",
+    "jupyterlite-core >=0.1.2,<0.2.0",
     "jupyterlite-pyodide-kernel >=0.0.4",
     "jupyterlite-javascript-kernel",
 ]

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "jupyterlite-core >=0.1.2,<0.2.0",
     "jupyterlite-pyodide-kernel >=0.1.1",
-    "jupyterlite-javascript-kernel >=0.1.1",
+    "jupyterlite-javascript-kernel >=0.1.2",
 ]
 keywords = [
     "browser",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #1019 

In line of https://github.com/jupyterlite/jupyterlite/issues/1008

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add bounds to the `jupyterlite-core` dependency. 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should help make upgrade scenarios smoother for those using the `jupyterlite` package instead of `jupyterlite-core`.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
