### PR TITLE
Mention file access via `SharedArrayBuffer` in the migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,6 +26,9 @@ kernel. Starting with version 0.4.0, JupyterLite allows kernels to leverage the 
 shared memory (via `SharedArrayBuffer`) to make accessing files more robust and
 resilient, and avoid caching issues.
 
+If the COOP and COEP headers, JupyterLite uses shared memory via `SharedArrayBuffer` to
+enable file access. Otherwise, it defaults to using the Service Worker, like before.
+
 See the [documentation on accessing files](./howto/content/files.md) for more
 information.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,6 +17,18 @@ See the JupyterLab and Notebook changelogs for more information:
 - [JupyterLab 4.2](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#v4-2-0)
 - [Jupyter Notebook 7.2](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#v7-2)
 
+### Accessing files from the kernel
+
+JupyterLite 0.4.0 introduces a more robust way for accessing files from kernels.
+
+Previously, JupyterLite was relying on a Service Worker to make the files visible to the
+kernel. Starting with version 0.4.0, JupyterLite allows kernels to leverage the use of
+shared memory (via `SharedArrayBuffer`) to make accessing files more robust and
+resilient, and avoid caching issues.
+
+See the [documentation on accessing files](./howto/content/files.md) for more
+information.
+
 ### API changes
 
 #### `@jupyterlite/application`


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlite/jupyterlite/pull/1405.

So that change is more visible in the migration guide.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation update.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
