### PR TITLE
[WIP] Contents: avoid double-URIdecoding paths

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -282,7 +282,7 @@ export class Contents implements IContents {
     options?: ServerContents.IFetchOptions,
   ): Promise<IModel | null> {
     // remove leading slash
-    path = decodeURIComponent(path.replace(/^\//, ''));
+    path = path.replace(/^\//, '');
 
     if (path === '') {
       return await this._getFolder(path);
@@ -352,10 +352,10 @@ export class Contents implements IContents {
    * @returns A promise which resolves with the new file content model when the file is renamed.
    */
   async rename(oldLocalPath: string, newLocalPath: string): Promise<IModel> {
-    const path = decodeURIComponent(oldLocalPath);
-    const file = await this.get(path, { content: true });
+    console.log('rename:', oldLocalPath, newLocalPath);
+    const file = await this.get(oldLocalPath, { content: true });
     if (!file) {
-      throw Error(`Could not find file with path ${path}`);
+      throw Error(`Could not find file with path ${oldLocalPath}`);
     }
     const modified = new Date().toISOString();
     const name = PathExt.basename(newLocalPath);
@@ -368,9 +368,9 @@ export class Contents implements IContents {
     const storage = await this.storage;
     await storage.setItem(newLocalPath, newFile);
     // remove the old file
-    await storage.removeItem(path);
+    await storage.removeItem(oldLocalPath);
     // remove the corresponding checkpoint
-    await (await this.checkpoints).removeItem(path);
+    await (await this.checkpoints).removeItem(oldLocalPath);
     // if a directory, recurse through all children
     if (file.type === 'directory') {
       let child: IModel;
@@ -394,8 +394,6 @@ export class Contents implements IContents {
    * @returns A promise which resolves with the file content model when the file is saved.
    */
   async save(path: string, options: Partial<IModel> = {}): Promise<IModel | null> {
-    path = decodeURIComponent(path);
-
     // process the file if coming from an upload
     const ext = PathExt.extname(options.name ?? '');
     const chunk = options.chunk;
@@ -552,7 +550,6 @@ export class Contents implements IContents {
    * @returns A promise which resolves when the checkpoint is restored.
    */
   async restoreCheckpoint(path: string, checkpointID: string): Promise<void> {
-    path = decodeURIComponent(path);
     const copies = ((await (await this.checkpoints).getItem(path)) || []) as IModel[];
     const id = parseInt(checkpointID);
     const item = copies[id];

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -477,7 +477,6 @@ export class Contents implements IContents {
    * @param path - The path to the file.
    */
   async delete(path: string): Promise<void> {
-    path = decodeURIComponent(path);
     const slashed = `${path}/`;
     const toDelete = (await (await this.storage).keys()).filter(
       (key) => key === path || key.startsWith(slashed),
@@ -507,7 +506,6 @@ export class Contents implements IContents {
    */
   async createCheckpoint(path: string): Promise<ServerContents.ICheckpointModel> {
     const checkpoints = await this.checkpoints;
-    path = decodeURIComponent(path);
     const item = await this.get(path, { content: true });
     if (!item) {
       throw Error(`Could not find file with path ${path}`);
@@ -570,7 +568,6 @@ export class Contents implements IContents {
    * @returns A promise which resolves when the checkpoint is deleted.
    */
   async deleteCheckpoint(path: string, checkpointID: string): Promise<void> {
-    path = decodeURIComponent(path);
     const copies = ((await (await this.checkpoints).getItem(path)) || []) as IModel[];
     const id = parseInt(checkpointID);
     copies.splice(id, 1);

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -87,6 +87,7 @@ const contentsPlugin: JupyterLiteServerPlugin<IContents> = {
   },
 };
 
+
 /**
  * A plugin providing the routes for the contents service.
  */
@@ -99,6 +100,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.get(
       '/api/contents/(.+)/checkpoints',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         const res = await contents.listCheckpoints(filename);
         return new Response(JSON.stringify(res));
       },
@@ -108,6 +110,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.post(
       '/api/contents/(.+)/checkpoints/(.*)',
       async (req: Router.IRequest, filename: string, checkpoint: string) => {
+        filename = decodeURIComponent(filename);
         const res = await contents.restoreCheckpoint(filename, checkpoint);
         return new Response(JSON.stringify(res), { status: 204 });
       },
@@ -117,6 +120,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.post(
       '/api/contents/(.+)/checkpoints',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         const res = await contents.createCheckpoint(filename);
         return new Response(JSON.stringify(res), { status: 201 });
       },
@@ -126,6 +130,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.delete(
       '/api/contents/(.+)/checkpoints/(.*)',
       async (req: Router.IRequest, filename: string, checkpoint: string) => {
+        filename = decodeURIComponent(filename);
         const res = await contents.deleteCheckpoint(filename, checkpoint);
         return new Response(JSON.stringify(res), { status: 204 });
       },
@@ -135,6 +140,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.get(
       '/api/contents(.*)',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         const options: ServerContents.IFetchOptions = {
           content: req.query?.content === '1',
         };
@@ -177,6 +183,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.put(
       '/api/contents/(.+)',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         const body = req.body;
         const nb = await contents.save(filename, body);
         return new Response(JSON.stringify(nb));
@@ -187,6 +194,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.delete(
       '/api/contents/(.+)',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         await contents.delete(filename);
         return new Response(null, { status: 204 });
       },

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -87,7 +87,6 @@ const contentsPlugin: JupyterLiteServerPlugin<IContents> = {
   },
 };
 
-
 /**
  * A plugin providing the routes for the contents service.
  */
@@ -156,6 +155,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.post('/api/contents(.*)', async (req: Router.IRequest, path: string) => {
       const options = req.body;
       const copyFrom = options?.copy_from as string;
+      path = decodeURIComponent(path);
       let file: ServerContents.IModel | null;
       if (copyFrom) {
         file = await contents.copy(copyFrom, path);
@@ -172,6 +172,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
     app.router.patch(
       '/api/contents(.*)',
       async (req: Router.IRequest, filename: string) => {
+        filename = decodeURIComponent(filename);
         const newPath = (req.body?.path as string) ?? '';
         filename = filename[0] === '/' ? filename.slice(1) : filename;
         const nb = await contents.rename(filename, newPath);
@@ -195,6 +196,7 @@ const contentsRoutesPlugin: JupyterLiteServerPlugin<void> = {
       '/api/contents/(.+)',
       async (req: Router.IRequest, filename: string) => {
         filename = decodeURIComponent(filename);
+        console.log('deleting', filename);
         await contents.delete(filename);
         return new Response(null, { status: 204 });
       },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -111,7 +111,19 @@ export class JupyterLiteServer extends Application<never> {
     if (!(req instanceof Request)) {
       throw Error('Request info is not a Request');
     }
-    return this._router.route(req);
+    const debug = new URL(req.url).pathname.startsWith('/api/contents');
+    if (debug) {
+      const req2 = req.clone();
+      const json = await req2.text();
+      console.debug('>!! fetch', req2, json);
+    }
+    const res = await this._router.route(req);
+    if (debug) {
+      const res2 = res.clone();
+      const json = await res2.json();
+      console.debug('>!! >!!', res2, json);
+    }
+    return res;
   }
 
   /**

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -22,7 +22,7 @@ test.use({
   waitForApplication: firefoxWaitForApplication,
 });
 
-test.describe('Contents Tests', () => {
+test.describe.only('Contents Tests', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('lab/index.html');
   });
@@ -110,7 +110,16 @@ test.describe('Contents Tests', () => {
     expect(output2![0]).toBe('4');
   });
 
-  test('Create a new notebook and delete it', async ({ page }) => {
+  test('WIP test: Open a URL with a percent-encoded filename', async ({ page }) => {
+    await page.menu.clickMenuItem('File>Open from URL…');
+
+    await page.locator('#jp-dialog-input-id').fill("https://raw.githubusercontent.com/mds2/rocketry/main/rocket%20equations.ipynb");
+    await page.locator(".jp-mod-accept").click();
+
+    await page.notebook.close();
+  });
+
+  test('Create a new notebook from a URL', async ({ page }) => {
     const name = await page.notebook.createNew();
     if (!name) {
       throw new Error('Notebook name is undefined');


### PR DESCRIPTION
Hello! We're working on a jupyterlite integration over at https://prospective.co. I'm thrilled to contribute a bug fix back to jupyterlite! 🎉 

## References

Addresses https://github.com/jupyterlite/jupyterlite/issues/1211

## Code changes

The paths coming in to /api/contents need to be URI decoded, because jupyterlab's frontend URI encodes them.

The existing Contents API would sometimes double-decode the filenames. For example, `Contents.createCheckpoint()` would decode the path once, then call `this.get()` on the path, which would decode it again.

To prevent double-decoding, the URI decode is moved out of the Contents class and into the route definitions.

## User-facing changes

Users can now add both files from URLs containing percent-encoded characters, and files from their filesystem with names like `hello%20world.txt`.

## Backwards-incompatible changes

This has a side effect of changing the Contents class API to accept "regular" paths, and not URI-encoded ones. For example, `Contents.get("hello%20world.txt")` will now return a file named `hello%20world.txt` on the filesystem, instead of a file named `hello world.txt`.