### PR TITLE
Ping service worker every 20s

### DIFF
--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -6,7 +6,7 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IServiceWorkerManager, WORKER_NAME } from './tokens';
 
 const VERSION = PageConfig.getOption('appVersion');
-const SW_PING_ENDPOINT = '/api/keep-sw-alive';
+const SW_PING_ENDPOINT = '/api/service-worker-heartbeat';
 export class ServiceWorkerManager implements IServiceWorkerManager {
   constructor(options?: IServiceWorkerManager.IOptions) {
     const workerUrl =

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -6,7 +6,7 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IServiceWorkerManager, WORKER_NAME } from './tokens';
 
 const VERSION = PageConfig.getOption('appVersion');
-
+const SW_PING_ENDPOINT = '/api/keep-sw-alive';
 export class ServiceWorkerManager implements IServiceWorkerManager {
   constructor(options?: IServiceWorkerManager.IOptions) {
     const workerUrl =
@@ -100,9 +100,16 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       this._ready.reject(void 0);
     } else {
       this._ready.resolve(void 0);
+      setTimeout(this._pingServiceWorker, 20000);
     }
   }
-
+  private _pingServiceWorker = async (): Promise<void> => {
+    const response = await fetch(SW_PING_ENDPOINT);
+    const text = await response.text();
+    if (text === 'ok') {
+      setTimeout(this._pingServiceWorker, 20000);
+    }
+  };
   private _setRegistration(registration: ServiceWorkerRegistration | null) {
     this._registration = registration;
     this._registrationChanged.emit(this._registration);

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -50,9 +50,12 @@ async function onFetch(event: FetchEvent): Promise<void> {
   const { request } = event;
 
   const url = new URL(event.request.url);
+  if (url.pathname === '/api/keep-sw-alive') {
+    event.respondWith(new Response('ok'));
+    return;
+  }
 
   let responsePromise: Promise<Response> | null = null;
-
   if (shouldBroadcast(url)) {
     responsePromise = broadcastOne(request);
   } else if (!shouldDrop(request, url)) {

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -50,7 +50,7 @@ async function onFetch(event: FetchEvent): Promise<void> {
   const { request } = event;
 
   const url = new URL(event.request.url);
-  if (url.pathname === '/api/keep-sw-alive') {
+  if (url.pathname === '/api/service-worker-heartbeat') {
     event.respondWith(new Response('ok'));
     return;
   }


### PR DESCRIPTION
## References

Most of web browsers have timeout for service worker (30 seconds for both Chrome and Firefox), if there is no activity for the service worker, it will be stopped by the browser. This PR pings the SW every 20 seconds to keep it alive. This might fix the issue with file accessing in the kernel which fails randomly in voici.

_Firefox stops the SW after 30 seconds_

![litesw](https://github.com/user-attachments/assets/8e736e5b-ef60-4331-ac50-d061ffe2ac4c)

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
