### PR TITLE
update jupyterlab trove classifiers

### DIFF
--- a/py/jupyterlite-core/pyproject.toml
+++ b/py/jupyterlite-core/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
-    "Framework :: Jupyter :: JupyterLab :: 3",
+    "Framework :: Jupyter :: JupyterLab :: 4",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",

--- a/py/jupyterlite-javascript-kernel/pyproject.toml
+++ b/py/jupyterlite-javascript-kernel/pyproject.toml
@@ -22,6 +22,8 @@ license = { file = "LICENSE" }
 requires-python = ">=3.7"
 classifiers = [
     "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 4",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/py/jupyterlite/pyproject.toml
+++ b/py/jupyterlite/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
-    "Framework :: Jupyter :: JupyterLab :: 3",
+    "Framework :: Jupyter :: JupyterLab :: 4",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
## References

- noticed during https://github.com/conda-forge/jupyterlite-feedstock/pull/6

## Code changes

- [x] update jupyterlab trove classifiers
- [ ] ???

## User-facing changes

- browsers of PyPI will find the extensions in the accurate places

## Backwards-incompatible changes

- n/a