### PR TITLE
Update link to Notebook 7 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 [try it with jupyterlab!]: https://jupyterlite.readthedocs.io/en/stable/try/lab
 [lab-screenshot]:
   https://github.com/jupyterlite/jupyterlite/assets/591645/8cd26a4e-59db-4b34-bf9b-cd2e9cbc7f98
-[try it with jupyter notebook!]: https://jupyterlite.readthedocs.io/en/stable/try/retro
+[try it with jupyter notebook!]: https://jupyterlite.readthedocs.io/en/stable/try/tree
 [notebook-screenshot]:
   https://github.com/jupyterlite/jupyterlite/assets/591645/39acb251-69aa-4e2e-8768-6f33fc32b3e2
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

The link was pointing to `/retro` while iterating on the JupyterLab 4 and Notebook 7 update.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

`README.md` update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Redirect to Notebook 7 from the README.

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
