### PR TITLE
JupyterLab 4 / Notebook 7 update fixes

### DIFF
--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -268,7 +268,6 @@
       "@jupyterlab/apputils-extension:resolver",
       "@jupyterlab/apputils-extension:running-sessions-status",
       "@jupyterlab/apputils-extension:splash",
-      "@jupyterlab/apputils-extension:utilityCommands",
       "@jupyterlab/apputils-extension:workspaces",
       "@jupyterlab/console-extension:kernel-status",
       "@jupyterlab/docmanager-extension:download",

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "resolutions": {
     "@jupyter-notebook/application": "~7.0.4",
+    "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
+    "@jupyter-notebook/docmanager-extension": "~7.0.4",
+    "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyterlab/application": "~4.0.6",
     "@jupyterlab/application-extension": "~4.0.6",
     "@jupyterlab/apputils": "~4.1.6",
@@ -102,6 +106,11 @@
     "yjs": "^13.6.7"
   },
   "dependencies": {
+    "@jupyter-notebook/application": "~7.0.4",
+    "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
+    "@jupyter-notebook/docmanager-extension": "~7.0.4",
+    "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyterlab/application": "~4.0.6",
     "@jupyterlab/application-extension": "~4.0.6",
     "@jupyterlab/apputils-extension": "~4.0.6",
@@ -187,6 +196,7 @@
       "@jupyterlab/ui-components-extension",
       "@jupyterlab/vega5-extension",
       "@jupyter-notebook/application-extension",
+      "@jupyter-notebook/console-extension",
       "@jupyter-notebook/docmanager-extension",
       "@jupyter-notebook/help-extension",
       "@jupyterlite/application-extension",

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -268,7 +268,6 @@
       "@jupyterlab/apputils-extension:resolver",
       "@jupyterlab/apputils-extension:running-sessions-status",
       "@jupyterlab/apputils-extension:splash",
-      "@jupyterlab/apputils-extension:utilityCommands",
       "@jupyterlab/apputils-extension:workspaces",
       "@jupyterlab/console-extension:kernel-status",
       "@jupyterlab/docmanager-extension:download",

--- a/app/jupyter-lite.json
+++ b/app/jupyter-lite.json
@@ -4,7 +4,6 @@
     "appName": "JupyterLite",
     "appVersion": "0.2.0-alpha.1",
     "baseUrl": "./",
-    "appUrl": "/lab",
     "defaultKernelName": "python",
     "faviconUrl": "./lab/favicon.ico",
     "federated_extensions": [],

--- a/app/jupyter-lite.json
+++ b/app/jupyter-lite.json
@@ -4,7 +4,7 @@
     "appName": "JupyterLite",
     "appVersion": "0.2.0-alpha.1",
     "baseUrl": "./",
-    "appUrl": "./lab",
+    "appUrl": "/lab",
     "defaultKernelName": "python",
     "faviconUrl": "./lab/favicon.ico",
     "federated_extensions": [],

--- a/app/lab/jupyter-lite.json
+++ b/app/lab/jupyter-lite.json
@@ -1,6 +1,7 @@
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
+    "appUrl": "/lab",
     "settingsUrl": "../build/schemas",
     "themesUrl": "./build/themes"
   }

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -281,7 +281,6 @@
       "@jupyterlab/apputils-extension:resolver",
       "@jupyterlab/apputils-extension:running-sessions-status",
       "@jupyterlab/apputils-extension:splash",
-      "@jupyterlab/apputils-extension:utilityCommands",
       "@jupyterlab/apputils-extension:workspaces",
       "@jupyterlab/console-extension:kernel-status",
       "@jupyterlab/docmanager-extension:download",

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -5,6 +5,7 @@
   "resolutions": {
     "@jupyter-notebook/application": "~7.0.4",
     "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
     "@jupyter-notebook/docmanager-extension": "~7.0.4",
     "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyter-notebook/notebook-extension": "~7.0.4",
@@ -109,6 +110,7 @@
   "dependencies": {
     "@jupyter-notebook/application": "~7.0.4",
     "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
     "@jupyter-notebook/docmanager-extension": "~7.0.4",
     "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyter-notebook/notebook-extension": "~7.0.4",
@@ -199,6 +201,7 @@
       "@jupyterlab/ui-components-extension",
       "@jupyterlab/vega5-extension",
       "@jupyter-notebook/application-extension",
+      "@jupyter-notebook/console-extension",
       "@jupyter-notebook/docmanager-extension",
       "@jupyter-notebook/help-extension",
       "@jupyter-notebook/notebook-extension",

--- a/app/repl/package.json
+++ b/app/repl/package.json
@@ -219,7 +219,6 @@
       "@jupyterlab/apputils-extension:splash",
       "@jupyterlab/apputils-extension:toggle-header",
       "@jupyterlab/apputils-extension:toolbar-registry",
-      "@jupyterlab/apputils-extension:utilityCommands",
       "@jupyterlab/apputils-extension:workspaces",
       "@jupyterlab/console-extension:kernel-status",
       "@jupyterlab/docmanager-extension:download",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -242,7 +242,6 @@
       "@jupyterlab/apputils-extension:resolver",
       "@jupyterlab/apputils-extension:running-sessions-status",
       "@jupyterlab/apputils-extension:splash",
-      "@jupyterlab/apputils-extension:utilityCommands",
       "@jupyterlab/apputils-extension:workspaces",
       "@jupyterlab/console-extension:kernel-status",
       "@jupyterlab/docmanager-extension:download",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -5,6 +5,7 @@
   "resolutions": {
     "@jupyter-notebook/application": "~7.0.4",
     "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
     "@jupyter-notebook/docmanager-extension": "~7.0.4",
     "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyter-notebook/tree-extension": "~7.0.4",
@@ -91,6 +92,7 @@
   "dependencies": {
     "@jupyter-notebook/application": "~7.0.4",
     "@jupyter-notebook/application-extension": "~7.0.4",
+    "@jupyter-notebook/console-extension": "~7.0.4",
     "@jupyter-notebook/docmanager-extension": "~7.0.4",
     "@jupyter-notebook/help-extension": "~7.0.4",
     "@jupyter-notebook/tree-extension": "~7.0.4",
@@ -161,6 +163,7 @@
       "@jupyterlab/ui-components-extension",
       "@jupyterlab/vega5-extension",
       "@jupyter-notebook/application-extension",
+      "@jupyter-notebook/console-extension",
       "@jupyter-notebook/docmanager-extension",
       "@jupyter-notebook/help-extension",
       "@jupyter-notebook/tree-extension",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -64,7 +64,8 @@
     "access": "public"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   },
   "styleModule": "style/index.js"
 }

--- a/packages/application-extension/schema/share-file.json
+++ b/packages/application-extension/schema/share-file.json
@@ -1,0 +1,16 @@
+{
+  "title": "File Browser Download",
+  "description": "File Browser Download settings.",
+  "jupyter.lab.menus": {
+    "context": [
+      {
+        "command": "filebrowser:download",
+        "selector": ".jp-DirListing-item[data-isdir=\"false\"]",
+        "rank": 9
+      }
+    ]
+  },
+  "properties": {},
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -250,13 +250,12 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           if (!widget) {
             return;
           }
-          const selected = widget.selectedItems();
-          for (const item of selected) {
-            if (item.type === 'directory') {
-              continue;
+          const selected = Array.from(widget.selectedItems());
+          selected.forEach(async (item) => {
+            if (item.type !== 'directory') {
+              await downloadContent(item.path, item.name);
             }
-            await downloadContent(item.path, item.name);
-          }
+          });
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),
         label: trans.__('Download'),

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -26,7 +26,7 @@ import { downloadIcon, linkIcon } from '@jupyterlab/ui-components';
 
 import { liteIcon, liteWordmark } from '@jupyterlite/ui-components';
 
-import { filter, toArray } from '@lumino/algorithm';
+import { filter } from '@lumino/algorithm';
 
 import { Widget } from '@lumino/widgets';
 
@@ -252,13 +252,13 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           if (!widget) {
             return;
           }
-          const selected = toArray(widget.selectedItems());
-          selected.forEach(async (item: Contents.IModel) => {
+          const selected = widget.selectedItems();
+          for (const item of selected) {
             if (item.type === 'directory') {
-              return;
+              continue;
             }
             await downloadContent(item.path, item.name);
-          });
+          };
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),
         label: trans.__('Download'),
@@ -429,7 +429,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
         }
 
         const url = new URL(URLExt.join(baseUrl, appUrl, 'index.html'));
-        const models = toArray(
+        const models = Array.from(
           filter(widget.selectedItems(), (item) => item.type !== 'directory'),
         );
         models.forEach((model) => {
@@ -442,7 +442,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
       },
       isVisible: () =>
         !!tracker.currentWidget &&
-        toArray(tracker.currentWidget.selectedItems()).length >= 1,
+        Array.from(tracker.currentWidget.selectedItems()).length >= 1,
       icon: linkIcon.bindprops({ stylesheet: 'menuItem' }),
       label: trans.__('Copy Shareable Link'),
     });

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -18,8 +18,6 @@ import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
-import { Contents } from '@jupyterlab/services';
-
 import { ITranslator } from '@jupyterlab/translation';
 
 import { downloadIcon, linkIcon } from '@jupyterlab/ui-components';
@@ -258,7 +256,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
               continue;
             }
             await downloadContent(item.path, item.name);
-          };
+          }
         },
         icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),
         label: trans.__('Download'),

--- a/packages/notebook-application-extension/src/index.ts
+++ b/packages/notebook-application-extension/src/index.ts
@@ -63,7 +63,6 @@ const pathOpener: JupyterFrontEndPlugin<INotebookPathOpener> = {
   autoStart: true,
   provides: INotebookPathOpener,
   activate: (app: JupyterFrontEnd): INotebookPathOpener => {
-    console.log('using the JupyterLite path opener');
     return {
       open(options: INotebookPathOpener.IOpenOptions): Window | null {
         const { prefix, path, searchParams, target, features } = options;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,6 +2106,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyter-notebook/console-extension@npm:~7.0.4":
+  version: 7.0.4
+  resolution: "@jupyter-notebook/console-extension@npm:7.0.4"
+  dependencies:
+    "@jupyter-notebook/application": ^7.0.4
+    "@jupyterlab/application": ^4.0.6
+    "@jupyterlab/console": ^4.0.6
+    "@jupyterlab/coreutils": ^6.0.6
+    "@lumino/algorithm": ^2.0.1
+  checksum: e604cc1092731772608d4bd3166d253a16662dfc930735e9e2537e1c7ec596168e97984bedef2acc942cde6e849713361d3a8654fb6855d7c4a4303872513eaf
+  languageName: node
+  linkType: hard
+
 "@jupyter-notebook/docmanager-extension@npm:~7.0.4":
   version: 7.0.4
   resolution: "@jupyter-notebook/docmanager-extension@npm:7.0.4"
@@ -3994,6 +4007,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlite/app-edit@workspace:app/edit"
   dependencies:
+    "@jupyter-notebook/application": ~7.0.4
+    "@jupyter-notebook/application-extension": ~7.0.4
+    "@jupyter-notebook/console-extension": ~7.0.4
+    "@jupyter-notebook/docmanager-extension": ~7.0.4
+    "@jupyter-notebook/help-extension": ~7.0.4
     "@jupyterlab/application": ~4.0.6
     "@jupyterlab/application-extension": ~4.0.6
     "@jupyterlab/apputils-extension": ~4.0.6
@@ -4115,6 +4133,7 @@ __metadata:
   dependencies:
     "@jupyter-notebook/application": ~7.0.4
     "@jupyter-notebook/application-extension": ~7.0.4
+    "@jupyter-notebook/console-extension": ~7.0.4
     "@jupyter-notebook/docmanager-extension": ~7.0.4
     "@jupyter-notebook/help-extension": ~7.0.4
     "@jupyter-notebook/notebook-extension": ~7.0.4
@@ -4218,6 +4237,7 @@ __metadata:
   dependencies:
     "@jupyter-notebook/application": ~7.0.4
     "@jupyter-notebook/application-extension": ~7.0.4
+    "@jupyter-notebook/console-extension": ~7.0.4
     "@jupyter-notebook/docmanager-extension": ~7.0.4
     "@jupyter-notebook/help-extension": ~7.0.4
     "@jupyter-notebook/tree-extension": ~7.0.4


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Addresses some items from https://github.com/jupyterlite/jupyterlite/issues/1141.

Fixes https://github.com/jupyterlite/jupyterlite/issues/398.
Fixes https://github.com/jupyterlite/jupyterlite/issues/509.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Update use of the Lumino `toArray`
- [x] Fix copy shareable link for the lab app
- [x] Fix missing download context menu entry in the file browser (~+ update UI tests to use the context menu?~)
- [x] Check keyboard shortcuts: https://github.com/jupyterlite/jupyterlite/issues/509
- [x] Fix opening consoles in Notebook 7

## User-facing changes

Might fix some user facing issues reported in #1141.

- Show keyboard shortcuts in notebook pages and `repl`:

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/3dc6eca0-d0f6-4215-b85a-662c88d2a89d)


## Backwards-incompatible changes

None
