### PR TITLE
Use custom `artifact_name` and `report_name` in `playwright-update.yml`

### DIFF
--- a/.github/workflows/playwright-update.yml
+++ b/.github/workflows/playwright-update.yml
@@ -98,5 +98,7 @@ jobs:
           test_folder: ui-tests
           start_server_script: 'null'
           update_script: test:update --browser ${{ matrix.browser }}
+          artifact_name: playwright-snapshots-${{ matrix.browser }}
+          report_name: playwright-report-${{ matrix.browser }}
         env:
           DEBUG: pw:webserver


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

The workflow would otherwise give the following error:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

![image](https://github.com/user-attachments/assets/6e640a55-e733-474a-8e84-dbbe57ae12a8)

Likely because we test on both `firefox` and `chromium` and the artifact names were the same.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Use custom `artifact_name` and `report_name` in `playwright-update.yml` to include the name of the browser.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
