### PR TITLE
Update to Python 3.12 for the dev environment and CI

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   ### DOCS ENV ###
   # runtimes
   - nodejs >=20,<21
-  - python >=3.11,<3.12
+  - python >=3.12,<3.13
   # build
   - doit >=0.34,<1
   - hatch >=1.6.3,<2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ jlpm serve
 
 To serve with Python's built-in
 [`http.server`](https://docs.python.org/3/library/http.server.html) module (requires
-Python 3.8+):
+Python 3.7+):
 
 ```bash
 jlpm serve:py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You'll need:
 - `git`
 - `nodejs >=20,<21`
 - `jupyterlab >=4.3,<4.4`
-- `python >=3.11,<3.12`
+- `python >=3.12,<3.13`
 
 Various package managers on different operating systems provide these.
 
@@ -165,7 +165,7 @@ jlpm serve
 
 To serve with Python's built-in
 [`http.server`](https://docs.python.org/3/library/http.server.html) module (requires
-Python 3.7+):
+Python 3.8+):
 
 ```bash
 jlpm serve:py

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   ### DOCS ENV ###
   # runtimes
   - nodejs >=20,<21
-  - python >=3.11,<3.12
+  - python >=3.12,<3.13
   # build
   - doit >=0.34,<1
   - hatch >=1.6.3,<2


### PR DESCRIPTION
Python 3.12 is now almost a year available, so it looks like a good time to update the dev environment and the CI to it. Python 3.12 is faster and offers better error messages, among other features.

This PR does two things:

- Enable Python 3.12 testing on the CI
- Update from Python 3.11 to Python 3.12 for the dev setup.

If preferred, the minimum Python version could also be increased.

See also:
- https://github.com/jupyterlite/jupyterlite/pull/1016
- https://github.com/jupyterlite/jupyterlite/pull/1355