### PR TITLE
Mention `jupyterlite-pyodide-kernel` supports the `SharedArrayBuffer` in the documentation

### DIFF
--- a/docs/howto/content/python.md
+++ b/docs/howto/content/python.md
@@ -54,7 +54,7 @@ See the various deployment guides in the [How-to section of the documentation](.
 ```{note}
 File system access via `SharedArrayBuffer` is available with the following Python kernels:
 
-- ❌ `jupyterlite-pyodide-kernel`
+- ✅ `jupyterlite-pyodide-kernel`
 - ✅ `jupyterlite-xeus` with the Xeus Python kernel
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1408

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update documentation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
