### PR TITLE
Provide the server router from a token rather than an app attribute

### DIFF
--- a/docs/howto/extensions/kernel.md
+++ b/docs/howto/extensions/kernel.md
@@ -19,7 +19,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
   id: 'my-custom-kernel:plugin',
   autoStart: true,
   requires: [IKernelSpecs],
-  activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
+  activate: (app: IJupyterLiteServer, kernelspecs: IKernelSpecs) => {
     kernelspecs.register({
       spec: {
         name: 'custom',

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -11,7 +11,27 @@ import { WebSocket } from 'mock-socket';
 
 import { Router } from './router';
 
-export type JupyterLiteServerPlugin<T> = IPlugin<JupyterLiteServer, T>;
+/**
+ * JupyterLiteServer application interface
+ */
+export interface IJupyterLiteServer extends Application<never> {
+  /**
+   * Get the underlying `Router` instance.
+   *
+   * @deprecated Please use the token {@link IServerRouter}. This will be removed in a future release.
+   */
+  readonly router: Router;
+
+  /**
+   * Get the underlying lite service manager for this app.
+   */
+  readonly serviceManager: ServiceManager;
+}
+
+/**
+ * A user-defined JupyterLiteServer plugin
+ */
+export type JupyterLiteServerPlugin<T> = IPlugin<IJupyterLiteServer, T>;
 
 /**
  * Mock the Event Manager for now
@@ -186,6 +206,6 @@ export namespace JupyterLiteServer {
     /**
      * The default export.
      */
-    default: IPlugin<JupyterLiteServer, any> | IPlugin<JupyterLiteServer, any>[];
+    default: IPlugin<IJupyterLiteServer, any> | IPlugin<IJupyterLiteServer, any>[];
   }
 }

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -2,7 +2,22 @@ import { Token } from '@lumino/coreutils';
 
 import { ISignal } from '@lumino/signaling';
 
+import type { Router } from './router';
+
 import SW_URL from './service-worker?text';
+
+/**
+ * The server router token.
+ */
+export const IServerRouter = new Token<IServerRouter>(
+  '@jupyterlite/server:IServerRouter',
+  'Provides the server request router.',
+);
+
+/**
+ * Server router interface
+ */
+export type IServerRouter = Router;
 
 /**
  * The token for the ServiceWorker.

--- a/py/jupyterlite-javascript-kernel/src/index.ts
+++ b/py/jupyterlite-javascript-kernel/src/index.ts
@@ -3,7 +3,7 @@
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { JupyterLiteServer, JupyterLiteServerPlugin } from '@jupyterlite/server';
+import { IJupyterLiteServer, JupyterLiteServerPlugin } from '@jupyterlite/server';
 
 import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
 
@@ -16,7 +16,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
   id: '@jupyterlite/javascript-kernel-extension:kernel',
   autoStart: true,
   requires: [IKernelSpecs],
-  activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {
+  activate: (app: IJupyterLiteServer, kernelspecs: IKernelSpecs) => {
     const baseUrl = PageConfig.getBaseUrl();
     kernelspecs.register({
       spec: {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes partly #1284. The next step is to make the `JupyterFrontEnd` more composable to allow dropping the namespacing separation between JupyterLite and JupyterLab/Notebook.

The goal is for third-party developer to be able to hook part of their Jupyter extension into the JupyterLiteServer without additional burden of namespacing plugins (what can be lifted if the Lumino `Application` is changed to a composition of plugins).

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Make the server request router available from a token.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None - the `router` attribute has been marked as deprecated but not removed.
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
