### PR TITLE
Fix file indexing that caused content duplication

### DIFF
--- a/py/jupyterlite-core/jupyterlite_core/addons/contents.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/contents.py
@@ -164,6 +164,10 @@ class ContentsAddon(BaseAddon):
         fm = FileContentsManager(root_dir=str(self.output_files_dir), parent=self)
 
         listing_path = str(output_file_dir.relative_to(self.output_files_dir))
+        # normalize the root folder to avoid adding a `./` prefix to the
+        # path field in the generated listing
+        if listing_path == ".":
+            listing_path = ""
 
         try:
             listing = fm.get(listing_path)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Partial backport of https://github.com/jupyterlite/jupyterlite/pull/1176 to `0.1.x`.

See https://github.com/jupyterlite/jupyterlite/issues/1141#issuecomment-1739346299 for more information.

## Code changes

Normalize the listing path to avoid creating an index with `./` as prefix for top-level `path` fields.


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should fix duplicated files issues on save as reported in https://github.com/jupyterlite/jupyterlite/issues/1141

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
