### PR TITLE
Fix deprecation warning in the Altair example

### DIFF
--- a/examples/pyodide/altair.ipynb
+++ b/examples/pyodide/altair.ipynb
@@ -1,208 +1,211 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Altair in `JupyterLite`\n",
-        "\n",
-        "**Altair** is a declarative statistical visualization library for Python.\n",
-        "\n",
-        "Most of the examples below are from: https://altair-viz.github.io/gallery"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Import the dependencies:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -q altair"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Simple Bar Chart"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import altair as alt\n",
-        "import pandas as pd\n",
-        "\n",
-        "source = pd.DataFrame(\n",
-        "    {\n",
-        "        \"a\": [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n",
-        "        \"b\": [28, 55, 43, 91, 81, 53, 19, 87, 52],\n",
-        "    }\n",
-        ")\n",
-        "\n",
-        "alt.Chart(source).mark_bar().encode(x=\"a\", y=\"b\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Simple Heatmap"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import altair as alt\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "\n",
-        "# Compute x^2 + y^2 across a 2D grid\n",
-        "x, y = np.meshgrid(range(-5, 5), range(-5, 5))\n",
-        "z = x**2 + y**2\n",
-        "\n",
-        "# Convert this grid to columnar data expected by Altair\n",
-        "source = pd.DataFrame({\"x\": x.ravel(), \"y\": y.ravel(), \"z\": z.ravel()})\n",
-        "\n",
-        "alt.Chart(source).mark_rect().encode(x=\"x:O\", y=\"y:O\", color=\"z:Q\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Install the Vega Dataset"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -q vega-datasets"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Interactive Average"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import altair as alt\n",
-        "from vega_datasets import data\n",
-        "\n",
-        "source = data.seattle_weather()\n",
-        "brush = alt.selection_interval(encodings=['x'])\n",
-        "\n",
-        "bars = alt.Chart().mark_bar().encode(\n",
-        "    x='month(date):O',\n",
-        "    y='mean(precipitation):Q',\n",
-        "    opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),\n",
-        ").add_params(\n",
-        "    brush\n",
-        ")\n",
-        "\n",
-        "line = alt.Chart().mark_rule(color='firebrick').encode(\n",
-        "    y='mean(precipitation):Q',\n",
-        "    size=alt.SizeValue(3)\n",
-        ").transform_filter(\n",
-        "    brush\n",
-        ")\n",
-        "\n",
-        "alt.layer(bars, line, data=source)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Locations of US Airports"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import altair as alt\n",
-        "from vega_datasets import data\n",
-        "\n",
-        "airports = data.airports.url\n",
-        "states = alt.topo_feature(data.us_10m.url, feature=\"states\")\n",
-        "\n",
-        "# US states background\n",
-        "background = (\n",
-        "    alt.Chart(states)\n",
-        "    .mark_geoshape(fill=\"lightgray\", stroke=\"white\")\n",
-        "    .properties(width=500, height=300)\n",
-        "    .project(\"albersUsa\")\n",
-        ")\n",
-        "\n",
-        "# airport positions on background\n",
-        "points = (\n",
-        "    alt.Chart(airports)\n",
-        "    .transform_aggregate(\n",
-        "        latitude=\"mean(latitude)\",\n",
-        "        longitude=\"mean(longitude)\",\n",
-        "        count=\"count()\",\n",
-        "        groupby=[\"state\"],\n",
-        "    )\n",
-        "    .mark_circle()\n",
-        "    .encode(\n",
-        "        longitude=\"longitude:Q\",\n",
-        "        latitude=\"latitude:Q\",\n",
-        "        size=alt.Size(\"count:Q\", title=\"Number of Airports\"),\n",
-        "        color=alt.value(\"steelblue\"),\n",
-        "        tooltip=[\"state:N\", \"count:Q\"],\n",
-        "    )\n",
-        "    .properties(title=\"Number of airports in US\")\n",
-        ")\n",
-        "\n",
-        "background + points"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python (Pyodide)",
-      "language": "python",
-      "name": "python"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "python",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Altair in `JupyterLite`\n",
+    "\n",
+    "**Altair** is a declarative statistical visualization library for Python.\n",
+    "\n",
+    "Most of the examples below are from: https://altair-viz.github.io/gallery"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import the dependencies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q altair"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple Bar Chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "import pandas as pd\n",
+    "\n",
+    "source = pd.DataFrame(\n",
+    "    {\n",
+    "        \"a\": [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n",
+    "        \"b\": [28, 55, 43, 91, 81, 53, 19, 87, 52],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "alt.Chart(source).mark_bar().encode(x=\"a\", y=\"b\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple Heatmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Compute x^2 + y^2 across a 2D grid\n",
+    "x, y = np.meshgrid(range(-5, 5), range(-5, 5))\n",
+    "z = x**2 + y**2\n",
+    "\n",
+    "# Convert this grid to columnar data expected by Altair\n",
+    "source = pd.DataFrame({\"x\": x.ravel(), \"y\": y.ravel(), \"z\": z.ravel()})\n",
+    "\n",
+    "alt.Chart(source).mark_rect().encode(x=\"x:O\", y=\"y:O\", color=\"z:Q\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install the Vega Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q vega-datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive Average"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "from vega_datasets import data\n",
+    "\n",
+    "source = data.seattle_weather()\n",
+    "brush = alt.selection_interval(encodings=[\"x\"])\n",
+    "\n",
+    "bars = (\n",
+    "    alt.Chart()\n",
+    "    .mark_bar()\n",
+    "    .encode(\n",
+    "        x=\"month(date):O\",\n",
+    "        y=\"mean(precipitation):Q\",\n",
+    "        opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),\n",
+    "    )\n",
+    "    .add_params(brush)\n",
+    ")\n",
+    "\n",
+    "line = (\n",
+    "    alt.Chart()\n",
+    "    .mark_rule(color=\"firebrick\")\n",
+    "    .encode(y=\"mean(precipitation):Q\", size=alt.SizeValue(3))\n",
+    "    .transform_filter(brush)\n",
+    ")\n",
+    "\n",
+    "alt.layer(bars, line, data=source)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Locations of US Airports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "from vega_datasets import data\n",
+    "\n",
+    "airports = data.airports.url\n",
+    "states = alt.topo_feature(data.us_10m.url, feature=\"states\")\n",
+    "\n",
+    "# US states background\n",
+    "background = (\n",
+    "    alt.Chart(states)\n",
+    "    .mark_geoshape(fill=\"lightgray\", stroke=\"white\")\n",
+    "    .properties(width=500, height=300)\n",
+    "    .project(\"albersUsa\")\n",
+    ")\n",
+    "\n",
+    "# airport positions on background\n",
+    "points = (\n",
+    "    alt.Chart(airports)\n",
+    "    .transform_aggregate(\n",
+    "        latitude=\"mean(latitude)\",\n",
+    "        longitude=\"mean(longitude)\",\n",
+    "        count=\"count()\",\n",
+    "        groupby=[\"state\"],\n",
+    "    )\n",
+    "    .mark_circle()\n",
+    "    .encode(\n",
+    "        longitude=\"longitude:Q\",\n",
+    "        latitude=\"latitude:Q\",\n",
+    "        size=alt.Size(\"count:Q\", title=\"Number of Airports\"),\n",
+    "        color=alt.value(\"steelblue\"),\n",
+    "        tooltip=[\"state:N\", \"count:Q\"],\n",
+    "    )\n",
+    "    .properties(title=\"Number of airports in US\")\n",
+    ")\n",
+    "\n",
+    "background + points"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "python",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/examples/pyodide/altair.ipynb
+++ b/examples/pyodide/altair.ipynb
@@ -1,211 +1,208 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Altair in `JupyterLite`\n",
-    "\n",
-    "**Altair** is a declarative statistical visualization library for Python.\n",
-    "\n",
-    "Most of the examples below are from: https://altair-viz.github.io/gallery"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Altair in `JupyterLite`\n",
+        "\n",
+        "**Altair** is a declarative statistical visualization library for Python.\n",
+        "\n",
+        "Most of the examples below are from: https://altair-viz.github.io/gallery"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Import the dependencies:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -q altair"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Simple Bar Chart"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import altair as alt\n",
+        "import pandas as pd\n",
+        "\n",
+        "source = pd.DataFrame(\n",
+        "    {\n",
+        "        \"a\": [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n",
+        "        \"b\": [28, 55, 43, 91, 81, 53, 19, 87, 52],\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "alt.Chart(source).mark_bar().encode(x=\"a\", y=\"b\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Simple Heatmap"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import altair as alt\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "\n",
+        "# Compute x^2 + y^2 across a 2D grid\n",
+        "x, y = np.meshgrid(range(-5, 5), range(-5, 5))\n",
+        "z = x**2 + y**2\n",
+        "\n",
+        "# Convert this grid to columnar data expected by Altair\n",
+        "source = pd.DataFrame({\"x\": x.ravel(), \"y\": y.ravel(), \"z\": z.ravel()})\n",
+        "\n",
+        "alt.Chart(source).mark_rect().encode(x=\"x:O\", y=\"y:O\", color=\"z:Q\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Install the Vega Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install -q vega-datasets"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Interactive Average"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import altair as alt\n",
+        "from vega_datasets import data\n",
+        "\n",
+        "source = data.seattle_weather()\n",
+        "brush = alt.selection_interval(encodings=['x'])\n",
+        "\n",
+        "bars = alt.Chart().mark_bar().encode(\n",
+        "    x='month(date):O',\n",
+        "    y='mean(precipitation):Q',\n",
+        "    opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),\n",
+        ").add_params(\n",
+        "    brush\n",
+        ")\n",
+        "\n",
+        "line = alt.Chart().mark_rule(color='firebrick').encode(\n",
+        "    y='mean(precipitation):Q',\n",
+        "    size=alt.SizeValue(3)\n",
+        ").transform_filter(\n",
+        "    brush\n",
+        ")\n",
+        "\n",
+        "alt.layer(bars, line, data=source)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Locations of US Airports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import altair as alt\n",
+        "from vega_datasets import data\n",
+        "\n",
+        "airports = data.airports.url\n",
+        "states = alt.topo_feature(data.us_10m.url, feature=\"states\")\n",
+        "\n",
+        "# US states background\n",
+        "background = (\n",
+        "    alt.Chart(states)\n",
+        "    .mark_geoshape(fill=\"lightgray\", stroke=\"white\")\n",
+        "    .properties(width=500, height=300)\n",
+        "    .project(\"albersUsa\")\n",
+        ")\n",
+        "\n",
+        "# airport positions on background\n",
+        "points = (\n",
+        "    alt.Chart(airports)\n",
+        "    .transform_aggregate(\n",
+        "        latitude=\"mean(latitude)\",\n",
+        "        longitude=\"mean(longitude)\",\n",
+        "        count=\"count()\",\n",
+        "        groupby=[\"state\"],\n",
+        "    )\n",
+        "    .mark_circle()\n",
+        "    .encode(\n",
+        "        longitude=\"longitude:Q\",\n",
+        "        latitude=\"latitude:Q\",\n",
+        "        size=alt.Size(\"count:Q\", title=\"Number of Airports\"),\n",
+        "        color=alt.value(\"steelblue\"),\n",
+        "        tooltip=[\"state:N\", \"count:Q\"],\n",
+        "    )\n",
+        "    .properties(title=\"Number of airports in US\")\n",
+        ")\n",
+        "\n",
+        "background + points"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python (Pyodide)",
+      "language": "python",
+      "name": "python"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "python",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Import the dependencies:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q altair"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Simple Bar Chart"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import altair as alt\n",
-    "import pandas as pd\n",
-    "\n",
-    "source = pd.DataFrame(\n",
-    "    {\n",
-    "        \"a\": [\"A\", \"B\", \"C\", \"D\", \"E\", \"F\", \"G\", \"H\", \"I\"],\n",
-    "        \"b\": [28, 55, 43, 91, 81, 53, 19, 87, 52],\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "alt.Chart(source).mark_bar().encode(x=\"a\", y=\"b\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Simple Heatmap"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import altair as alt\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "\n",
-    "# Compute x^2 + y^2 across a 2D grid\n",
-    "x, y = np.meshgrid(range(-5, 5), range(-5, 5))\n",
-    "z = x**2 + y**2\n",
-    "\n",
-    "# Convert this grid to columnar data expected by Altair\n",
-    "source = pd.DataFrame({\"x\": x.ravel(), \"y\": y.ravel(), \"z\": z.ravel()})\n",
-    "\n",
-    "alt.Chart(source).mark_rect().encode(x=\"x:O\", y=\"y:O\", color=\"z:Q\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Install the Vega Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install -q vega-datasets"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Interactive Average"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import altair as alt\n",
-    "from vega_datasets import data\n",
-    "\n",
-    "source = data.seattle_weather()\n",
-    "brush = alt.selection(type=\"interval\", encodings=[\"x\"])\n",
-    "\n",
-    "bars = (\n",
-    "    alt.Chart()\n",
-    "    .mark_bar()\n",
-    "    .encode(\n",
-    "        x=\"month(date):O\",\n",
-    "        y=\"mean(precipitation):Q\",\n",
-    "        opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),\n",
-    "    )\n",
-    "    .add_selection(brush)\n",
-    ")\n",
-    "\n",
-    "line = (\n",
-    "    alt.Chart()\n",
-    "    .mark_rule(color=\"firebrick\")\n",
-    "    .encode(y=\"mean(precipitation):Q\", size=alt.SizeValue(3))\n",
-    "    .transform_filter(brush)\n",
-    ")\n",
-    "\n",
-    "alt.layer(bars, line, data=source)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Locations of US Airports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import altair as alt\n",
-    "from vega_datasets import data\n",
-    "\n",
-    "airports = data.airports.url\n",
-    "states = alt.topo_feature(data.us_10m.url, feature=\"states\")\n",
-    "\n",
-    "# US states background\n",
-    "background = (\n",
-    "    alt.Chart(states)\n",
-    "    .mark_geoshape(fill=\"lightgray\", stroke=\"white\")\n",
-    "    .properties(width=500, height=300)\n",
-    "    .project(\"albersUsa\")\n",
-    ")\n",
-    "\n",
-    "# airport positions on background\n",
-    "points = (\n",
-    "    alt.Chart(airports)\n",
-    "    .transform_aggregate(\n",
-    "        latitude=\"mean(latitude)\",\n",
-    "        longitude=\"mean(longitude)\",\n",
-    "        count=\"count()\",\n",
-    "        groupby=[\"state\"],\n",
-    "    )\n",
-    "    .mark_circle()\n",
-    "    .encode(\n",
-    "        longitude=\"longitude:Q\",\n",
-    "        latitude=\"latitude:Q\",\n",
-    "        size=alt.Size(\"count:Q\", title=\"Number of Airports\"),\n",
-    "        color=alt.value(\"steelblue\"),\n",
-    "        tooltip=[\"state:N\", \"count:Q\"],\n",
-    "    )\n",
-    "    .properties(title=\"Number of airports in US\")\n",
-    ")\n",
-    "\n",
-    "background + points"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Pyolite",
-   "language": "python",
-   "name": "python"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "python",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

As reported in https://github.com/jupyterlite/jupyterlite/issues/1141.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the "Interactive Average" altair example: https://altair-viz.github.io/gallery/selection_layer_bar_month.html

## User-facing changes

Executing the Altair example should not give a warning anymore:

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/d60316fc-2d4f-4954-9eeb-b0d3544eb33d)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
