### PR TITLE
Add Jupyter Notebook 7 to the migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,6 +14,25 @@ JupyterLab 4 comes with a couple of breaking changes which likely affect extensi
 If you were using JupyterLab 3 extensions in your JupyterLite deployment, you might have
 to update to a newer version of the extension that is compatible with JupyterLab 4.
 
+### Jupyter Notebook 7
+
+In JupyterLite 0.1.x the Notebook interface was provided by
+[RetroLab](https://github.com/jupyterlab/retrolab).
+
+In JupyterLite 0.2.0, the Notebook interface is now provided by
+[Jupyter Notebook 7](https://github.com/jupyter/notebook)
+
+Jupyter Notebook 7 is the successor of RetroLab and the Classic Notebook, based on
+JupyterLab components.
+
+This means the URL have also changed to be aligned with the ones provided by Jupyter
+Notebook 7:
+
+- `/retro/consoles` -> `/consoles`
+- `/retro/edit` -> `/edit`
+- `/retro/notebooks` -> `/notebooks`
+- `/retro/tree` -> `/tree`
+
 ### Service Worker
 
 The service worker file name has been changed. In `0.1.0`, it was


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to #1019.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Mention the update to Notebook 7 in the migration guide, and its new endpoints.

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/9c9f2061-2af2-4e12-8226-611e8394fa48)


## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
