### PR TITLE
Fix deployment issue by removing reliance on .bashrc for Vercel and Netlify environments

### DIFF
--- a/docs/howto/deployment/vercel-netlify.md
+++ b/docs/howto/deployment/vercel-netlify.md
@@ -62,12 +62,18 @@ yum install wget -y
 
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 
-./bin/micromamba shell init -s bash -p ~/micromamba
-source ~/.bashrc
+export PATH="$PWD/bin:$PATH"
+export MAMBA_ROOT_PREFIX="$PWD/micromamba"
 
-# activate the environment and install a new version of Python
-micromamba activate
-micromamba install python=3.10 -c conda-forge -y
+# Initialize Micromamba shell
+./bin/micromamba shell init -s bash --no-modify-profile -p $MAMBA_ROOT_PREFIX
+
+# Source Micromamba environment directly
+eval "$(./bin/micromamba shell hook -s bash)"
+
+# Activate the Micromamba environment
+micromamba create -n jupyterenv python=3.11 -c conda-forge -y
+micromamba activate jupyterenv
 
 # install the dependencies
 python -m pip install -r requirements-deploy.txt

--- a/docs/howto/deployment/vercel-netlify.md
+++ b/docs/howto/deployment/vercel-netlify.md
@@ -60,7 +60,7 @@ Then create a new `deploy.sh` file with the following content:
 
 yum install wget -y
 
-wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 
 export PATH="$PWD/bin:$PATH"
 export MAMBA_ROOT_PREFIX="$PWD/micromamba"


### PR DESCRIPTION
## References

This pull request addresses issue [#4](https://github.com/diegofcornejo/vercel-jupyter-lite/issues/4):
 * [Deployment fails due to missing .bashrc and command not found errors diegofcornejo/vercel-jupyter-lite#4 (comment)](https://github.com/diegofcornejo/vercel-jupyter-lite/issues/4#issuecomment-2263443845)

The changes also ensure compatibility with both Vercel and Netlify environments.

## Code changes

The following changes were made to address the issue:
- Removed the reliance on sourcing `.bashrc`, which was not present in Vercel environment.
- Configured environment variables directly in the script to ensure that `micromamba`, `python`, and `jupyter` are properly initialized and accessible.
- Added explicit initialization and activation of the `micromamba` environment without attempting to modify any shell profile files.

These changes ensure the deployment process completes successfully on both Vercel and Netlify.

## User-facing changes

There are no direct user-facing visual or interaction changes, as the modifications involve adjustments to the deployment process. However, users deploying on Vercel or Netlify will now experience successful builds without errors related to missing `.bashrc` or unrecognized commands.

## Backwards-incompatible changes
