### PR TITLE
Fix typo in docs for adding custom file type

### DIFF
--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -81,7 +81,7 @@ For example, to ensure the `.fasta` file format is served correctly as `text/pla
       "fasta": {
         "name": "fasta",
         "extensions": [".fasta"],
-        "mimetypes": ["text/plain"],
+        "mimeTypes": ["text/plain"],
         "fileFormat": "text"
       }
     }


### PR DESCRIPTION
Fix typo in the docs for providing a custom file type to the jupyter_lite_config.json

## References

Fixes #1286

## Code changes

Just fix the typo in the doc file

