### PR TITLE
Enable the notifications plugin in Notebook 7

### DIFF
--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -283,7 +283,6 @@
       "@jupyterlab/application-extension:tree-resolver",
       "@jupyterlab/apputils-extension:announcements",
       "@jupyterlab/apputils-extension:kernel-status",
-      "@jupyterlab/apputils-extension:notification",
       "@jupyterlab/apputils-extension:palette-restorer",
       "@jupyterlab/apputils-extension:print",
       "@jupyterlab/apputils-extension:resolver",

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -304,7 +304,6 @@
       "@jupyterlab/application-extension:tree-resolver",
       "@jupyterlab/apputils-extension:announcements",
       "@jupyterlab/apputils-extension:kernel-status",
-      "@jupyterlab/apputils-extension:notification",
       "@jupyterlab/apputils-extension:palette-restorer",
       "@jupyterlab/apputils-extension:print",
       "@jupyterlab/apputils-extension:resolver",

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -309,7 +309,6 @@
       "@jupyterlab/application-extension:tree-resolver",
       "@jupyterlab/apputils-extension:announcements",
       "@jupyterlab/apputils-extension:kernel-status",
-      "@jupyterlab/apputils-extension:notification",
       "@jupyterlab/apputils-extension:palette-restorer",
       "@jupyterlab/apputils-extension:print",
       "@jupyterlab/apputils-extension:resolver",

--- a/app/repl/package.json
+++ b/app/repl/package.json
@@ -225,7 +225,6 @@
       "@jupyterlab/application:mimedocument",
       "@jupyterlab/apputils-extension:announcements",
       "@jupyterlab/apputils-extension:kernel-status",
-      "@jupyterlab/apputils-extension:notification",
       "@jupyterlab/apputils-extension:palette-restorer",
       "@jupyterlab/apputils-extension:print",
       "@jupyterlab/apputils-extension:resolver",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -264,7 +264,6 @@
       "@jupyterlab/application-extension:tree-resolver",
       "@jupyterlab/apputils-extension:announcements",
       "@jupyterlab/apputils-extension:kernel-status",
-      "@jupyterlab/apputils-extension:notification",
       "@jupyterlab/apputils-extension:palette-restorer",
       "@jupyterlab/apputils-extension:print",
       "@jupyterlab/apputils-extension:resolver",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

As noticed in https://github.com/jupyterlite/jupyterlite/issues/1323

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Enable the `@jupyterlab/apputils-extension:notification` plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This should make it possible for extensions to use the notifications API in Notebook 7 apps.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
