### PR TITLE
Update the IFrame guide to reference the JupyterLab extension template

### DIFF
--- a/docs/howto/configure/advanced/iframe.md
+++ b/docs/howto/configure/advanced/iframe.md
@@ -22,15 +22,15 @@ Follow the
 to create an environment:
 
 ```bash
-conda create -n jupyterlab-iframe-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=3 cookiecutter nodejs jupyterlite-core
+conda create -n jupyterlab-iframe-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=4 nodejs=20 git copier=7 jinja2-time jupyterlite-core
 conda activate jupyterlab-iframe-ext
 ```
 
 Create a directory in your workspace, move to this directory, then generate an extension
-template using [cookiecutter](https://github.com/cookiecutter/cookiecutter):
+template using [copier](https://copier.readthedocs.io):
 
 ```bash
-cookiecutter https://github.com/jupyterlab/extension-cookiecutter-ts
+copier copy https://github.com/jupyterlab/extension-template .
 ```
 
 ```bash

--- a/docs/howto/extensions/frontend.md
+++ b/docs/howto/extensions/frontend.md
@@ -91,7 +91,7 @@ If you would like to have a Python kernel available in your test JupyterLite dep
 Once you have your extension running you might want to publish to PyPI so it can be
 installed by other folks.
 
-By default the extension created from the cookiecutter is compatible with the Jupyter
+By default the extension created from the template is compatible with the Jupyter
 Releaser.
 
 The Jupyter Releaser simplifies the release process and ensure best practices.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Update the guide to use the extension template instead of the cookieccuter: https://github.com/jupyterlab/extension-template.

The extension template is now the default in the JupyterLab tutorial: https://jupyterlab.readthedocs.io/en/latest/extension/extension_tutorial.html

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
