### PR TITLE
Unregistering old service workers when there is a new version 

### DIFF
--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -77,12 +77,6 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
 
     if (!registration && serviceWorker) {
       try {
-        // Unregister any existing service workers before registering the new one.
-        const registrations = await serviceWorker.getRegistrations();
-        await Promise.all(registrations.map((r) => r.unregister()));
-        // eslint-disable-next-line no-console
-        console.info('Existing JupyterLite ServiceWorkers unregistered');
-
         // eslint-disable-next-line no-console
         console.info('Registering new JupyterLite ServiceWorker', workerUrl);
         registration = await serviceWorker.register(workerUrl);

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -5,7 +5,7 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 import { IServiceWorkerManager, WORKER_NAME } from './tokens';
 
-const VERSION = '0.2.3'; // TODO: read this from elsewhere
+const VERSION = PageConfig.getOption('appVersion');
 
 export class ServiceWorkerManager implements IServiceWorkerManager {
   constructor(options?: IServiceWorkerManager.IOptions) {

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -37,7 +37,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
 
   private unregisterOldServiceWorkers = () => {
     // Check if we have an installed version. If we do, compare it to the current version
-    // And unregister all service workers if they are different.
+    // and unregister all service workers if they are different.
     const installedVersion = localStorage.getItem('jupyterlite-version');
 
     if ((installedVersion && installedVersion !== VERSION) || !installedVersion) {


### PR DESCRIPTION
## References
Closes https://github.com/jupyterlite/jupyterlite/issues/1335

## Code changes

I added a test to see which service worker version that is installed and will unregisted any old ones if there are a new version, or if no version is registered.

I would like to read the version from a global place rather than a const variable in the top of the file, so input in this is appreciated. 

Alternatively, adding a version (hash) to the service worker URL (which today is without version e.g. https://jupyterlite.readthedocs.io/en/stable/_static/service-worker.js ) would also work.

## User-facing changes
Breaking changes between service workers will no long lead to kernel death.
