### PR TITLE
Move prettier config to `package.json`, drop `trailingComma`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "singleQuote": true,
-  "printWidth": 88,
-  "proseWrap": "always",
-  "trailingComma": "es5"
-}

--- a/app/config-utils.js
+++ b/app/config-utils.js
@@ -46,7 +46,7 @@ const LITE_MAIN = 'jupyter-lite-main';
  */
 const HERE = `${window.location.origin}${window.location.pathname.replace(
   /(\/|\/index.html)?$/,
-  ''
+  '',
 )}/`;
 
 /**

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -16,7 +16,7 @@ const topLevelData = require('./package.json');
 
 const liteAppData = topLevelData.jupyterlite.apps.reduce(
   (memo, app) => ({ ...memo, [app]: require(`./${app}/package.json`) }),
-  {}
+  {},
 );
 
 const licensePlugins = [];
@@ -26,7 +26,7 @@ if (!process.env.NO_WEBPACK_LICENSES) {
 }
 
 // custom handlebars helper to check if a page corresponds to a value
-Handlebars.registerHelper('ispage', function (key, page) {
+Handlebars.registerHelper('ispage', (key, page) => {
   return key === page;
 });
 
@@ -173,7 +173,7 @@ for (const [name, data] of Object.entries(liteAppData)) {
 
   // Create the entry point and other assets in build directory.
   const template = Handlebars.compile(
-    fs.readFileSync(path.resolve(`./index.template.js`)).toString()
+    fs.readFileSync(path.resolve('./index.template.js')).toString(),
   );
   fs.writeFileSync(
     path.join(name, 'build', 'index.js'),
@@ -184,7 +184,7 @@ for (const [name, data] of Object.entries(liteAppData)) {
       extensions,
       mimeExtensions,
       disabledExtensions,
-    })
+    }),
   );
   // Create the bootstrap file that loads federated extensions and calls the
   // initialization logic in index.js
@@ -198,13 +198,13 @@ for (const [name, data] of Object.entries(liteAppData)) {
 
   // Inject the name of the app in the template to be able to filter bundle files
   const indexTemplate = Handlebars.compile(
-    fs.readFileSync(path.resolve(`./index.template.html`)).toString()
+    fs.readFileSync(path.resolve('./index.template.html')).toString(),
   );
   fs.writeFileSync(
     path.join(name, 'build', 'index.template.html'),
     indexTemplate({
       name,
-    })
+    }),
   );
   // Use templates to create cache-busting templates
   allHtmlPlugins.push(
@@ -214,7 +214,7 @@ for (const [name, data] of Object.entries(liteAppData)) {
       title: data.jupyterlab.title,
       filename: `../${name}/index.html`,
       template: `${name}/build/index.template.html`,
-    })
+    }),
   );
 }
 
@@ -340,7 +340,7 @@ module.exports = [
         name: 'CORE_FEDERATION',
         shared: Object.values(liteAppData).reduce(
           (memo, data) => createShared(data, memo),
-          {}
+          {},
         ),
       }),
       new CompileSchemasPlugin(),

--- a/dodo.py
+++ b/dodo.py
@@ -166,7 +166,7 @@ def task_lint():
         for ipynb in D.ALL_IPYNB:
             yield dict(
                 name=f"ipynb:{ipynb.relative_to(P.ROOT)}",
-                file_dep=[ipynb, P.PRETTIER_RC],
+                file_dep=[ipynb],
                 actions=[
                     U.do("nbstripout", ipynb),
                     (U.notebook_lint, [ipynb]),
@@ -911,9 +911,6 @@ class P:
     # CI
     CI = ROOT / ".github"
 
-    # lint
-    PRETTIER_RC = ROOT / ".prettierrc"
-
 
 def _js_version_to_py_version(js_version):
     return (
@@ -1517,7 +1514,7 @@ class U:
                 files[i] = tdp / f"{ipynb.stem}-{i:03d}.md"
                 files[i].write_text("".join([*cell["source"], "\n"]), **C.ENC)
 
-            args = [which("jlpm"), "prettier", "--config", P.PRETTIER_RC]
+            args = [which("jlpm"), "prettier"]
 
             args += ["--check"] if C.CI else ["--write", "--list-different"]
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,12 @@
       "pre-commit": "lint-staged"
     }
   },
+  "prettier": {
+    "singleQuote": true,
+    "printWidth": 88,
+    "proseWrap": "always",
+    "trailingComma": "es5"
+  },
   "resolutions": {
     "@types/react": "^18.0.26",
     "json-schema": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
   "prettier": {
     "singleQuote": true,
     "printWidth": 88,
-    "proseWrap": "always",
-    "trailingComma": "es5"
+    "proseWrap": "always"
   },
   "resolutions": {
     "@types/react": "^18.0.26",

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -80,7 +80,7 @@ const about: JupyterFrontEndPlugin<void> = {
     app: JupyterFrontEnd,
     translator: ITranslator,
     palette: ICommandPalette | null,
-    menu: IMainMenu | null
+    menu: IMainMenu | null,
   ): void => {
     const { commands } = app;
     const trans = translator.load(I18N_BUNDLE);
@@ -176,7 +176,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     translator: ITranslator,
     docManager: IDocumentManager,
     palette: ICommandPalette | null,
-    factory: IFileBrowserFactory | null
+    factory: IFileBrowserFactory | null,
   ) => {
     const trans = translator.load(I18N_BUNDLE);
     const { commands, serviceManager, shell } = app;
@@ -201,7 +201,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
         } else {
           const mime = model.mimetype ?? 'text/plain';
           element.href = `data:${mime};charset=utf-8,${encodeURIComponent(
-            model.content
+            model.content,
           )}`;
         }
       } else {
@@ -321,7 +321,7 @@ const opener: JupyterFrontEndPlugin<void> = {
     app: JupyterFrontEnd,
     router: IRouter,
     docManager: IDocumentManager,
-    labShell: ILabShell | null
+    labShell: ILabShell | null,
   ): void => {
     const { commands } = app;
 
@@ -405,7 +405,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     factory: IFileBrowserFactory,
-    translator: ITranslator
+    translator: ITranslator,
   ): void => {
     const trans = translator.load(I18N_BUNDLE);
     const { commands } = app;
@@ -430,7 +430,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
 
         const url = new URL(URLExt.join(baseUrl, appUrl, 'index.html'));
         const models = toArray(
-          filter(widget.selectedItems(), (item) => item.type !== 'directory')
+          filter(widget.selectedItems(), (item) => item.type !== 'directory'),
         );
         models.forEach((model) => {
           url.searchParams.append('path', model.path);

--- a/packages/application/src/singleWidgetShell.ts
+++ b/packages/application/src/singleWidgetShell.ts
@@ -17,7 +17,7 @@ import { Panel, Widget, PanelLayout } from '@lumino/widgets';
  * The single widget application shell token.
  */
 export const ISingleWidgetShell = new Token<ISingleWidgetShell>(
-  '@jupyterlite/application:ISingleWidgetShell'
+  '@jupyterlite/application:ISingleWidgetShell',
 );
 
 /**
@@ -78,7 +78,7 @@ export class SingleWidgetShell extends Widget implements JupyterFrontEnd.IShell 
   add(
     widget: Widget,
     area?: Shell.Area,
-    options?: DocumentRegistry.IOpenOptions
+    options?: DocumentRegistry.IOpenOptions,
   ): void {
     if (area === 'main' || area === undefined) {
       if (this._main.widgets.length > 0) {

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -279,7 +279,7 @@ export class Contents implements IContents {
    */
   async get(
     path: string,
-    options?: ServerContents.IFetchOptions
+    options?: ServerContents.IFetchOptions,
   ): Promise<IModel | null> {
     // remove leading slash
     path = decodeURIComponent(path.replace(/^\//, ''));
@@ -377,7 +377,7 @@ export class Contents implements IContents {
       for (child of file.content) {
         await this.rename(
           URLExt.join(oldLocalPath, child.name),
-          URLExt.join(newLocalPath, child.name)
+          URLExt.join(newLocalPath, child.name),
         );
       }
     }
@@ -480,7 +480,7 @@ export class Contents implements IContents {
     path = decodeURIComponent(path);
     const slashed = `${path}/`;
     const toDelete = (await (await this.storage).keys()).filter(
-      (key) => key === path || key.startsWith(slashed)
+      (key) => key === path || key.startsWith(slashed),
     );
     await Promise.all(toDelete.map(this.forgetPath, this));
   }
@@ -513,7 +513,7 @@ export class Contents implements IContents {
       throw Error(`Could not find file with path ${path}`);
     }
     const copies = (((await checkpoints.getItem(path)) as IModel[]) ?? []).filter(
-      Boolean
+      Boolean,
     );
     copies.push(item);
     // keep only a certain amount of checkpoints per file
@@ -540,7 +540,7 @@ export class Contents implements IContents {
 
   protected normalizeCheckpoint(
     model: IModel,
-    id: number
+    id: number,
   ): ServerContents.ICheckpointModel {
     return { id: id.toString(), last_modified: model.last_modified };
   }
@@ -588,7 +588,7 @@ export class Contents implements IContents {
   private _handleChunk(
     newContent: string,
     originalContent: string,
-    chunked?: boolean
+    chunked?: boolean,
   ): string {
     const escaped = decodeURIComponent(escape(atob(newContent)));
     const content = chunked ? originalContent + escaped : escaped;
@@ -645,7 +645,7 @@ export class Contents implements IContents {
    */
   private async _getServerContents(
     path: string,
-    options?: ServerContents.IFetchOptions
+    options?: ServerContents.IFetchOptions,
   ): Promise<IModel | null> {
     const name = PathExt.basename(path);
     const parentContents = await this._getServerDirectory(URLExt.join(path, '..'));
@@ -742,7 +742,7 @@ export class Contents implements IContents {
         PageConfig.getBaseUrl(),
         'api/contents',
         path,
-        'all.json'
+        'all.json',
       );
 
       try {
@@ -754,7 +754,7 @@ export class Contents implements IContents {
       } catch (err) {
         console.warn(
           `don't worry, about ${err}... nothing's broken. If there had been a
-          file at ${apiURL}, you might see some more files.`
+          file at ${apiURL}, you might see some more files.`,
         );
       }
       this._serverContents.set(path, content);

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -139,7 +139,7 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
     buffer: Uint8Array,
     offset: number,
     length: number,
-    position: number
+    position: number,
   ): number {
     if (
       length <= 0 ||
@@ -159,7 +159,7 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
     buffer: Uint8Array,
     offset: number,
     length: number,
-    position: number
+    position: number,
   ): number {
     if (length <= 0 || stream.file === undefined) {
       return 0;
@@ -244,7 +244,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
     parent: IEmscriptenFSNode,
     name: string,
     mode: number,
-    dev: number
+    dev: number,
   ): IEmscriptenFSNode {
     const path = this.fs.PATH.join2(this.fs.realPath(parent), name);
     this.fs.API.mknod(path, mode);
@@ -256,7 +256,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
       oldNode.parent
         ? this.fs.PATH.join2(this.fs.realPath(oldNode.parent), oldNode.name)
         : oldNode.name,
-      this.fs.PATH.join2(this.fs.realPath(newDir), newName)
+      this.fs.PATH.join2(this.fs.realPath(newDir), newName),
     );
 
     // Updating the in-memory node
@@ -294,7 +294,7 @@ export class ContentsAPI {
     driveName: string,
     mountpoint: string,
     FS: FS,
-    ERRNO_CODES: ERRNO_CODES
+    ERRNO_CODES: ERRNO_CODES,
   ) {
     this._baseUrl = baseUrl;
     this._driveName = driveName;
@@ -326,7 +326,7 @@ export class ContentsAPI {
 
   getmode(path: string): number {
     return Number.parseInt(
-      this.request({ method: 'getmode', path: this.normalizePath(path) })
+      this.request({ method: 'getmode', path: this.normalizePath(path) }),
     );
   }
 
@@ -482,7 +482,7 @@ export class DriveFS {
       options.driveName,
       options.mountpoint,
       this.FS,
-      this.ERRNO_CODES
+      this.ERRNO_CODES,
     );
     this.driveName = options.driveName;
 
@@ -501,7 +501,7 @@ export class DriveFS {
     parent: IEmscriptenFSNode | null,
     name: string,
     mode: number,
-    dev: number
+    dev: number,
   ): IEmscriptenFSNode {
     const FS = this.FS;
     if (!FS.isDir(mode) && !FS.isFile(mode)) {

--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -65,7 +65,7 @@ export interface IEmscriptenNodeOps {
     parent: IEmscriptenFSNode,
     name: string,
     mode: number,
-    dev: number
+    dev: number,
   ): IEmscriptenFSNode;
   rename(oldNode: IEmscriptenFSNode, newDir: IEmscriptenFSNode, newName: string): void;
   unlink(parent: IEmscriptenFSNode, name: string): void;
@@ -83,14 +83,14 @@ export interface IEmscriptenStreamOps {
     buffer: Uint8Array,
     offset: number,
     length: number,
-    position: number
+    position: number,
   ): number;
   write(
     stream: IEmscriptenStream,
     buffer: Uint8Array,
     offset: number,
     length: number,
-    position: number
+    position: number,
   ): number;
   llseek(stream: IEmscriptenStream, offset: number, whence: number): number;
 }
@@ -104,7 +104,7 @@ export type FS = EmscriptenFS & {
     parent: IEmscriptenFSNode | null,
     name: string,
     mode: number,
-    dev: number
+    dev: number,
   ) => IEmscriptenFSNode;
 };
 

--- a/packages/contents/src/tokens.ts
+++ b/packages/contents/src/tokens.ts
@@ -29,7 +29,7 @@ export interface IContents {
    * @returns A promise which resolves with the created file content when the file is created.
    */
   newUntitled(
-    options?: ServerContents.ICreateOptions
+    options?: ServerContents.ICreateOptions,
   ): Promise<ServerContents.IModel | null>;
 
   /**
@@ -56,7 +56,7 @@ export interface IContents {
    */
   get(
     path: string,
-    options?: ServerContents.IFetchOptions
+    options?: ServerContents.IFetchOptions,
   ): Promise<ServerContents.IModel | null>;
 
   /**
@@ -79,7 +79,7 @@ export interface IContents {
    */
   save(
     path: string,
-    options?: Partial<ServerContents.IModel>
+    options?: Partial<ServerContents.IModel>,
   ): Promise<ServerContents.IModel | null>;
 
   /**
@@ -147,7 +147,7 @@ export namespace FILE {
    * Build-time configured file types.
    */
   const TYPES: Record<string, Partial<IRenderMime.IFileType>> = JSON.parse(
-    PageConfig.getOption('fileTypes') || '{}'
+    PageConfig.getOption('fileTypes') || '{}',
   );
 
   /**
@@ -171,7 +171,7 @@ export namespace FILE {
    */
   export function hasFormat(
     ext: string,
-    fileFormat: 'base64' | 'text' | 'json'
+    fileFormat: 'base64' | 'text' | 'json',
   ): boolean {
     ext = ext.toLowerCase();
     for (const fileType of Object.values(TYPES)) {
@@ -192,7 +192,7 @@ export namespace FILE {
  * The token for the BroadcastChannel broadcaster.
  */
 export const IBroadcastChannelWrapper = new Token<IBroadcastChannelWrapper>(
-  '@jupyterlite/contents:IBroadcastChannelWrapper'
+  '@jupyterlite/contents:IBroadcastChannelWrapper',
 );
 
 export interface IBroadcastChannelWrapper extends IDisposable {

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -83,7 +83,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @param msg The parent message.
    */
   async executeRequest(
-    content: KernelMessage.IExecuteRequestMsg['content']
+    content: KernelMessage.IExecuteRequestMsg['content'],
   ): Promise<KernelMessage.IExecuteReplyMsg['content']> {
     const result = await this.remoteKernel.execute(content, this.parent);
     result.execution_count = this.executionCount;
@@ -96,7 +96,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @param msg The parent message.
    */
   async completeRequest(
-    content: KernelMessage.ICompleteRequestMsg['content']
+    content: KernelMessage.ICompleteRequestMsg['content'],
   ): Promise<KernelMessage.ICompleteReplyMsg['content']> {
     return await this.remoteKernel.complete(content, this.parent);
   }
@@ -109,7 +109,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   async inspectRequest(
-    content: KernelMessage.IInspectRequestMsg['content']
+    content: KernelMessage.IInspectRequestMsg['content'],
   ): Promise<KernelMessage.IInspectReplyMsg['content']> {
     throw new Error('Not implemented');
   }
@@ -122,7 +122,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   async isCompleteRequest(
-    content: KernelMessage.IIsCompleteRequestMsg['content']
+    content: KernelMessage.IIsCompleteRequestMsg['content'],
   ): Promise<KernelMessage.IIsCompleteReplyMsg['content']> {
     throw new Error('Not implemented');
   }
@@ -135,7 +135,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   async commInfoRequest(
-    content: KernelMessage.ICommInfoRequestMsg['content']
+    content: KernelMessage.ICommInfoRequestMsg['content'],
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']> {
     throw new Error('Not implemented');
   }
@@ -197,7 +197,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * @returns The initialized remote kernel.
    */
   protected initRemote(
-    options: JavaScriptKernel.IOptions
+    options: JavaScriptKernel.IOptions,
   ): IRemoteJavaScriptWorkerKernel {
     const remote: IRemoteJavaScriptWorkerKernel = wrap(this._worker);
     remote.initialize({ baseUrl: PageConfig.getBaseUrl() });
@@ -260,7 +260,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
           msg.content,
           msg.metadata,
           msg.buffers,
-          msg.parentHeader
+          msg.parentHeader,
         );
         break;
       }

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -157,7 +157,7 @@ export abstract class BaseKernel implements IKernel {
    * @param content - The content of the execute_request kernel message
    */
   abstract executeRequest(
-    content: KernelMessage.IExecuteRequestMsg['content']
+    content: KernelMessage.IExecuteRequestMsg['content'],
   ): Promise<KernelMessage.IExecuteReplyMsg['content']>;
 
   /**
@@ -166,7 +166,7 @@ export abstract class BaseKernel implements IKernel {
    * @param content - The content of the request.
    */
   abstract completeRequest(
-    content: KernelMessage.ICompleteRequestMsg['content']
+    content: KernelMessage.ICompleteRequestMsg['content'],
   ): Promise<KernelMessage.ICompleteReplyMsg['content']>;
 
   /**
@@ -177,7 +177,7 @@ export abstract class BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   abstract inspectRequest(
-    content: KernelMessage.IInspectRequestMsg['content']
+    content: KernelMessage.IInspectRequestMsg['content'],
   ): Promise<KernelMessage.IInspectReplyMsg['content']>;
 
   /**
@@ -188,7 +188,7 @@ export abstract class BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   abstract isCompleteRequest(
-    content: KernelMessage.IIsCompleteRequestMsg['content']
+    content: KernelMessage.IIsCompleteRequestMsg['content'],
   ): Promise<KernelMessage.IIsCompleteReplyMsg['content']>;
 
   /**
@@ -199,7 +199,7 @@ export abstract class BaseKernel implements IKernel {
    * @returns A promise that resolves with the response message.
    */
   abstract commInfoRequest(
-    content: KernelMessage.ICommInfoRequestMsg['content']
+    content: KernelMessage.ICommInfoRequestMsg['content'],
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']>;
 
   /**
@@ -240,7 +240,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IStreamMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -265,7 +265,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IDisplayDataMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     // Make sure metadata is always set
     const parentHeaderValue =
@@ -293,7 +293,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IInputRequestMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -318,7 +318,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IExecuteResultMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -343,7 +343,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IErrorMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -368,7 +368,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IUpdateDisplayDataMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -393,7 +393,7 @@ export abstract class BaseKernel implements IKernel {
     content: KernelMessage.IClearOutputMsg['content'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;
@@ -420,7 +420,7 @@ export abstract class BaseKernel implements IKernel {
     buffers: KernelMessage.ICommMsgMsg['buffers'],
     parentHeader:
       | KernelMessage.IHeader<KernelMessage.MessageType>
-      | undefined = undefined
+      | undefined = undefined,
   ): void {
     const parentHeaderValue =
       typeof parentHeader !== 'undefined' ? parentHeader : this._parentHeader;

--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -58,7 +58,7 @@ export class Kernels implements IKernels {
     const hook = (
       kernelId: string,
       clientId: string,
-      socket: WebSocketClient
+      socket: WebSocketClient,
     ): void => {
       const kernel = this._kernels.get(kernelId);
 
@@ -98,7 +98,7 @@ export class Kernels implements IKernels {
           } else {
             void processMsg(msg);
           }
-        }
+        },
       );
 
       const removeClient = () => {

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -163,30 +163,30 @@ export interface IWorkerKernel {
   initialize(options: IWorkerKernel.IOptions): Promise<void>;
   execute(
     content: KernelMessage.IExecuteRequestMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<KernelMessage.IExecuteReplyMsg['content']>;
   complete(
     content: KernelMessage.ICompleteRequestMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<KernelMessage.ICompleteReplyMsg['content']>;
   inspect(
     content: KernelMessage.IInspectRequestMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<KernelMessage.IInspectReplyMsg['content']>;
   isComplete(
     content: KernelMessage.IIsCompleteRequestMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<KernelMessage.IIsCompleteReplyMsg['content']>;
   commInfo(
     content: KernelMessage.ICommInfoRequestMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<KernelMessage.ICommInfoReplyMsg['content']>;
   commOpen(content: KernelMessage.ICommOpenMsg, parent: any): Promise<void>;
   commMsg(content: KernelMessage.ICommMsgMsg, parent: any): Promise<void>;
   commClose(content: KernelMessage.ICommCloseMsg, parent: any): Promise<void>;
   inputReply(
     content: KernelMessage.IInputReplyMsg['content'],
-    parent: any
+    parent: any,
   ): Promise<void>;
 }
 

--- a/packages/licenses/src/licenses.ts
+++ b/packages/licenses/src/licenses.ts
@@ -108,7 +108,7 @@ export class Licenses implements ILicenses {
         this.labExtensionsUrl,
         ext.name,
         'static',
-        THIRD_PARTY_LICENSES
+        THIRD_PARTY_LICENSES,
       );
       const response = await fetch(url);
       bundles[ext.name] = await response.json();

--- a/packages/localforage/src/memory.ts
+++ b/packages/localforage/src/memory.ts
@@ -9,7 +9,7 @@ import memoryStorageDriver from 'localforage-memoryStorageDriver';
  * Ensure a localforage singleton has had the memory storage driver installed
  */
 export async function ensureMemoryStorage(
-  theLocalforage: typeof localforage
+  theLocalforage: typeof localforage,
 ): Promise<void> {
   return await theLocalforage.defineDriver(memoryStorageDriver);
 }

--- a/packages/localforage/src/tokens.ts
+++ b/packages/localforage/src/tokens.ts
@@ -9,7 +9,7 @@ import { Token } from '@lumino/coreutils';
  * The token for the localforage singleton.
  */
 export const ILocalForage = new Token<ILocalForage>(
-  '@jupyterlite/localforge:ILocalForage'
+  '@jupyterlite/localforge:ILocalForage',
 );
 
 /**

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -39,7 +39,7 @@ const buttons: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    tracker: IConsoleTracker | null
+    tracker: IConsoleTracker | null,
   ) => {
     if (!tracker) {
       return;
@@ -131,7 +131,7 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     tracker: IConsoleTracker | null,
-    themeManager: IThemeManager | null
+    themeManager: IThemeManager | null,
   ) => {
     if (!tracker) {
       return;

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -56,7 +56,7 @@ const localforageMemoryPlugin: JupyterLiteServerPlugin<void> = {
   activate: async (app: JupyterLiteServer, forage: ILocalForage) => {
     if (JSON.parse(PageConfig.getOption('enableMemoryStorage') || 'false')) {
       console.warn(
-        'Memory storage fallback enabled: contents and settings may not be saved'
+        'Memory storage fallback enabled: contents and settings may not be saved',
       );
       await ensureMemoryStorage(forage.localforage);
     }
@@ -74,7 +74,7 @@ const contentsPlugin: JupyterLiteServerPlugin<IContents> = {
   activate: (app: JupyterLiteServer, forage: ILocalForage) => {
     const storageName = PageConfig.getOption('contentsStorageName');
     const storageDrivers = JSON.parse(
-      PageConfig.getOption('contentsStorageDrivers') || 'null'
+      PageConfig.getOption('contentsStorageDrivers') || 'null',
     );
     const { localforage } = forage;
     const contents = new Contents({
@@ -101,7 +101,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, filename: string) => {
         const res = await contents.listCheckpoints(filename);
         return new Response(JSON.stringify(res));
-      }
+      },
     );
 
     // POST /api/contents/{path}/checkpoints/{checkpoint_id} - Restore a file to a particular checkpointed state
@@ -110,7 +110,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, filename: string, checkpoint: string) => {
         const res = await contents.restoreCheckpoint(filename, checkpoint);
         return new Response(JSON.stringify(res), { status: 204 });
-      }
+      },
     );
 
     // POST /api/contents/{path}/checkpoints - Create a new checkpoint for a file
@@ -119,7 +119,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, filename: string) => {
         const res = await contents.createCheckpoint(filename);
         return new Response(JSON.stringify(res), { status: 201 });
-      }
+      },
     );
 
     // DELETE /api/contents/{path}/checkpoints/{checkpoint_id} - Delete a checkpoint
@@ -128,7 +128,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, filename: string, checkpoint: string) => {
         const res = await contents.deleteCheckpoint(filename, checkpoint);
         return new Response(JSON.stringify(res), { status: 204 });
-      }
+      },
     );
 
     // GET /api/contents/{path} - Get contents of file or directory
@@ -143,7 +143,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
           return new Response(null, { status: 404 });
         }
         return new Response(JSON.stringify(nb));
-      }
+      },
     );
 
     // POST /api/contents/{path} - Create a new file in the specified path
@@ -170,7 +170,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
         filename = filename[0] === '/' ? filename.slice(1) : filename;
         const nb = await contents.rename(filename, newPath);
         return new Response(JSON.stringify(nb));
-      }
+      },
     );
 
     // PUT /api/contents/{path} - Save or upload a file
@@ -180,7 +180,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
         const body = req.body;
         const nb = await contents.save(filename, body);
         return new Response(JSON.stringify(nb));
-      }
+      },
     );
 
     // DELETE /api/contents/{path} - Delete a file in the given path
@@ -189,7 +189,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, filename: string) => {
         await contents.delete(filename);
         return new Response(null, { status: 204 });
-      }
+      },
     );
   },
 };
@@ -216,7 +216,7 @@ const emscriptenFileSystemPlugin: JupyterLiteServerPlugin<IBroadcastChannelWrapp
   provides: IBroadcastChannelWrapper,
   activate: (
     app: JupyterLiteServer,
-    serviceWorkerRegistrationWrapper?: IServiceWorkerManager
+    serviceWorkerRegistrationWrapper?: IServiceWorkerManager,
   ): IBroadcastChannelWrapper => {
     const { contents } = app.serviceManager;
     const broadcaster = new BroadcastChannelWrapper({ contents });
@@ -286,7 +286,7 @@ const kernelsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, kernelId: string) => {
         const res = await kernels.restart(kernelId);
         return new Response(JSON.stringify(res));
-      }
+      },
     );
 
     // DELETE /api/kernels/{kernel_id} - Kill a kernel and delete the kernel id
@@ -295,7 +295,7 @@ const kernelsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, kernelId: string) => {
         const res = await kernels.shutdown(kernelId);
         return new Response(JSON.stringify(res), { status: 204 });
-      }
+      },
     );
   },
 };
@@ -453,7 +453,7 @@ const sessionsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, id: string) => {
         await sessions.shutdown(id);
         return new Response(null, { status: 204 });
-      }
+      },
     );
 
     // POST /api/sessions - Create a new session or return an existing session if a session of the same name already exists
@@ -476,7 +476,7 @@ const settingsPlugin: JupyterLiteServerPlugin<ISettings> = {
   activate: (app: JupyterLiteServer, forage: ILocalForage) => {
     const storageName = PageConfig.getOption('settingsStorageName');
     const storageDrivers = JSON.parse(
-      PageConfig.getOption('settingsStorageDrivers') || 'null'
+      PageConfig.getOption('settingsStorageDrivers') || 'null',
     );
     const { localforage } = forage;
     const settings = new Settings({ storageName, storageDrivers, localforage });
@@ -531,7 +531,7 @@ const translationPlugin: JupyterLiteServerPlugin<ITranslation> = {
       async (req: Router.IRequest, locale: string) => {
         const data = await translation.get(locale || 'all');
         return new Response(JSON.stringify(data));
-      }
+      },
     );
 
     return translation;
@@ -551,7 +551,7 @@ const translationRoutesPlugin: JupyterLiteServerPlugin<void> = {
       async (req: Router.IRequest, locale: string) => {
         const data = await translation.get(locale || 'all');
         return new Response(JSON.stringify(data));
-      }
+      },
     );
   },
 };

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -106,7 +106,7 @@ export class JupyterLiteServer extends Application<never> {
    */
   async fetch(
     req: RequestInfo,
-    init?: RequestInit | null | undefined
+    init?: RequestInit | null | undefined,
   ): Promise<Response> {
     if (!(req instanceof Request)) {
       throw Error('Request info is not a Request');

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -93,7 +93,7 @@ export class Router {
           body,
           query: Object.fromEntries(url.searchParams),
         },
-        ...matches
+        ...matches,
       );
     }
 
@@ -110,7 +110,7 @@ export class Router {
   private _add(
     method: Router.Method,
     pattern: string | RegExp,
-    callback: Router.Callback
+    callback: Router.Callback,
   ): void {
     if (typeof pattern === 'string') {
       pattern = new RegExp(pattern);

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -53,7 +53,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       } catch (err: any) {
         console.warn(err);
         console.warn(
-          `JupyterLite ServiceWorker registration unexpectedly failed: ${err}`
+          `JupyterLite ServiceWorker registration unexpectedly failed: ${err}`,
         );
       }
     }
@@ -74,7 +74,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
 
   private _registration: ServiceWorkerRegistration | null = null;
   private _registrationChanged = new Signal<this, ServiceWorkerRegistration | null>(
-    this
+    this,
   );
   private _ready = new PromiseDelegate<void>();
 }

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -8,7 +8,7 @@ import SW_URL from './service-worker?text';
  * The token for the ServiceWorker.
  */
 export const IServiceWorkerManager = new Token<IServiceWorkerManager>(
-  '@jupyterlite/server-extension:IServiceWorkerManager'
+  '@jupyterlite/server-extension:IServiceWorkerManager',
 );
 
 /**

--- a/packages/session/src/sessions.ts
+++ b/packages/session/src/sessions.ts
@@ -69,7 +69,7 @@ export class Sessions implements ISessions {
       // Kernel id takes precedence over name.
       if (kernel.id) {
         const session = this._sessions.find(
-          (session) => session.kernel?.id === kernel?.id
+          (session) => session.kernel?.id === kernel?.id,
         );
         if (session) {
           patched.kernel = session.kernel;

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -116,7 +116,7 @@ export class Settings implements ISettings {
           raw,
           settings: json5.parse(raw),
         };
-      })
+      }),
     );
     return { settings };
   }
@@ -150,7 +150,7 @@ export class Settings implements ISettings {
       packageName,
       'schemas',
       packageName,
-      `${schemaName}.json`
+      `${schemaName}.json`,
     );
     const packageUrl = URLExt.join(labExtensionsUrl, packageName, 'package.json');
     const schema = await (await fetch(schemaUrl)).json();
@@ -192,7 +192,7 @@ export namespace Settings {
  */
 namespace Private {
   const _overrides: Record<string, IPlugin['schema']['default']> = JSON.parse(
-    PageConfig.getOption('settingsOverrides') || '{}'
+    PageConfig.getOption('settingsOverrides') || '{}',
   );
 
   /**

--- a/packages/translation/src/tokens.ts
+++ b/packages/translation/src/tokens.ts
@@ -4,7 +4,7 @@ import { JSONObject, Token } from '@lumino/coreutils';
  * The token for the settings service.
  */
 export const ITranslation = new Token<ITranslation>(
-  '@jupyterlite/translation:ITranslation'
+  '@jupyterlite/translation:ITranslation',
 );
 
 /**

--- a/packages/translation/src/translation.ts
+++ b/packages/translation/src/translation.ts
@@ -19,7 +19,7 @@ export class Translation {
   async get(locale: string): Promise<JSONObject> {
     const apiURL = URLExt.join(
       PageConfig.getBaseUrl(),
-      `api/translations/${locale}.json`
+      `api/translations/${locale}.json`,
     );
     try {
       const response = await fetch(apiURL);

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -218,7 +218,7 @@ async function serve(request, response) {
       new Date().toISOString(),
       code,
       method,
-      url
+      url,
     );
     response.writeHead(code, { 'Content-Type': mime });
     response.end(content, 'utf-8');

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -54,7 +54,7 @@ test.describe('Contents Tests', () => {
     await page.filebrowser.refresh();
     await page.filebrowser.open(file);
     expect(
-      await page.filebrowser.isFileListedInBrowser(path.basename(file))
+      await page.filebrowser.isFileListedInBrowser(path.basename(file)),
     ).toBeTruthy();
   });
 
@@ -78,7 +78,7 @@ test.describe('Contents Tests', () => {
 
     await page.reload();
     expect(
-      await page.filebrowser.isFileListedInBrowser(path.basename(name))
+      await page.filebrowser.isFileListedInBrowser(path.basename(name)),
     ).toBeTruthy();
 
     await page.notebook.open(name);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Actually we could leave the `trailingComma` setting set to `es5` for now and see how it goes. And remove it later if we want to.

Closes https://github.com/jupyterlite/jupyterlite/issues/1138

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move the prettier config to `package.json`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
