### PR TITLE
Remove dependency on `jupyterlite-pyodide-kernel`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,16 @@ jlpm build:test
 jlpm test
 ```
 
+#### Installing other kernels
+
+By default this repository only includes the JavaScript kernel.
+
+If you would like to setup a local environment with an additional, you can install
+explicitely, before running the `jupyter lite build` command. For example:
+
+- To install the Pyodide kernel: `pip install jupyterlite-pyodide-kernel`
+- To install the Xeus Python kernel: `pip install jupyterlite-xeus-python`
+
 ### UI Tests
 
 `jupyterlite` uses the

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,6 +37,18 @@ Notebook 7:
 - `/retro/notebooks` -> `/notebooks`
 - `/retro/tree` -> `/tree`
 
+### `jupyterlite` metapackage
+
+In version `0.1.x`, installing the `jupyterlite` metapackage would automatically install
+the Pyodide kernel by default, since the `jupyterlite` metapackage would depend on
+`jupyterlite-pyodide-kernel`.
+
+In version `0.2.0` this is not the case anymore. You will need to install the
+`jupyterlite-pyodide-kernel` explicitely in your build environment alongside
+`jupyterlite-core` (the package providing the `jupyter-lite` CLI).
+
+See [the documentation for adding kernels](./howto/configure/kernels.md) to learn more.
+
 ### Service Worker
 
 The service worker file name has been changed. In `0.1.0`, it was

--- a/docs/quickstart/deploy.md
+++ b/docs/quickstart/deploy.md
@@ -4,8 +4,8 @@
 If you first want to get familiar with the interface, check out the [User Guide](./using.md).
 ```
 
-JupyterLite can easily be deployed on [GitHub Pages], using the `jupyterlite` CLI to add
-content and extensions.
+JupyterLite can easily be deployed on [GitHub Pages], using the `jupyter-lite` CLI to
+add content and extensions.
 
 ```{note}
 Deploying to GitHub Pages requires a Github account.

--- a/docs/quickstart/standalone.md
+++ b/docs/quickstart/standalone.md
@@ -133,7 +133,7 @@ however, that `http-server` does not support the `application/wasm` MIME type.
 
 ## Using a release archive
 
-As an alternative to using the `jupyterlite` CLI, you can also download a release
+As an alternative to using the `jupyter-lite` CLI, you can also download a release
 archive from the [GitHub Releases][releases] page.
 
 Download it an extract it, then use one of the approaches mentioned above to start the

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 dependencies = [
     "jupyterlite-core >=0.2.0a4",
-    "jupyterlite-pyodide-kernel >=0.1.2",
     "jupyterlite-javascript-kernel",
 ]
 keywords = [


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlite/jupyterlite/pull/1142

`jupyterlite-pyodide-kernel` was initially added to the `jupyterlite` metapackage just to ease migration from the `0.1.0` pre-releases to the final `0.1.0` release, and to avoid breaking existing workflows.

- [x] Drop dependency on `jupyterlite-pyodide-kernel` in the `jupyterlite` metapackage
- [x] Document this change in the migration guide and the documentation
- [x] Update contributing guide to mention how to install other kernels

## Code changes

In the `jupyterlite` package, remove the dependency on `jupyterlite-pyodide-kernel`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Site deployers will need to explicitely install `jupyterlite-pyodide-kernel` if they want that kernel, just like `jupyterlite-xeus-python`.

This is documented in the migration guide:

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/a00ccd5e-f39e-4042-ae60-c5aaf25be71e)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Changes default package install for the `jupyterlite` metapackage.

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
