### PR TITLE
Typo in RTD link in index page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -40,7 +40,7 @@ Your JupyterLite is structured like this:
 
       See the recognized schema as described in the documentation:
 
-      - https://jupyterlite.rtfd.io/en/latest/schema
+      - https://jupyterlite.rtfd.io/en/latest/reference/schema.html
 
       Notes
         - fields that...


### PR DESCRIPTION
Fixes an RTD link in index.html

## References
N/A

## Code changes
N/A

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
