### PR TITLE
Fix extra console.log, avoid future console.log noise

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,9 +46,10 @@ module.exports = {
     ],
     'jest/no-done-callback': 'off',
     'jest/no-standalone-expect': 'off',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
+    'prefer-arrow-callback': 'error',
     curly: ['error', 'all'],
     eqeqeq: ['error'],
-    'prefer-arrow-callback': 'error',
   },
   settings: {
     react: {

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -439,7 +439,6 @@ const sessionContextPatch: JupyterFrontEndPlugin<void> = {
     const contents = app.serviceManager.contents;
 
     widgetOpener.opened.connect((_, widget) => {
-      console.log('widget opened', widget);
       const context = docManager.contextForWidget(widget);
       const driveName = contents.driveName(context?.path ?? '');
       if (driveName === '') {

--- a/packages/javascript-kernel/src/worker.ts
+++ b/packages/javascript-kernel/src/worker.ts
@@ -7,6 +7,7 @@ export class JavaScriptRemoteKernel {
    * @param options The options for the kernel.
    */
   async initialize(options: IJavaScriptWorkerKernel.IOptions) {
+    // eslint-disable-next-line no-console
     console.log = function (...args) {
       const bundle = {
         name: 'stdout',
@@ -17,6 +18,7 @@ export class JavaScriptRemoteKernel {
         bundle,
       });
     };
+    // eslint-disable-next-line no-console
     console.info = console.log;
 
     console.error = function (...args) {

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -232,6 +232,7 @@ const emscriptenFileSystemPlugin: JupyterLiteServerPlugin<IBroadcastChannelWrapp
       if (err || msg) {
         console.warn(`${what} will NOT be synced`);
       } else {
+        // eslint-disable-next-line no-console
         console.info(`${what} will be synced`);
       }
     }

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -44,13 +44,16 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       registration =
         (await serviceWorker.getRegistration(serviceWorker.controller.scriptURL)) ||
         null;
+      // eslint-disable-next-line no-console
       console.info('JupyterLite ServiceWorker was already registered');
     }
 
     if (!registration && serviceWorker) {
       try {
+        // eslint-disable-next-line no-console
         console.info('Registering new JupyterLite ServiceWorker', workerUrl);
         registration = await serviceWorker.register(workerUrl);
+        // eslint-disable-next-line no-console
         console.info('JupyterLite ServiceWorker was sucessfully registered');
       } catch (err: any) {
         console.warn(err);


### PR DESCRIPTION
## References

- noted during smoke tests of https://github.com/jupyterlite/pyodide-kernel/pull/74

## Code changes

- [x] remove errant `console.log`
- [x] make future, unexpected `console.(log|info)` eslint errors
- [x] `// eslint-disable-next-line no-console` for existing, important things (redirecting working streams)

## User-facing changes

- users should not see debugging console noise when e.g. reporting errors

## Backwards-incompatible changes

- n/a