### PR TITLE
Handle missing `all_federated.json`

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -248,10 +248,6 @@ class CompileSchemasPlugin {
       });
 
       fs.writeFileSync(path.resolve(schemaDir, 'all.json'), JSON.stringify(all));
-
-      // ensure the settings file for federated is also created
-      fs.writeFileSync(path.resolve(schemaDir, 'all_federated.json'), {});
-
       callback();
     });
   }

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -227,7 +227,6 @@ class CompileSchemasPlugin {
     compiler.hooks.done.tapAsync('CompileSchemasPlugin', (compilation, callback) => {
       // ensure all schemas are statically compiled
       const schemaDir = path.resolve(topLevelBuild, './schemas');
-      const allCore = 'all.json';
       const files = glob.sync(`${schemaDir}/**/*.json`, {
         ignore: [`${schemaDir}/all*.json`],
       });
@@ -248,7 +247,11 @@ class CompileSchemasPlugin {
         };
       });
 
-      fs.writeFileSync(path.resolve(schemaDir, allCore), JSON.stringify(all));
+      fs.writeFileSync(path.resolve(schemaDir, 'all.json'), JSON.stringify(all));
+
+      // ensure the settings file for federated is also created
+      fs.writeFileSync(path.resolve(schemaDir, 'all_federated.json'), {});
+
       callback();
     });
   }

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -96,10 +96,13 @@ export class Settings implements ISettings {
    * Get all the settings
    */
   async getAll(): Promise<{ settings: IPlugin[] }> {
-    const [allCore, allFederated] = await Promise.all([
-      this._getAll('all.json'),
-      this._getAll('all_federated.json'),
-    ]);
+    const allCore = await this._getAll('all.json');
+    let allFederated: IPlugin[] = [];
+    try {
+      allFederated = await this._getAll('all_federated.json');
+    } catch {
+      // handle the case where there is no federated extension
+    }
 
     // JupyterLab 4 expects all settings to be returned in one go
     // so append the settings from federated plugins to the core ones


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1268


## Code changes

There might be cases where `all_federated.json` is missing, for example when there is no federated extension in the build environment.

Or when building the source JS packages, or reusing some of them without running a `jupyter lite build`.

## User-facing changes

Should prevent 404 errors as reported in https://github.com/jupyterlite/jupyterlite/issues/1268.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
