### PR TITLE
[0.2.x] Bump to `jupyterlite-pyodide-kernel==0.2.3` in the demo site

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -18,7 +18,7 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_miami_nights-0.4.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/notebook-7.0.7-pyhd8ed1ab_0.conda",
-      "https://conda.anaconda.org/conda-forge/noarch/jupyterlite-pyodide-kernel-0.2.0-pyhd8ed1ab_0.conda",
+      "https://conda.anaconda.org/conda-forge/noarch/jupyterlite-pyodide-kernel-0.2.3-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/plotly-5.15.0-pyhd8ed1ab_0.conda",
       "https://github.com/jupyterlite/p5-kernel/releases/download/v0.1.0/jupyterlite_p5_kernel-0.1.0-py3-none-any.whl"
     ],


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes #1342 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update to the fixed `jupyterlite-pyodide-kernel`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Fixes some notebooks for the `stable` version of the demo.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
