### PR TITLE
Update to `jupyterlite-pyodide-kernel==0.2.0`

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   # https://github.com/jupyterlite/jupyterlab-webrtc-docprovider/issues/16
   # - jupyterlab-webrtc-docprovider >=0.1.1
   - jupyterlab-night
-  - jupyterlite-pyodide-kernel >=0.1.1
+  - jupyterlite-pyodide-kernel >=0.2.0
   # if a package is pinned with == `doit check` will ensure the version is pinned
   # in `docs/_build/_static/files/*.ipynb`
   - bqplot

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -18,7 +18,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.6-pyhd8ed1ab_0.conda",
-      "https://conda.anaconda.org/conda-forge/label/jupyterlite_pyodide_kernel_alpha/noarch/jupyterlite-pyodide-kernel-0.2.0a1-pyh9178eb9_0.conda",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlite-pyodide-kernel-0.2.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.15.0-pyhd8ed1ab_0.conda",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl"
     ],

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
 ../py/jupyterlite-javascript-kernel
 jupyterlab-language-pack-fr-FR
 jupyterlite-p5-kernel==0.1.1
-jupyterlite-pyodide-kernel==0.2.0a2
+jupyterlite-pyodide-kernel==0.2.0
 notebook==7.0.6
 theme-darcula==4.0.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Since there is now a stable release of `jupyterlite-pyodide-kernel`: https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.2.0

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update the version of `jupyterlite-pyodide-kernel` used on ReadTheDocs and for the UI tests.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes



<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
