### PR TITLE
Fix a few typos in documentation

### DIFF
--- a/docs/howto/configure/advanced/extensions.md
+++ b/docs/howto/configure/advanced/extensions.md
@@ -98,7 +98,7 @@ federated extensions, as packaged on:
 
 If detected, [`libarchive-c`](https://pypi.org/project/libarchive-c) will be used for
 better performance, especially when working with archives with many/large assets,
-espcially [pyodide](../../pyodide/pyodide.md).
+especially [pyodide](../../pyodide/pyodide.md).
 
 If `libarchive-c` is not detected, Python's built-in `zipfile` and `tarfile` modules
 will be used.

--- a/docs/howto/configure/config_files.md
+++ b/docs/howto/configure/config_files.md
@@ -77,7 +77,7 @@ Check out the [](../../reference/schema.md) for a complete list of the available
 The `overrides.json` file is used to override the plugins and extension settings of
 JupyterLite.
 
-For example it can be used to overridde the default theme when users launch JupyterLite.
+For example it can be used to override the default theme when users launch JupyterLite.
 The content of the file then be:
 
 ```json

--- a/docs/howto/configure/interface_switcher.md
+++ b/docs/howto/configure/interface_switcher.md
@@ -49,4 +49,4 @@ Notebook interfaces:
 ## References
 
 Check out the [guide for adding extensions](../configure/simple_extensions.md) for more
-informations about how to add extensions to your JupyterLite site.
+information about how to add extensions to your JupyterLite site.

--- a/docs/howto/configure/simple_extensions.md
+++ b/docs/howto/configure/simple_extensions.md
@@ -160,7 +160,7 @@ demonstrates a few [extensions](../../reference/demo.md).
 [#9461]: https://github.com/jupyterlab/jupyterlab/issues/9461
 [pre-built extensions]: https://jupyterlab.readthedocs.io/en/stable/user/extensions.html
 
-## Avanced extension configuration
+## Advanced extension configuration
 
 If you are looking for more options to configure extensions, check out the dedicated
 guide on [Advanced extension configuration](./advanced/extensions.md).

--- a/docs/howto/extensions/cli-addons.md
+++ b/docs/howto/extensions/cli-addons.md
@@ -196,5 +196,5 @@ my-unique-addon = "my_module:MyAddon"
 ## General Guidance
 
 - it's worth looking at how what `BaseAddon` and its subclasses handle certain tasks
-- keeping reproducbility in mind, cache liberally, and make use of `file_deps`,
+- keeping reproducibility in mind, cache liberally, and make use of `file_deps`,
   `targets`, and `uptodate` to keep builds snappy

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -44,7 +44,7 @@ the Pyodide kernel by default, since the `jupyterlite` metapackage would depend 
 `jupyterlite-pyodide-kernel`.
 
 In version `0.2.0` this is not the case anymore. You will need to install the
-`jupyterlite-pyodide-kernel` explicitely in your build environment alongside
+`jupyterlite-pyodide-kernel` explicitly in your build environment alongside
 `jupyterlite-core` (the package providing the `jupyter-lite` CLI).
 
 See [the documentation for adding kernels](./howto/configure/kernels.md) to learn more.

--- a/docs/quickstart/configure.md
+++ b/docs/quickstart/configure.md
@@ -1,14 +1,14 @@
 # Configure a JupyterLite site
 
 Once you have initialized a JupyterLite site, configuration changes can be made by
-either adding or editing configutation files in the
+either adding or editing configuration files in the
 [Lite Dir](../reference/cli.ipynb#the-lite-dir).
 
 Configuration values are set in one or more of the
 [Runtime Configuration Files](../reference/config.md) in
 [well known locations in the Lite Dir](../reference/cli.ipynb#the-lite-dir).
 Configuration information is merged in a cascade, allowing settings to be set in the
-root of the [Lite Dir](../reference/cli.ipynb#the-lite-dir), and superceeded by settings
+root of the [Lite Dir](../reference/cli.ipynb#the-lite-dir), and superseded by settings
 for an individual app such as `repl` and `lab`.
 
 Available options are defined in the Jupyter Config Data

--- a/docs/quickstart/using.md
+++ b/docs/quickstart/using.md
@@ -72,7 +72,7 @@ JupyterLite Kernels implement [Jupyter Kernel Messaging][jkm] in the browser wit
 help of [`mock-socket`][mock-socket] and [WebAssembly][webassembly], without relying on
 any external infrastructure.
 
-The JupyterLite contibutors develop and maintain the following kernels:
+The JupyterLite contributors develop and maintain the following kernels:
 
 - a Python kernel based on [Pyodide][pyodide]:
   [https://github.com/jupyterlite/pyodide-kernel](https://github.com/jupyterlite/pyodide-kernel)

--- a/examples/pyodide/python-packages.ipynb
+++ b/examples/pyodide/python-packages.ipynb
@@ -125,7 +125,7 @@
     "- `--editable` (or `-e.`) local or remote paths\n",
     "- any version control system (VCS) paths\n",
     "- non-`.whl` URLs or local archives\n",
-    "- `--constraint` (or `-c`) contraint files"
+    "- `--constraint` (or `-c`) constraint files"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes a few typos found whilst reading the documentation and trying out `jupyterlite`.