### PR TITLE
Add `tsconfig.eslint.json` with a list of `include`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: 'tsconfigbase.json',
+    project: 'tsconfig.eslint.json',
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'jest'],

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfigbase",
+  "include": [
+    "*",
+    ".eslintrc.js",
+    "docs/**/*",
+    "packages/**/src/**/*",
+    "packages/**/test/**/*",
+    "packages/**/style/**/*",
+    "packages/**/*.config.js",
+    "py/**/src/**/*",
+    "scripts/*",
+    "ui-tests/test/**/*",
+    "ui-tests/*.config.js"
+  ]
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Hopefully fix #194 ?

Follow the recommendations from https://typescript-eslint.io/linting/troubleshooting/performance-troubleshooting/ to reduce the `includes` glob. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add `tsconfig.eslint.json` file for ESLint, and add an `include` to not default to the widest glob.

Actually the Jupyterlab repo uses a similar config: https://github.com/jupyterlab/jupyterlab/blob/main/tsconfig.eslint.json

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
