### PR TITLE
DriveFS: Handle receiving a stream instead of a node

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -28,6 +28,12 @@ See the JupyterLab and Notebook changelogs for more information:
 This follows this change in JupyterLab:
 [Add `IShell.currentChanged` and notify commands based on it](https://github.com/jupyterlab/jupyterlab/pull/15449)
 
+#### `@jupyterlite/contents` package
+
+The TypeScript interface `IEmscriptenNodeOps` has changed. All methods now take `IEmscriptenFSNode | IEmscriptenStream`
+as input instead of only `IEmscriptenFSNode`. Classes implementing `IEmscriptenNodeOps` will need to be updated accordingly.
+See https://github.com/jupyterlite/jupyterlite/pull/1395 for an example implementation.
+
 ## `0.2.0` to `0.3.0`
 
 ### Extensions

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -30,9 +30,10 @@ This follows this change in JupyterLab:
 
 #### `@jupyterlite/contents` package
 
-The TypeScript interface `IEmscriptenNodeOps` has changed. All methods now take `IEmscriptenFSNode | IEmscriptenStream`
-as input instead of only `IEmscriptenFSNode`. Classes implementing `IEmscriptenNodeOps` will need to be updated accordingly.
-See https://github.com/jupyterlite/jupyterlite/pull/1395 for an example implementation.
+The TypeScript interface `IEmscriptenNodeOps` has changed. All methods now take
+`IEmscriptenFSNode | IEmscriptenStream` as input instead of only `IEmscriptenFSNode`.
+Classes implementing `IEmscriptenNodeOps` will need to be updated accordingly. See
+https://github.com/jupyterlite/jupyterlite/pull/1395 for an example implementation.
 
 ## `0.2.0` to `0.3.0`
 

--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -64,21 +64,32 @@ export function instanceOfStream(
 }
 
 export interface IEmscriptenNodeOps {
-  getattr(node: IEmscriptenFSNode): IStats;
-  setattr(node: IEmscriptenFSNode, attr: IStats): void;
-  lookup(parent: IEmscriptenFSNode, name: string): IEmscriptenFSNode;
+  getattr(node: IEmscriptenFSNode | IEmscriptenStream): IStats;
+  setattr(node: IEmscriptenFSNode | IEmscriptenStream, attr: IStats): void;
+  lookup(
+    parent: IEmscriptenFSNode | IEmscriptenStream,
+    name: string,
+  ): IEmscriptenFSNode;
   mknod(
-    parent: IEmscriptenFSNode,
+    parent: IEmscriptenFSNode | IEmscriptenStream,
     name: string,
     mode: number,
     dev: number,
   ): IEmscriptenFSNode;
-  rename(oldNode: IEmscriptenFSNode, newDir: IEmscriptenFSNode, newName: string): void;
-  unlink(parent: IEmscriptenFSNode, name: string): void;
-  rmdir(parent: IEmscriptenFSNode, name: string): void;
-  readdir(node: IEmscriptenFSNode): string[];
-  symlink(parent: IEmscriptenFSNode, newName: string, oldPath: string): void;
-  readlink(node: IEmscriptenFSNode): string;
+  rename(
+    oldNode: IEmscriptenFSNode | IEmscriptenStream,
+    newDir: IEmscriptenFSNode | IEmscriptenStream,
+    newName: string,
+  ): void;
+  unlink(parent: IEmscriptenFSNode | IEmscriptenStream, name: string): void;
+  rmdir(parent: IEmscriptenFSNode | IEmscriptenStream, name: string): void;
+  readdir(node: IEmscriptenFSNode | IEmscriptenStream): string[];
+  symlink(
+    parent: IEmscriptenFSNode | IEmscriptenStream,
+    newName: string,
+    oldPath: string,
+  ): void;
+  readlink(node: IEmscriptenFSNode | IEmscriptenStream): string;
 }
 
 export interface IEmscriptenStreamOps {

--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -57,6 +57,12 @@ export interface IEmscriptenStream {
   position: number;
 }
 
+export function instanceOfStream(
+  nodeOrStream: IEmscriptenFSNode | IEmscriptenStream,
+): nodeOrStream is IEmscriptenStream {
+  return 'node' in nodeOrStream;
+}
+
 export interface IEmscriptenNodeOps {
   getattr(node: IEmscriptenFSNode): IStats;
   setattr(node: IEmscriptenFSNode, attr: IStats): void;


### PR DESCRIPTION
This will allow removing the monkey patch in https://github.com/jupyterlite/xeus/blob/main/src/worker.ts#L19

This monkey patch was introduced in https://github.com/jupyterlite/xeus-python-kernel/pull/27