### PR TITLE
Mock `/api/config` endpoint

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -13,6 +13,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-geojson-3.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-github-4.0.0-pyhd8ed1ab_2.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-kernelspy-4.0.0-pyhd8ed1ab_0.conda",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-tour-4.0.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda",

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -13,7 +13,6 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-geojson-3.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-github-4.0.0-pyhd8ed1ab_2.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-kernelspy-4.0.0-pyhd8ed1ab_0.conda",
-      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-tour-4.0.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda",

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -64,6 +64,23 @@ const localforageMemoryPlugin: JupyterLiteServerPlugin<void> = {
 };
 
 /**
+ * A plugin providing the routes for the config section.
+ * TODO: implement logic to persist the config sections?
+ */
+const configSectionRoutesPlugin: JupyterLiteServerPlugin<void> = {
+  id: '@jupyterlite/server-extension:config-section-routes',
+  autoStart: true,
+  activate: (app: JupyterLiteServer) => {
+    app.router.get('/api/config', async (req: Router.IRequest) => {
+      return new Response(JSON.stringify({}));
+    });
+    app.router.patch('/api/config', async (req: Router.IRequest) => {
+      return new Response(JSON.stringify({}));
+    });
+  },
+};
+
+/**
  * The contents service plugin.
  */
 const contentsPlugin: JupyterLiteServerPlugin<IContents> = {
@@ -561,6 +578,7 @@ const translationRoutesPlugin: JupyterLiteServerPlugin<void> = {
 };
 
 const plugins: JupyterLiteServerPlugin<any>[] = [
+  configSectionRoutesPlugin,
   contentsPlugin,
   contentsRoutesPlugin,
   emscriptenFileSystemPlugin,

--- a/packages/server-extension/src/index.ts
+++ b/packages/server-extension/src/index.ts
@@ -71,11 +71,17 @@ const configSectionRoutesPlugin: JupyterLiteServerPlugin<void> = {
   id: '@jupyterlite/server-extension:config-section-routes',
   autoStart: true,
   activate: (app: JupyterLiteServer) => {
-    app.router.get('/api/config', async (req: Router.IRequest) => {
-      return new Response(JSON.stringify({}));
+    const sections: {
+      [id: string]: string;
+    } = {};
+    app.router.get('/api/config/(.*)', async (req: Router.IRequest, id: string) => {
+      const section = sections[id] ?? JSON.stringify({});
+      return new Response(section);
     });
-    app.router.patch('/api/config', async (req: Router.IRequest) => {
-      return new Response(JSON.stringify({}));
+    app.router.patch('/api/config/(.*)', async (req: Router.IRequest, id: string) => {
+      const payload = req.body as any;
+      sections[id] = payload;
+      return new Response(payload);
     });
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Looking into mocking `/api/config` so extensions that use it (like `jupyterlab-tour`) don't fail hard, or trigger errors in the dev tools console.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Handle `/api/config` endpoint: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/master/jupyter_server/services/api/api.yaml#/config

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Should help with https://github.com/jupyterlite/jupyterlite/pull/1258

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
