### PR TITLE
Fix handling of files in custom drives

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -453,6 +453,8 @@ const sessionContextPatch: JupyterFrontEndPlugin<void> = {
       // with a kernel.
       // This was changed in JupyterLab 4 in https://github.com/jupyterlab/jupyterlab/pull/14519
       // and is needed for the kernel to be aware of the drive it is associated with.
+      // This is a temporary fix until a better solution is found upstream in JupyterLab ideally.
+      // This also avoid having to patch the downstream kernels (e.g. xeus-python and pyodide)
       sessionContext['_name'] = context?.path;
       sessionContext['_path'] = context?.path;
     });

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -8,7 +8,13 @@ import {
   ILabShell,
 } from '@jupyterlab/application';
 
-import { Clipboard, ICommandPalette, Dialog, showDialog, SessionContext } from '@jupyterlab/apputils';
+import {
+  Clipboard,
+  ICommandPalette,
+  Dialog,
+  showDialog,
+  SessionContext,
+} from '@jupyterlab/apputils';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
@@ -442,6 +448,9 @@ const sessionContextPatch: JupyterFrontEndPlugin<void> = {
       }
       const sessionContext = widget.context.sessionContext as SessionContext;
       // Path the session context to include the drive name
+      // In JupyterLab 3 the path used to contain the drive name as prefix, which was
+      // also part of the /api/sessions requests. Which allowed for knowing the drive associated
+      // with a kernel.
       // This was changed in JupyterLab 4 in https://github.com/jupyterlab/jupyterlab/pull/14519
       // and is needed for the kernel to be aware of the drive it is associated with.
       sessionContext['_name'] = context?.path;

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -8,11 +8,11 @@ import {
   ILabShell,
 } from '@jupyterlab/application';
 
-import { Clipboard, ICommandPalette, Dialog, showDialog } from '@jupyterlab/apputils';
+import { Clipboard, ICommandPalette, Dialog, showDialog, SessionContext } from '@jupyterlab/apputils';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { IDocumentManager } from '@jupyterlab/docmanager';
+import { IDocumentManager, IDocumentWidgetOpener } from '@jupyterlab/docmanager';
 
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
@@ -417,6 +417,40 @@ const opener: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to patch the session context path so it includes the drive name.
+ * TODO: investigate a better way for the kernel to be aware of the drive it is
+ * associated with.
+ */
+const sessionContextPatch: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlite/application-extension:session-context-patch',
+  autoStart: true,
+  requires: [IDocumentManager, IDocumentWidgetOpener],
+  activate: (
+    app: JupyterFrontEnd,
+    docManager: IDocumentManager,
+    widgetOpener: IDocumentWidgetOpener,
+  ) => {
+    const contents = app.serviceManager.contents;
+
+    widgetOpener.opened.connect((_, widget) => {
+      console.log('widget opened', widget);
+      const context = docManager.contextForWidget(widget);
+      const driveName = contents.driveName(context?.path ?? '');
+      if (driveName === '') {
+        // do nothing if this is the default drive
+        return;
+      }
+      const sessionContext = widget.context.sessionContext as SessionContext;
+      // Path the session context to include the drive name
+      // This was changed in JupyterLab 4 in https://github.com/jupyterlab/jupyterlab/pull/14519
+      // and is needed for the kernel to be aware of the drive it is associated with.
+      sessionContext['_name'] = context?.path;
+      sessionContext['_path'] = context?.path;
+    });
+  },
+};
+
+/**
  * A custom plugin to share a link to a file.
  *
  * This url can be used to open a particular file in JupyterLab.
@@ -494,6 +528,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   liteLogo,
   notifyCommands,
   opener,
+  sessionContextPatch,
   shareFile,
 ];
 

--- a/packages/contents/src/broadcast.ts
+++ b/packages/contents/src/broadcast.ts
@@ -113,8 +113,11 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
         });
         await _contents.rename(model.path, path);
         break;
-      case 'getattr':
+      case 'getattr': {
         model = await _contents.get(path);
+        // create a default date for drives that send incomplete information
+        // for nested foldes and files
+        const defaultDate = new Date(0).toISOString();
 
         response = {
           dev: 1,
@@ -125,12 +128,13 @@ export class BroadcastChannelWrapper implements IBroadcastChannelWrapper {
           size: model.size || 0,
           blksize: BLOCK_SIZE,
           blocks: Math.ceil(model.size || 0 / BLOCK_SIZE),
-          atime: model.last_modified, // TODO Get the proper atime?
-          mtime: model.last_modified,
-          ctime: model.created,
+          atime: model.last_modified || defaultDate, // TODO Get the proper atime?
+          mtime: model.last_modified || defaultDate,
+          ctime: model.created || defaultDate,
           timestamp: 0,
         };
         break;
+      }
       case 'get':
         model = await _contents.get(path, { content: true });
 

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -78,14 +78,16 @@ async function maybeFromCache(event: FetchEvent): Promise<Response> {
  * Restore a response from the cache based on the request.
  */
 async function fromCache(request: Request): Promise<Response | null> {
-  const cache = await openCache();
-  const response = await cache.match(request);
+  // disable cache for now
+  return null;
+  // const cache = await openCache();
+  // const response = await cache.match(request);
 
-  if (!response || response.status === 404) {
-    return null;
-  }
+  // if (!response || response.status === 404) {
+  //   return null;
+  // }
 
-  return response;
+  // return response;
 }
 
 /**

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -78,16 +78,14 @@ async function maybeFromCache(event: FetchEvent): Promise<Response> {
  * Restore a response from the cache based on the request.
  */
 async function fromCache(request: Request): Promise<Response | null> {
-  // disable cache for now
-  return null;
-  // const cache = await openCache();
-  // const response = await cache.match(request);
+  const cache = await openCache();
+  const response = await cache.match(request);
 
-  // if (!response || response.status === 404) {
-  //   return null;
-  // }
+  if (!response || response.status === 404) {
+    return null;
+  }
 
-  // return response;
+  return response;
 }
 
 /**

--- a/packages/session/src/sessions.ts
+++ b/packages/session/src/sessions.ts
@@ -111,9 +111,12 @@ export class Sessions implements ISessions {
     }
     const kernelName = options.kernel?.name ?? '';
     const id = options.id ?? UUID.uuid4();
-    const dirname = PathExt.dirname(options.name ?? options.path);
-    const hasDrive = dirname.includes(':');
-    const location = hasDrive ? `${dirname.split(':')[0]}:` : '';
+    const nameOrPath = options.name ?? options.path;
+    const dirname = PathExt.dirname(nameOrPath);
+    const hasDrive = nameOrPath.includes(':');
+    const driveName = hasDrive ? nameOrPath.split(':')[0] : '';
+    // add drive name if missing (top level directory)
+    const location = dirname.includes(driveName) ? dirname : `${driveName}:${dirname}`;
     const kernel = await this._kernels.startNew({
       id,
       name: kernelName,

--- a/packages/session/src/sessions.ts
+++ b/packages/session/src/sessions.ts
@@ -112,7 +112,7 @@ export class Sessions implements ISessions {
     const kernelName = options.kernel?.name ?? '';
     const id = options.id ?? UUID.uuid4();
     const nameOrPath = options.name ?? options.path;
-    const dirname = PathExt.dirname(nameOrPath);
+    const dirname = PathExt.dirname(options.name) || PathExt.dirname(options.path);
     const hasDrive = nameOrPath.includes(':');
     const driveName = hasDrive ? nameOrPath.split(':')[0] : '';
     // add drive name if missing (top level directory)

--- a/packages/session/src/sessions.ts
+++ b/packages/session/src/sessions.ts
@@ -111,10 +111,13 @@ export class Sessions implements ISessions {
     }
     const kernelName = options.kernel?.name ?? '';
     const id = options.id ?? UUID.uuid4();
+    const dirname = PathExt.dirname(options.name ?? options.path);
+    const hasDrive = dirname.includes(':');
+    const location = hasDrive ? `${dirname.split(':')[0]}:` : '';
     const kernel = await this._kernels.startNew({
       id,
       name: kernelName,
-      location: PathExt.dirname(options.path),
+      location,
     });
     const session: Session.IModel = {
       id,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/942

As noticed in https://github.com/jupyterlab/jupyterlab/pull/14519#issuecomment-1774055091, JupyterLab 4 does not store the drive prefix (for example `FileSystem:`) in the session path anymore.

But JupyterLite is relying on this information to start a new kernel:

https://github.com/jupyterlite/jupyterlite/blob/0ce857b1aab8db3253d51d6a126e8cd6a0260d9d/packages/session/src/sessions.ts#L114-L118

Which is then used in the kernel to store the name of the drive, and pass it to the `DriveFS` used in the kernels:

**Pyodide**

https://github.com/jupyterlite/pyodide-kernel/blob/143526c9e11589b03c8d6844be5471d527b76255/packages/pyodide-kernel/src/worker.ts#L23-L30

https://github.com/jupyterlite/pyodide-kernel/blob/143526c9e11589b03c8d6844be5471d527b76255/packages/pyodide-kernel/src/worker.ts#L117-L124

**Xeus Python**

https://github.com/jupyter-xeus/xeus-lite/blob/07df211bc73c1002558017b86499d63806d133d6/share/xeus-lite/web_worker_kernel.ts#L164-L171

https://github.com/jupyter-xeus/xeus-lite/blob/07df211bc73c1002558017b86499d63806d133d6/share/xeus-lite/worker.ts#L119-L126

As a result, the update to JupyterLab 4 broke accessing files from a custom drive, as the `driveName` would always be empty since it would never be known to the kernel.

See the following discussions for more information:

- https://github.com/jupyterlab/jupyterlab/pull/14519#issuecomment-1774055091
- https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/55#issuecomment-1772879905
- https://github.com/jupyterlab/jupyterlab/issues/15143
- https://github.com/jupyterlab/jupyterlab/issues/15289


## Code changes

To restore this functionality, we add a small plugin to patch `sessionContext['_path']` and `sessionContext['_name']` when a document context is created and opened.

This also allows fixing the behavior without having to introduce breaking changes (and updating kernels) in 0.2.0. However this is more of a workaround, and a better approach should be found in 0.3.0, which will require quite some work in JupyterLab directly to allow for such use cases.

- [x] Fix accessing contents of custom drives from kernels
- [x] Fix previous issue where trying to access content from a notebook created at the top-level of a custom drive would default to accessing the content from the default browser
- [x] ~Add `jupyterlab-filesystem-access` extension to the RTD demo site?~ -> postponing to a later time since there is already `jupyterlab-github`
  - Would need https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/pull/55, https://github.com/jupyterlab-contrib/jupyterlab-filesystem-access/issues/58 and a new release of the extension first
  - There is already `jupyterlab-github` that we can use to test by opening the `virtual_filesystem` notebook from within the GitHub drive
- [x] ~UI test with a simple custom drive?~ -> tracked in https://github.com/jupyterlite/jupyterlite/issues/1231

## User-facing changes

This should allow accessing files from a custom drive from a kernel in JupyterLite 0.2.0:

**jupyterlab-filesystem-access**

https://github.com/jupyterlite/jupyterlite/assets/591645/a0ab40d1-1a94-482b-8323-1b2e50c0528f

**jupyterlab-github**

![image](https://github.com/jupyterlite/jupyterlite/assets/591645/ef541847-1aea-4546-9ca4-907e789a83ed)


## Backwards-incompatible changes

None
