### PR TITLE
Fix tbump rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "package.json"
+search = "\"version"\: \"{current_version}\""
 
 [[tool.tbump.file]]
 src = "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "package.json"
-search = "\"version"\: \"{current_version}\""
+search = "\"version\": \"{current_version}\""
 
 [[tool.tbump.file]]
 src = "pyproject.toml"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

As seen on the latest commit after the bump to `0.4.0`: https://github.com/jupyterlite/jupyterlite/actions/runs/10091623303/job/27903550574

The issue was related to `json-schema` also being bumped:

https://github.com/jupyterlite/jupyterlite/blob/ed84e0ac0ffb9ed4d5c3acaefa20c4837079a5d1/package.json#L68

![image](https://github.com/user-attachments/assets/ac96a628-3887-4e28-a3c8-8ede5c953ec1)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix `tbump` rule.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
