### PR TITLE
Add an option to enable the service worker cache

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -187,6 +187,11 @@
           "description": "Whether to enable collaborative editing over WebRTC. Should be paired with the ``?room=<room name>`` URL parameter",
           "type": "boolean",
           "default": false
+        },
+        "enableServiceWorkerCache": {
+          "description": "Whether to enable the service worker cache for offline use",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -189,7 +189,7 @@
           "default": false
         },
         "enableServiceWorkerCache": {
-          "description": "Whether to enable the service worker cache for offline use",
+          "description": "Whether to enable the service worker cache",
           "type": "boolean",
           "default": false
         }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,6 +33,33 @@ As an alternative to `jupyterlite-javascript-kernel`, you may also want to use [
 [Xeus JavaScript]: https://github.com/jupyter-xeus/xeus-javascript
 [jupyterlite-javascript-kernel]: https://github.com/jupyterlite/javascript-kernel
 
+### Service Worker
+
+JupyterLite uses a Service Worker to make files and notebooks visible to the kernels, so
+they can be manipulated by the user via code in the notebook.
+
+In previous versions, the Service Worker had caching enabled by default, and it was not
+possible to easily disable it.
+
+The Service Worker cache was however the source of many issues when accessing files from
+a kernel, often giving errors to users, who would have to clear their cache to fix the
+issue.
+
+In JupyterLite 0.3.0, the Service Worker cache is **disabled** by default, but it is
+still possible to enable it if needed.
+
+To enable the Service Worker cache, add the `enableServiceWorkerCache` option to your
+`jupyter-lite.json` file. For example:
+
+```json
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "enableServiceWorkerCache": true
+  }
+}
+```
+
 ## `0.1.0` to `0.2.0`
 
 ### Extensions

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -11,7 +11,10 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
   constructor(options?: IServiceWorkerManager.IOptions) {
     const workerUrl =
       options?.workerUrl ?? URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
-    void this.initialize(workerUrl).catch(console.warn);
+    const fullWorkerUrl = new URL(workerUrl, window.location.href);
+    // TODO: read from page config
+    fullWorkerUrl.searchParams.set('enableCache', 'true');
+    void this.initialize(fullWorkerUrl.href).catch(console.warn);
   }
 
   /**
@@ -91,7 +94,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       }
     }
 
-    this.setRegistration(registration);
+    this._setRegistration(registration);
 
     if (!registration) {
       this._ready.reject(void 0);
@@ -100,7 +103,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     }
   }
 
-  private setRegistration(registration: ServiceWorkerRegistration | null) {
+  private _setRegistration(registration: ServiceWorkerRegistration | null) {
     this._registration = registration;
     this._registrationChanged.emit(this._registration);
   }

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -13,7 +13,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       options?.workerUrl ?? URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
     const fullWorkerUrl = new URL(workerUrl, window.location.href);
     // TODO: read from page config
-    fullWorkerUrl.searchParams.set('enableCache', 'true');
+    fullWorkerUrl.searchParams.set('enableCache', 'false');
     void this.initialize(fullWorkerUrl.href).catch(console.warn);
   }
 

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -12,7 +12,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     const workerUrl =
       options?.workerUrl ?? URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
     const fullWorkerUrl = new URL(workerUrl, window.location.href);
-    const enableCache = PageConfig.getOption('enableServiceWorkerCache');
+    const enableCache = PageConfig.getOption('enableServiceWorkerCache') || 'false';
     fullWorkerUrl.searchParams.set('enableCache', enableCache);
     void this.initialize(fullWorkerUrl.href).catch(console.warn);
   }

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -12,8 +12,8 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     const workerUrl =
       options?.workerUrl ?? URLExt.join(PageConfig.getBaseUrl(), WORKER_NAME);
     const fullWorkerUrl = new URL(workerUrl, window.location.href);
-    // TODO: read from page config
-    fullWorkerUrl.searchParams.set('enableCache', 'false');
+    const enableCache = PageConfig.getOption('enableServiceWorkerCache');
+    fullWorkerUrl.searchParams.set('enableCache', enableCache);
     void this.initialize(fullWorkerUrl.href).catch(console.warn);
   }
 

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -29,9 +29,6 @@ self.addEventListener('fetch', onFetch);
  * Handle installation with the cache
  */
 function onInstall(event: ExtendableEvent): void {
-  // check if we should enable the cache
-  const searchParams = new URL(location.href).searchParams;
-  enableCache = searchParams.get('enableCache') === 'true';
   void self.skipWaiting();
   event.waitUntil(cacheAll());
 }
@@ -40,6 +37,9 @@ function onInstall(event: ExtendableEvent): void {
  * Handle activation.
  */
 function onActivate(event: ExtendableEvent): void {
+  // check if we should enable the cache
+  const searchParams = new URL(location.href).searchParams;
+  enableCache = searchParams.get('enableCache') === 'true';
   event.waitUntil(self.clients.claim());
 }
 

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -12,6 +12,11 @@ const CACHE = 'precache';
 const broadcast = new BroadcastChannel('/api/drive.v1');
 
 /**
+ * Whether to enable the cache
+ */
+let enableCache = false;
+
+/**
  * Install event listeners
  */
 self.addEventListener('install', onInstall);
@@ -24,6 +29,9 @@ self.addEventListener('fetch', onFetch);
  * Handle installation with the cache
  */
 function onInstall(event: ExtendableEvent): void {
+  // check if we should enable the cache
+  const searchParams = new URL(location.href).searchParams;
+  enableCache = searchParams.get('enableCache') === 'true';
   void self.skipWaiting();
   event.waitUntil(cacheAll());
 }
@@ -61,6 +69,10 @@ async function onFetch(event: FetchEvent): Promise<void> {
 /** Get a cached response, and update cache. */
 async function maybeFromCache(event: FetchEvent): Promise<Response> {
   const { request } = event;
+
+  if (!enableCache) {
+    return await fetch(request);
+  }
 
   let response: Response | null = await fromCache(request);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1103

Also related to:
- https://github.com/jupyterlite/jupyterlite/issues/1294
- https://github.com/jupyterlite/jupyterlite/issues/969
- https://github.com/jupyterlite/jupyterlite/issues/815

The service worker caching is probably one of the biggest frustration points for JupyterLite users. Making it an opt-in might help make the user experience smoother.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Add an (opt-in) option to enable the Service Worker cache.
- [x] Read from page config
- [x] Add to migration guide

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Hopefully less issues about missing files and after updating JupyterLite versions.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

More of a change in behavior than a breaking change. Still need to be documented in the migration guide though.

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
