### PR TITLE
Update `LocalEventManager` to emit an `Event.Emission` that mimics the back-end

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -25,8 +25,8 @@ class LocalEventManager implements Event.IManager {
     this._stream = new Stream(this);
   }
 
-  async emit(event: Event.Request): Promise<void> {
-    this._stream.emit(event);
+  async emit({ data, schema_id }: Event.Request): Promise<void> {
+    this._stream.emit({ ...data, schema_id });
   }
 
   dispose(): void {


### PR DESCRIPTION
The new `LocalEventManager` introduced in https://github.com/jupyterlite/jupyterlite/pull/1481 naively emits an `Event.Request` as soon as it receives it.

This works because an `Event.Request` looks like this:

```ts
  /**
   * The event request type.
   */
  export type Request = {
    data: JSONObject;
    schema_id: string;
    version: string;
  };
```

And an `Event.Emission` looks like this:

```ts
  /**
   * The event emission type.
   */
  export type Emission = ReadonlyJSONObject & {
    schema_id: string;
  };
```

So a `Request` is always a valid `Emission`. However, the back-end version of the event system emits events that are *not* identical to the incoming request, rather they contain the `data` of the request as top-level attributes of the emission.

This PR updates the `LocalEventManager` to mimic the behavior of JupyterLab.

## References
This is a follow-on PR amending https://github.com/jupyterlite/jupyterlite/pull/1481

## Code changes
The `LocalEventManager` emits emissions that matches the JupyterLab version.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A