### PR TITLE
Add markdownviewer-extension to edit app

### DIFF
--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -193,6 +193,7 @@
       "@jupyterlab/json-extension",
       "@jupyterlab/lsp-extension",
       "@jupyterlab/mainmenu-extension",
+      "@jupyterlab/markdownviewer-extension",
       "@jupyterlab/markedparser-extension",
       "@jupyterlab/mathjax-extension",
       "@jupyterlab/metadataform-extension",

--- a/py/jupyterlite/README.md
+++ b/py/jupyterlite/README.md
@@ -38,7 +38,7 @@ JupyterLite works with both [JupyterLab](https://github.com/jupyterlab/jupyterla
 [try it with jupyterlab!]: https://jupyterlite.readthedocs.io/en/stable/try/lab
 [lab-screenshot]:
   https://github.com/jupyterlite/jupyterlite/assets/591645/8cd26a4e-59db-4b34-bf9b-cd2e9cbc7f98
-[try it with jupyter notebook!]: https://jupyterlite.readthedocs.io/en/stable/try/retro
+[try it with jupyter notebook!]: https://jupyterlite.readthedocs.io/en/stable/try/tree
 [notebook-screenshot]:
   https://github.com/jupyterlite/jupyterlite/assets/591645/39acb251-69aa-4e2e-8768-6f33fc32b3e2
 


### PR DESCRIPTION
## References

- fixes #1248

## Code changes

- [x] add `@jupyterlab/markdownviewer-extension` to edit `package.json`
- [x] run linter (dangling change from #1234)

## User-facing changes

- users should be able to view markdown previews when editing `.md` documents

![image](https://github.com/jupyterlite/jupyterlite/assets/45380/5749f434-3628-4142-add7-fbaf8dfca87b)

## Backwards-incompatible changes

- n/a