### PR TITLE
Load all settings from federated extensions at startup

### DIFF
--- a/app/doc/tree/index.html
+++ b/app/doc/tree/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      // redirect to /lab by default
+      (function () {
+        window.location.href = window.location.href.replace(
+          /(\/|\/index.html)?(\?.*)$/,
+          '/../../lab/index.html$2'
+        );
+      }.call(this));
+    </script>
+  </head>
+</html>

--- a/app/lab/package.json
+++ b/app/lab/package.json
@@ -86,6 +86,7 @@
     "@jupyterlite/kernel": "~0.2.0-rc.0",
     "@jupyterlite/licenses": "~0.2.0-rc.0",
     "@jupyterlite/localforage": "~0.2.0-rc.0",
+    "@jupyterlite/notebook-application-extension": "~0.2.0-rc.0",
     "@jupyterlite/server": "~0.2.0-rc.0",
     "@jupyterlite/server-extension": "~0.2.0-rc.0",
     "@jupyterlite/types": "~0.2.0-rc.0",
@@ -157,6 +158,7 @@
     "@jupyterlite/iframe-extension": "^0.2.0-rc.0",
     "@jupyterlite/licenses": "^0.2.0-rc.0",
     "@jupyterlite/localforage": "^0.2.0-rc.0",
+    "@jupyterlite/notebook-application-extension": "^0.2.0-rc.0",
     "@jupyterlite/server": "^0.2.0-rc.0",
     "@jupyterlite/server-extension": "^0.2.0-rc.0",
     "@jupyterlite/types": "^0.2.0-rc.0",
@@ -212,6 +214,7 @@
       "@jupyterlab/vega5-extension",
       "@jupyterlite/application-extension",
       "@jupyterlite/iframe-extension",
+      "@jupyterlite/notebook-application-extension",
       "@jupyterlite/server-extension"
     ],
     "singletonPackages": [
@@ -287,7 +290,9 @@
       "@jupyterlab/docmanager-extension:download",
       "@jupyterlab/filebrowser-extension:download",
       "@jupyterlab/filebrowser-extension:share-file",
-      "@jupyterlab/help-extension:about"
+      "@jupyterlab/help-extension:about",
+      "@jupyterlite/notebook-application-extension:logo",
+      "@jupyterlite/notebook-application-extension:notify-commands"
     ],
     "mimeExtensions": {
       "@jupyterlab/javascript-extension": "",

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -228,9 +228,8 @@ class CompileSchemasPlugin {
       // ensure all schemas are statically compiled
       const schemaDir = path.resolve(topLevelBuild, './schemas');
       const allCore = 'all.json';
-      const allFederated = 'all_federated.json';
       const files = glob.sync(`${schemaDir}/**/*.json`, {
-        ignore: [`${schemaDir}/${allCore}`, `${schemaDir}/${allFederated}`],
+        ignore: [`${schemaDir}/all*.json`],
       });
       const all = files.map((file) => {
         const schema = fs.readJSONSync(file);

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -227,8 +227,10 @@ class CompileSchemasPlugin {
     compiler.hooks.done.tapAsync('CompileSchemasPlugin', (compilation, callback) => {
       // ensure all schemas are statically compiled
       const schemaDir = path.resolve(topLevelBuild, './schemas');
+      const allCore = 'all.json';
+      const allFederated = 'all_federated.json';
       const files = glob.sync(`${schemaDir}/**/*.json`, {
-        ignore: [`${schemaDir}/all.json`],
+        ignore: [`${schemaDir}/${allCore}`, `${schemaDir}/${allFederated}`],
       });
       const all = files.map((file) => {
         const schema = fs.readJSONSync(file);
@@ -247,7 +249,7 @@ class CompileSchemasPlugin {
         };
       });
 
-      fs.writeFileSync(path.resolve(schemaDir, 'all.json'), JSON.stringify(all));
+      fs.writeFileSync(path.resolve(schemaDir, allCore), JSON.stringify(all));
       callback();
     });
   }

--- a/docs/howto/configure/interface_switcher.md
+++ b/docs/howto/configure/interface_switcher.md
@@ -2,10 +2,12 @@
 
 By default JupyterLite includes both the JupyterLab and Notebook interfaces.
 
-The JupyterLab interface is available under the `/lab` path, and the Notebook file browser is available under the `/tree` path.
-However there is no convenient way to switch between the two interfaces by default.
+The JupyterLab interface is available under the `/lab` path, and the Notebook file
+browser is available under the `/tree` path. However there is no convenient way to
+switch between the two interfaces by default.
 
-To add menu entries and toolbar items to help switching between interfaces, you can install the `notebook` package in the build environment, just like any other extension.
+To add menu entries and toolbar items to help switching between interfaces, you can
+install the `notebook` package in the build environment, just like any other extension.
 
 ## Installing the `notebook` package
 
@@ -27,20 +29,24 @@ Then build your JupyterLite site as usual:
 jupyter lite build
 ```
 
-The `notebook` package includes a JupyterLab extensions that adds the menu entries and toolbar items to switch between interfaces.
+The `notebook` package includes a JupyterLab extensions that adds the menu entries and
+toolbar items to switch between interfaces.
 
 ## Launch the Jupyter Notebook File Browser menu item
 
-The `notebook` package adds a menu item to launch the Jupyter Notebook File Browser via the `Help > Launch Jupyter Notebook File Browser`:
+The `notebook` package adds a menu item to launch the Jupyter Notebook File Browser via
+the `Help > Launch Jupyter Notebook File Browser`:
 
 ![a screenshot showing how to launch Jupyter Notebook from the menu entry](https://github.com/jupyterlite/jupyterlite/assets/591645/bc45a79a-1ede-44ca-b6ca-3deb5fe56187)
 
 ## Switch between JupyterLab and Notebook interfaces
 
-The `notebook` package also adds a toolbar item to switch between the JupyterLab and Notebook interfaces:
+The `notebook` package also adds a toolbar item to switch between the JupyterLab and
+Notebook interfaces:
 
 ![a screenshot showing how to launch JupyterLab from a notebook](https://github.com/jupyterlite/jupyterlite/assets/591645/009c5e32-d8bf-4658-a711-b28c45dcdd1d)
 
 ## References
 
-Check out the [guide for adding extensions](../configure/simple_extensions.md) for more informations about how to add extensions to your JupyterLite site.
+Check out the [guide for adding extensions](../configure/simple_extensions.md) for more
+informations about how to add extensions to your JupyterLite site.

--- a/docs/howto/configure/interface_switcher.md
+++ b/docs/howto/configure/interface_switcher.md
@@ -1,0 +1,46 @@
+# Enable switching between the JupyterLab and Notebook interfaces
+
+By default JupyterLite includes both the JupyterLab and Notebook interfaces.
+
+The JupyterLab interface is available under the `/lab` path, and the Notebook file browser is available under the `/tree` path.
+However there is no convenient way to switch between the two interfaces by default.
+
+To add menu entries and toolbar items to help switching between interfaces, you can install the `notebook` package in the build environment, just like any other extension.
+
+## Installing the `notebook` package
+
+In your build environment, install the `notebook` package:
+
+```shell
+pip install notebook
+```
+
+Or add it to your `requirements.txt` or similar file for managing dependencies:
+
+```text
+notebook
+```
+
+Then build your JupyterLite site as usual:
+
+```shell
+jupyter lite build
+```
+
+The `notebook` package includes a JupyterLab extensions that adds the menu entries and toolbar items to switch between interfaces.
+
+## Launch the Jupyter Notebook File Browser menu item
+
+The `notebook` package adds a menu item to launch the Jupyter Notebook File Browser via the `Help > Launch Jupyter Notebook File Browser`:
+
+![a screenshot showing how to launch Jupyter Notebook from the menu entry](https://github.com/jupyterlite/jupyterlite/assets/591645/bc45a79a-1ede-44ca-b6ca-3deb5fe56187)
+
+## Switch between JupyterLab and Notebook interfaces
+
+The `notebook` package also adds a toolbar item to switch between the JupyterLab and Notebook interfaces:
+
+![a screenshot showing how to launch JupyterLab from a notebook](https://github.com/jupyterlite/jupyterlite/assets/591645/009c5e32-d8bf-4658-a711-b28c45dcdd1d)
+
+## References
+
+Check out the [guide for adding extensions](../configure/simple_extensions.md) for more informations about how to add extensions to your JupyterLite site.

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -23,6 +23,7 @@ configure/settings
 configure/translation
 configure/rtc
 configure/config_files
+configure/interface_switcher
 ```
 
 ## Contents

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -17,6 +17,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-myst-2.0.2-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda",
+      "https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/label/jupyterlite_pyodide_kernel_alpha/noarch/jupyterlite-pyodide-kernel-0.2.0a1-pyh9178eb9_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.15.0-pyhd8ed1ab_0.conda",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl"

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -37,7 +37,7 @@ import React from 'react';
 /**
  * A regular expression to match path to notebooks, documents and consoles
  */
-const URL_PATTERN = new RegExp('/(lab|notebooks|edit|consoles)\\/?');
+const URL_PATTERN = new RegExp('/(lab|tree|notebooks|edit|consoles)\\/?');
 
 /**
  * The JupyterLab document manager plugin id.
@@ -340,7 +340,21 @@ const opener: JupyterFrontEndPlugin<void> = {
         app.started.then(async () => {
           const page = PageConfig.getOption('notebookPage');
           const [file] = files;
-          if (page === 'consoles') {
+          if (page === 'tree') {
+            let appUrl = '/edit';
+            // check if the file is a notebook
+            const defaultFactory = docRegistry.defaultWidgetFactory(file);
+            if (defaultFactory.name === 'Notebook') {
+              appUrl = '/notebooks';
+            }
+            const baseUrl = PageConfig.getBaseUrl();
+            const url = new URL(URLExt.join(baseUrl, appUrl, 'index.html'));
+            url.searchParams.append('path', file);
+
+            // redirect to the proper page
+            window.location.href = url.toString();
+            return;
+          } else if (page === 'consoles') {
             commands.execute('console:create', { path: file });
             return;
           } else if (page === 'notebooks' || page === 'edit') {

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -333,7 +333,7 @@ const opener: JupyterFrontEndPlugin<void> = {
 
         const urlParams = new URLSearchParams(search);
         const paths = urlParams.getAll('path');
-        if (!paths) {
+        if (paths.length === 0) {
           return;
         }
         const files = paths.map((path) => decodeURIComponent(path));

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -96,8 +96,10 @@ export class Settings implements ISettings {
    * Get all the settings
    */
   async getAll(): Promise<{ settings: IPlugin[] }> {
-    const allCore = await this._getAll('all.json');
-    const allFederated = await this._getAll('all_federated.json');
+    const [allCore, allFederated] = await Promise.all([
+      this._getAll('all.json'),
+      this._getAll('all_federated.json'),
+    ]);
 
     // JupyterLab 4 expects all settings to be returned in one go
     // so append the settings from federated plugins to the core ones

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -6,7 +6,7 @@ import * as json5 from 'json5';
 
 import type localforage from 'localforage';
 
-import { IPlugin, ISettings } from './tokens';
+import { IPlugin, ISettings, SettingsFile } from './tokens';
 
 /**
  * The name of the local storage.
@@ -96,8 +96,8 @@ export class Settings implements ISettings {
    * Get all the settings
    */
   async getAll(): Promise<{ settings: IPlugin[] }> {
-    const allCore = await this._getAll('core');
-    const allFederated = await this._getAll('federated');
+    const allCore = await this._getAll('all.json');
+    const allFederated = await this._getAll('all_federated.json');
 
     // JupyterLab 4 expects all settings to be returned in one go
     // so append the settings from federated plugins to the core ones
@@ -133,9 +133,8 @@ export class Settings implements ISettings {
   /**
    * Get all the settings for core or federated plugins
    */
-  private async _getAll(type: 'core' | 'federated' = 'core'): Promise<IPlugin[]> {
+  private async _getAll(file: SettingsFile): Promise<IPlugin[]> {
     const settingsUrl = PageConfig.getOption('settingsUrl') ?? '/';
-    const file = type === 'core' ? 'all.json' : 'all_federated.json';
     const all = (await (
       await fetch(URLExt.join(settingsUrl, file))
     ).json()) as IPlugin[];

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -6,8 +6,6 @@ import * as json5 from 'json5';
 
 import type localforage from 'localforage';
 
-// import { IFederatedExtension } from '@jupyterlite/types';
-
 import { IPlugin, ISettings } from './tokens';
 
 /**
@@ -151,26 +149,6 @@ export class Settings implements ISettings {
     ).json()) as IPlugin[];
     return all;
   }
-
-  // /**
-  //  * Get the settings for a federated extension
-  //  *
-  //  * @param pluginId The id of a plugin
-  //  */
-  // private async _getFederated(
-  //   ext: IFederatedExtension,
-  // ): Promise<IPlugin[] | undefined> {
-  //   const packageName = ext.name;
-  //   const labExtensionsUrl = PageConfig.getOption('fullLabextensionsUrl');
-  //   const schemaUrl = URLExt.join(labExtensionsUrl, packageName, 'all.json');
-  //   const settings = await (await fetch(schemaUrl)).json();
-  //   return settings.map((setting: IPlugin) => {
-  //     return {
-  //       ...settings,
-  //       raw: json5.parse(setting.raw) || {},
-  //     };
-  //   });
-  // }
 
   private _storageName: string = DEFAULT_STORAGE_NAME;
   private _storageDrivers: string[] | null = null;

--- a/packages/settings/src/tokens.ts
+++ b/packages/settings/src/tokens.ts
@@ -8,6 +8,11 @@ import { JSONObject, PartialJSONObject, Token } from '@lumino/coreutils';
 export const ISettings = new Token<ISettings>('@jupyterlite/settings:ISettings');
 
 /**
+ * The settings file to request
+ */
+export type SettingsFile = 'all.json' | 'all_federated.json';
+
+/**
  * An interface for the plugin settings.
  */
 export interface IPlugin extends PartialJSONObject {

--- a/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
@@ -295,9 +295,9 @@ class FederatedExtensionAddon(BaseAddon):
 
     def ensure_federated_settings(self, manager, lab_extensions):
         """ensure settings from federated extensions are aggregated in a single file"""
-        all_federated_settings = [
-            setting for p in lab_extensions for setting in self.get_federated_settings(p.parent)
-        ]
+        all_federated_settings = sorted(
+            [setting for p in lab_extensions for setting in self.get_federated_settings(p.parent)]
+        )
 
         app_schemas = manager.output_dir / "build" / "schemas"
         if not app_schemas.is_dir():
@@ -314,7 +314,7 @@ class FederatedExtensionAddon(BaseAddon):
         if not settings_dir.is_dir():
             # bail if there is no settings for that extension
             return []
-        setting_files = settings_dir.rglob("*.json")
+        setting_files = sorted(settings_dir.rglob("*.json"))
 
         pkg_name = pkg_data["name"]
         pkg_version = pkg_data["version"]

--- a/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
@@ -295,9 +295,9 @@ class FederatedExtensionAddon(BaseAddon):
 
     def ensure_federated_settings(self, manager, lab_extensions):
         """ensure settings from federated extensions are aggregated in a single file"""
-        all_federated_settings = sorted(
-            [setting for p in lab_extensions for setting in self.get_federated_settings(p.parent)]
-        )
+        all_federated_settings = [
+            setting for p in lab_extensions for setting in self.get_federated_settings(p.parent)
+        ]
 
         app_schemas = manager.output_dir / "build" / "schemas"
         if not app_schemas.is_dir():

--- a/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
@@ -286,12 +286,15 @@ class FederatedExtensionAddon(BaseAddon):
                 actions=[(self.copy_one, [theme_dir, dest])],
             )
 
-        # ensure settings from federated extensions are aggregated in a single file
-        self.ensure_federated_settings(manager)
+        yield self.task(
+            name="settings",
+            doc=f"ensure {ALL_FEDERATED_JSON} includes the settings of federated extensions",
+            file_dep=[*lab_extensions],
+            actions=[(self.ensure_federated_settings, [manager, lab_extensions])],
+        )
 
-    def ensure_federated_settings(self, manager):
-        lab_extensions_root = manager.output_dir / LAB_EXTENSIONS
-        lab_extensions = self.env_extensions(lab_extensions_root)
+    def ensure_federated_settings(self, manager, lab_extensions):
+        """ensure settings from federated extensions are aggregated in a single file"""
         all_federated_settings = [
             setting for p in lab_extensions for setting in self.get_federated_settings(p.parent)
         ]

--- a/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/federated_extensions.py
@@ -297,6 +297,9 @@ class FederatedExtensionAddon(BaseAddon):
         ]
 
         app_schemas = manager.output_dir / "build" / "schemas"
+        if not app_schemas.is_dir():
+            # bail if there is no schemas dir
+            return
         all_federated_json = app_schemas / ALL_FEDERATED_JSON
         all_federated_json.write_text(json.dumps(all_federated_settings), **UTF8)
 

--- a/py/jupyterlite-core/jupyterlite_core/constants.py
+++ b/py/jupyterlite-core/jupyterlite_core/constants.py
@@ -80,8 +80,9 @@ JUPYTER_LITE_CONFIG = "jupyter_lite_config.json"
 #: Needs a better canonical location
 DEFAULT_OUTPUT_DIR = "_output"
 
-#: commonly-used filename for response fixtures, e.g. settings
+#: commonly-used filenames for response fixtures, e.g. settings
 ALL_JSON = "all.json"
+ALL_FEDERATED_JSON = "all_federated.json"
 
 ### Environment Variables
 

--- a/py/jupyterlite-core/jupyterlite_core/tests/test_cli.py
+++ b/py/jupyterlite-core/jupyterlite_core/tests/test_cli.py
@@ -210,7 +210,7 @@ def test_build_repl_no_sourcemaps(an_empty_lite_dir, script_runner):
     """does (re-)building create a predictable pattern of file counts"""
     out = an_empty_lite_dir / "_output"
 
-    args = original_args = "jupyter", "lite", "build"
+    args = original_args = "jupyter", "lite", "build", "--disable-addons", "federated_extensions"
     status = script_runner.run(args, cwd=str(an_empty_lite_dir))
     norm_files = sorted(out.rglob("*"))
     assert status.success

--- a/py/jupyterlite-core/jupyterlite_core/tests/test_cli.py
+++ b/py/jupyterlite-core/jupyterlite_core/tests/test_cli.py
@@ -210,6 +210,7 @@ def test_build_repl_no_sourcemaps(an_empty_lite_dir, script_runner):
     """does (re-)building create a predictable pattern of file counts"""
     out = an_empty_lite_dir / "_output"
 
+    # disable the federated_extensions addon as it may output settings for federated extensions
     args = original_args = "jupyter", "lite", "build", "--disable-addons", "federated_extensions"
     status = script_runner.run(args, cwd=str(an_empty_lite_dir))
     norm_files = sorted(out.rglob("*"))

--- a/py/jupyterlite-core/pyproject.toml
+++ b/py/jupyterlite-core/pyproject.toml
@@ -65,6 +65,7 @@ libarchive = [
 ]
 lab = [
     "jupyterlab >=4.0.7,<5.0",
+    "notebook >=7.0.6,<8.0",
 ]
 contents = [
     "jupyter_server",
@@ -84,6 +85,7 @@ all = [
     "jupyterlab >=4.0.7,<5.0",
     "jupyterlab_server >=2.8.1,<3",
     "libarchive-c >=4.0",
+    "notebook >=7.0.6,<8.0",
     "pkginfo",
     "tornado >=6.1",
 ]

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -52,6 +52,7 @@ libarchive = [
 ]
 lab = [
     "jupyterlab >=4.0.7,<5.0",
+    "notebook >=7.0.6,<8.0",
 ]
 contents = [
     "jupyter_server",
@@ -71,6 +72,7 @@ all = [
     "jupyterlab >=4.0.7,<5.0",
     "jupyterlab_server >=2.8.1,<3",
     "libarchive-c >=4.0",
+    "notebook >=7.0.6,<8.0",
     "pkginfo",
     "tornado >=6.1",
 ]

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,6 +3,7 @@
   "include": [
     "*",
     ".eslintrc.js",
+    "app/**/*.config.js",
     "docs/**/*",
     "packages/**/src/**/*",
     "packages/**/test/**/*",

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,5 +1,6 @@
 ../py/jupyterlite-javascript-kernel
-jupyterlite-pyodide-kernel==0.2.0a2
-jupyterlite-p5-kernel==0.1.1
 jupyterlab-language-pack-fr-FR
+jupyterlite-p5-kernel==0.1.1
+jupyterlite-pyodide-kernel==0.2.0a2
+notebook==7.0.6
 theme-darcula==4.0.0

--- a/ui-tests/test/notebook.test.ts
+++ b/ui-tests/test/notebook.test.ts
@@ -143,3 +143,19 @@ test.describe('Notebook favicons', () => {
     expect(finalFavicon).toEqual(favicon);
   });
 });
+
+test.describe('Switch between Notebook and JupyterLab', () => {
+  test('Switch to Notebook from JupyterLab', async ({ page }) => {
+    await page.goto('lab/index.html');
+
+    const [treePage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.menu.clickMenuItem('Help>Launch Jupyter Notebook File Browser'),
+    ]);
+
+    await treePage.waitForLoadState('domcontentloaded');
+    await treePage.waitForSelector('#filebrowser');
+
+    expect(treePage.url()).toContain('tree');
+  });
+});

--- a/ui-tests/test/notebook.test.ts
+++ b/ui-tests/test/notebook.test.ts
@@ -167,7 +167,6 @@ test.describe('Switch between Notebook and JupyterLab', () => {
       page.menu.clickMenuItem('Help>Launch Jupyter Notebook File Browser'),
     ]);
 
-    await treePage.waitForLoadState('domcontentloaded');
     await treePage.waitForSelector('#filebrowser');
 
     expect(treePage.url()).toContain('tree');
@@ -181,7 +180,6 @@ test.describe('Switch between Notebook and JupyterLab', () => {
       page.locator('.jp-ToolbarButtonComponent >> text=JupyterLab').first().click(),
     ]);
 
-    await labPage.waitForLoadState('domcontentloaded');
     await labPage.waitForSelector('.jp-NotebookPanel');
 
     expect(labPage.url()).toContain('lab');
@@ -195,7 +193,6 @@ test.describe('Switch between Notebook and JupyterLab', () => {
       page.locator('.jp-ToolbarButtonComponent >> text=Notebook').first().click(),
     ]);
 
-    await notebookPage.waitForLoadState('domcontentloaded');
     await notebookPage.waitForSelector('.jp-NotebookPanel');
 
     expect(notebookPage.url()).toContain('notebooks');

--- a/ui-tests/test/notebook.test.ts
+++ b/ui-tests/test/notebook.test.ts
@@ -145,7 +145,21 @@ test.describe('Notebook favicons', () => {
 });
 
 test.describe('Switch between Notebook and JupyterLab', () => {
-  test('Switch to Notebook from JupyterLab', async ({ page }) => {
+  const NOTEBOOK = 'empty.ipynb';
+
+  test.use({
+    waitForApplication: async function ({ baseURL }, use, testInfo) {
+      const waitIsReady = async (page): Promise<void> => {
+        const selector = page.url().includes('lab')
+          ? `text=${NOTEBOOK}`
+          : '.jp-NotebookPanel';
+        await page.waitForSelector(selector);
+      };
+      await use(waitIsReady);
+    },
+  });
+
+  test('Open the notebook file browser', async ({ page }) => {
     await page.goto('lab/index.html');
 
     const [treePage] = await Promise.all([
@@ -157,5 +171,33 @@ test.describe('Switch between Notebook and JupyterLab', () => {
     await treePage.waitForSelector('#filebrowser');
 
     expect(treePage.url()).toContain('tree');
+  });
+
+  test('Open a notebook with JupyterLab', async ({ page }) => {
+    await page.goto(`notebooks/index.html?path=${NOTEBOOK}`);
+
+    const [labPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.locator('.jp-ToolbarButtonComponent >> text=JupyterLab').first().click(),
+    ]);
+
+    await labPage.waitForLoadState('domcontentloaded');
+    await labPage.waitForSelector('.jp-NotebookPanel');
+
+    expect(labPage.url()).toContain('lab');
+  });
+
+  test('Open a notebook with Notebook', async ({ page }) => {
+    await page.goto(`lab/index.html?path=${NOTEBOOK}`);
+
+    const [notebookPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.locator('.jp-ToolbarButtonComponent >> text=Notebook').first().click(),
+    ]);
+
+    await notebookPage.waitForLoadState('domcontentloaded');
+    await notebookPage.waitForSelector('.jp-NotebookPanel');
+
+    expect(notebookPage.url()).toContain('notebooks');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4118,6 +4118,7 @@ __metadata:
     "@jupyterlite/iframe-extension": ^0.2.0-rc.0
     "@jupyterlite/licenses": ^0.2.0-rc.0
     "@jupyterlite/localforage": ^0.2.0-rc.0
+    "@jupyterlite/notebook-application-extension": ^0.2.0-rc.0
     "@jupyterlite/server": ^0.2.0-rc.0
     "@jupyterlite/server-extension": ^0.2.0-rc.0
     "@jupyterlite/types": ^0.2.0-rc.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

JupyterLab 4 seems to now be expecting all settings (including the ones from federated extensions) to be returned in one go on the first call to `/api/settings`.

This is likely related to the change in https://github.com/jupyterlab/jupyterlab/pull/14195 and/or other upstream PRs as well.

Fixes https://github.com/jupyterlite/jupyterlite/issues/1213

## Code changes

- [x] Aggregate settings from federated extensions in a `all_federated.json` file by adding a step in the `federated_extensions` addon `post_build`
- [x] UI test to check the "Launch Notebook File Browser" item is available when the `notebook` package is installed in the build environment
- [x] Handle redirects to `/doc/tree`
- [x] UI test to check going from Notebook to Lab with the toolbar button
- [x] Mention installing the `notebook` package in the docs to get the UI elements

An alternative could have been to create an `all.json` file with all the settings for a federated extension, in each federated extension directory. And query this file for each extension. However many extensions don't provide settings, so these queries would lead to many 404s.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

End users should be able to see menu entries or toolbar items defined in third-party extensions via the settings system.

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/1dea718b-e8f5-4c9e-8c8d-acf5ee97f77e)



https://github.com/jupyterlite/jupyterlite/assets/591645/63e7cbad-e4eb-4df4-b6c4-8d92e2610812



## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
