### PR TITLE
javascript-kernel: use string repr of eval result

### DIFF
--- a/packages/javascript-kernel/package.json
+++ b/packages/javascript-kernel/package.json
@@ -44,13 +44,15 @@
   "dependencies": {
     "@jupyterlab/coreutils": "~6.0.7",
     "@jupyterlite/kernel": "^0.2.1",
-    "comlink": "^4.3.1"
+    "comlink": "^4.3.1",
+    "object-inspect": "^1.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.12.1",
     "@jupyterlab/testutils": "~4.0.7",
     "@types/jest": "^29.5.3",
+    "@types/object-inspect": "^1.8.4",
     "jest": "^29.6.2",
     "rimraf": "~5.0.1",
     "ts-jest": "^29.1.1",

--- a/packages/javascript-kernel/src/worker.ts
+++ b/packages/javascript-kernel/src/worker.ts
@@ -1,4 +1,6 @@
 import { IJavaScriptWorkerKernel } from './tokens';
+import { KernelMessage } from '@jupyterlab/services';
+import objectInspect from 'object-inspect';
 
 export class JavaScriptRemoteKernel {
   /**
@@ -44,13 +46,17 @@ export class JavaScriptRemoteKernel {
   async execute(content: any, parent: any) {
     const { code } = content;
     try {
-      const result = self.eval(code);
+      const result = self.eval(code) as unknown;
       this._executionCount++;
 
-      const bundle = {
-        data: {
-          'text/plain': result,
-        },
+      const textPlain = this._inspect(result);
+      const data: { ['text/plain']?: string } = {};
+      if (typeof textPlain === 'string') {
+        data['text/plain'] = textPlain;
+      }
+
+      const bundle: KernelMessage.IExecuteResultMsg['content'] = {
+        data,
         metadata: {},
         execution_count: this._executionCount,
       };
@@ -104,6 +110,14 @@ export class JavaScriptRemoteKernel {
       metadata: {},
       status: 'ok',
     };
+  }
+
+  private _inspect(val: unknown): string | undefined {
+    if (typeof val === 'undefined') {
+      return undefined;
+    } else {
+      return objectInspect(val);
+    }
   }
 
   private _executionCount = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,8 +4416,10 @@ __metadata:
     "@jupyterlab/testutils": ~4.0.7
     "@jupyterlite/kernel": ^0.2.1
     "@types/jest": ^29.5.3
+    "@types/object-inspect": ^1.8.4
     comlink: ^4.3.1
     jest: ^29.6.2
+    object-inspect: ^1.13.1
     rimraf: ~5.0.1
     ts-jest: ^29.1.1
     typescript: ~5.0.4
@@ -6053,6 +6055,13 @@ __metadata:
   version: 2.4.1
   resolution: "@types/normalize-package-data@npm:2.4.1"
   checksum: e87bccbf11f95035c89a132b52b79ce69a1e3652fe55962363063c9c0dae0fe2477ebc585e03a9652adc6f381d24ba5589cc5e51849df4ced3d3e004a7d40ed5
+  languageName: node
+  linkType: hard
+
+"@types/object-inspect@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "@types/object-inspect@npm:1.8.4"
+  checksum: 06e1993607285603c619e6f8402effb8d3a7a797fc857a96f9d8200eb31e0e2017d26efc82b0a5e40ae82f6da5caa824edc4dff798afb63dbfaa8a029cd3b4ad
   languageName: node
   linkType: hard
 
@@ -14621,6 +14630,13 @@ __metadata:
   version: 1.12.3
   resolution: "object-inspect@npm:1.12.3"
   checksum: dabfd824d97a5f407e6d5d24810d888859f6be394d8b733a77442b277e0808860555176719c5905e765e3743a7cada6b8b0a3b85e5331c530fd418cc8ae991db
+  languageName: node
+  linkType: hard
+
+"object-inspect@npm:^1.13.1":
+  version: 1.13.1
+  resolution: "object-inspect@npm:1.13.1"
+  checksum: 7d9fa9221de3311dcb5c7c307ee5dc011cdd31dc43624b7c184b3840514e118e05ef0002be5388304c416c0eb592feb46e983db12577fc47e47d5752fbbfb61f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## References

Closes #1255

## Code changes

Adds the `object-inspect` library to the Javascript kernel, and uses that to represent values evaluated in the Javascript kernel.

## User-facing changes

* In Javascript notebooks, objects print key/value instead of `[object Object]`, arrays are printed with enclosing brackets.
* .ipynb files made by the Javascript kernel meet nbformat's schema

## Backwards-incompatible changes

N/A