### PR TITLE
Add use-credentials to manifest link

### DIFF
--- a/app/index.template.html
+++ b/app/index.template.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="Description" content="WASM powered Jupyter running in the browser." />
-    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="manifest" href="../manifest.webmanifest" crossorigin="use-credentials"/>
     <link
       id="jupyter-lite-main"
       rel="preload"


### PR DESCRIPTION
I keep getting CORS errors from the manifest file:  `has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

I propose adding a `crossorigin="use-credentials"` - I guess it will fix. Hope it is OK to file a tiny PR without issue.