### PR TITLE
remove jupyterlab-github

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - jupyterlab_widgets >=3.0.4,<4.0.0
   - jupyterlab-fasta >=3,<4
   - jupyterlab-geojson >=3,<4
-  - jupyterlab-github >=4.0.0
   - jupyterlab-kernelspy >=4.0.0
   - jupyterlab-tour >=4.0.1
   # TODO: re-add after JupyterLab 4 compatibility

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -14,7 +14,6 @@
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.11-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-fasta-3.3.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-geojson-3.4.0-pyhd8ed1ab_0.conda",
-      "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-github-4.0.0-pyhd8ed1ab_2.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-kernelspy-4.0.0-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/jupyterlab-tour-4.0.1-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda",


### PR DESCRIPTION
## References

- fixes #1374

## Code changes

- remove `jupyterlab-github`

## User-facing changes

- visitors to the documentation website will be able to again create new files

## Backwards-incompatible changes

- visitors to the documentation website will not be able to use any github-related features