### PR TITLE
Fix contents example in `jupyter_lite_config.json`

### DIFF
--- a/docs/howto/configure/config_files.md
+++ b/docs/howto/configure/config_files.md
@@ -23,7 +23,7 @@ Here is an example of a `jupyter_lite_config.json` to configure the `contents` a
 ```json
 {
   "LiteBuildConfig": {
-    "contents": "notebooks",
+    "contents": ["notebooks"],
     "outputDir": "dist"
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fix the example in the documentation: https://jupyterlite.readthedocs.io/en/latest/howto/configure/config_files.html#jupyter-lite-config-json

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation change to match what the trait expects: 

https://github.com/jupyterlite/jupyterlite/blob/ebd965e2f8dd695287fafea38f4dc1eadbcc7ef3/py/jupyterlite-core/jupyterlite_core/config.py#L68

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should help fix some traitlet issues that site deployers may encounter at build time.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
