### PR TITLE
Set `navigation_with_keys` to `False`explicitely

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ html_theme_options = {
         "version_match": os.environ.get("READTHEDOCS_VERSION", "latest"),
     },
     "check_switcher": False,
+    "navigation_with_keys": False
 }
 
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ html_theme_options = {
         "version_match": os.environ.get("READTHEDOCS_VERSION", "latest"),
     },
     "check_switcher": False,
-    "navigation_with_keys": False
+    "navigation_with_keys": False,
 }
 
 html_context = {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1229

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add the following to the docs theme options:

```py
"navigation_with_keys": False
```

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

## Backwards-incompatible changes

None