### PR TITLE
Service worker unregistering should be completed before registering new service worker

### DIFF
--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -49,9 +49,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       console.info('New version, unregistering existing service workers.');
       const registrations = await navigator.serviceWorker.getRegistrations();
 
-      for (const registration of registrations) {
-        await registration.unregister();
-      }
+      await Promise.all(registrations.map((registration) => registration.unregister()));
 
       // eslint-disable-next-line no-console
       console.info('All existing service workers have been unregistered.');

--- a/packages/server/src/service-manager.ts
+++ b/packages/server/src/service-manager.ts
@@ -38,7 +38,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     return this._ready.promise;
   }
 
-  private unregisterOldServiceWorkers = (scriptURL: string) => {
+  private unregisterOldServiceWorkers = async (scriptURL: string) => {
     const versionKey = `${scriptURL}-version`;
     // Check if we have an installed version. If we do, compare it to the current version
     // and unregister all service workers if they are different.
@@ -47,17 +47,14 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     if ((installedVersion && installedVersion !== VERSION) || !installedVersion) {
       // eslint-disable-next-line no-console
       console.info('New version, unregistering existing service workers.');
-      navigator.serviceWorker
-        .getRegistrations()
-        .then((registrations) => {
-          for (const registration of registrations) {
-            registration.unregister();
-          }
-        })
-        .then(() => {
-          // eslint-disable-next-line no-console
-          console.info('All existing service workers have been unregistered.');
-        });
+      const registrations = await navigator.serviceWorker.getRegistrations();
+
+      for (const registration of registrations) {
+        await registration.unregister();
+      }
+
+      // eslint-disable-next-line no-console
+      console.info('All existing service workers have been unregistered.');
     }
 
     localStorage.setItem(versionKey, VERSION);
@@ -72,7 +69,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       console.warn('ServiceWorkers not supported in this browser');
     } else if (serviceWorker.controller) {
       const scriptURL = serviceWorker.controller.scriptURL;
-      this.unregisterOldServiceWorkers(scriptURL);
+      await this.unregisterOldServiceWorkers(scriptURL);
 
       registration = (await serviceWorker.getRegistration(scriptURL)) || null;
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## References
In https://github.com/jupyterlite/jupyterlite/pull/1336 we introduced detection of a new service worker to avoid mismatch between old version when a new version is in place. However, I noticed when we updated our JupyterLite from 0.4.1 to 0.4.2 today that this happened in console:
```
New version, unregistering existing service workers.
JupyterLite ServiceWorker was already registered
All existing service workers have been unregistered.
```
aka it did not have time to unregister before it tried to load again. This is because the promise is not finished when it tries to register again. 

## Code changes
In this PR I made `unregisterOldServiceWorkers` async and run it with `await` for it to complete before it continues.

## User-facing changes
When a new version of JupyterLite is in place, the first session will no longer crash.

## Backwards-incompatible changes
None