### PR TITLE
Allow config worker url in ServiceWorkerManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,6 @@ app/test/data
 # do not include kernels such as Pyodide
 app/kernels
 app/extensions
-app/service-worker-*.js
 app/service-worker.js
 
 # generated html

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ app/test/data
 app/kernels
 app/extensions
 app/service-worker-*.js
+app/service-worker.js
 
 # generated html
 app/index.app.template.html

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -259,7 +259,7 @@ class CompileSchemasPlugin {
 class ServiceWorkerPlugin {
   apply(compiler) {
     compiler.hooks.done.tapAsync('ServiceWorkerPlugin', (compilation, callback) => {
-      const worker = glob.sync(`${topLevelBuild}/service-worker-*.js`)[0];
+      const worker = glob.sync(`${topLevelBuild}/service-worker.js`)[0];
       fs.copyFileSync(worker, path.resolve(path.basename(worker)));
       callback();
     });

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -313,7 +313,7 @@ module.exports = [
           resourceQuery: /text/,
           type: 'asset/resource',
           generator: {
-            filename: '[name]-[contenthash:7][ext]',
+            filename: '[name][ext]',
           },
         },
       ],

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,6 +14,10 @@ JupyterLab 4 comes with a couple of breaking changes which likely affect extensi
 If you were using JupyterLab 3 extensions in your JupyterLite deployment, you might have
 to update to a newer version of the extension that is compatible with JupyterLab 4.
 
+### Service Worker
+
+The service worker file name has been changed. In `0.1.0`, it was `service-worker-[hash].js` with the `hash` computed by webpack, in `0.2.0` the hash is removed and the new file name is `service-worker.js`.
+
 ## `0.1.0b19` to `0.1.0b20`
 
 ### `jupyterlite-core`

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -6,8 +6,10 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IServiceWorkerManager, WORKER_NAME } from './tokens';
 
 export class ServiceWorkerManager implements IServiceWorkerManager {
-  constructor() {
-    void this.initialize().catch(console.warn);
+  constructor(options?: IServiceWorkerManager.IOptions) {
+    const workerUrl =
+      options?.workerUrl ?? URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
+    void this.initialize(workerUrl).catch(console.warn);
   }
 
   /**
@@ -31,9 +33,9 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     return this._ready.promise;
   }
 
-  private async initialize(): Promise<void> {
+  private async initialize(workerUrl: string): Promise<void> {
     const { serviceWorker } = navigator;
-    const workerUrl = URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
+
     let registration: ServiceWorkerRegistration | null = null;
 
     if (!serviceWorker) {

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -2,6 +2,8 @@ import { Token } from '@lumino/coreutils';
 
 import { ISignal } from '@lumino/signaling';
 
+import SW_URL from './service-worker?text';
+
 /**
  * The token for the ServiceWorker.
  */
@@ -47,4 +49,4 @@ export namespace IServiceWorkerManager {
   }
 }
 
-export const WORKER_NAME = 'service-worker.js';
+export const WORKER_NAME = `${SW_URL}`.split('/').slice(-1)[0];

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -2,8 +2,6 @@ import { Token } from '@lumino/coreutils';
 
 import { ISignal } from '@lumino/signaling';
 
-import SW_URL from './service-worker?text';
-
 /**
  * The token for the ServiceWorker.
  */
@@ -42,8 +40,11 @@ export namespace IServiceWorkerManager {
    * An options object for initializing a worker manager.
    */
   export interface IOptions {
+    /**
+     * URL to load the worker file. Default to "{baseURL}/service-worker.js"
+     */
     workerUrl?: string;
   }
 }
 
-export const WORKER_NAME = `${SW_URL}`.split('/').slice(-1)[0];
+export const WORKER_NAME = 'service-worker.js';

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -34,4 +34,16 @@ export interface IServiceWorkerManager {
   ready: Promise<void>;
 }
 
+/**
+ * A namespace for `ServiceWorkerManager` class.
+ */
+export namespace IServiceWorkerManager {
+  /**
+   * An options object for initializing a worker manager.
+   */
+  export interface IOptions {
+    workerUrl?: string;
+  }
+}
+
 export const WORKER_NAME = `${SW_URL}`.split('/').slice(-1)[0];


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Closes #1158 

## Code changes

Allow users to provide service worker URL in `ServiceWorkerManager` constructor

## User-facing changes

N/A

## Backwards-incompatible changes

The service worker file name has been changed. In `0.1.0`, it was `service-worker-[hash].js` with the `hash` computed by webpack, in `0.2.0` the hash is removed and the new file name is `service-worker.js`.