### PR TITLE
handle binary file chunks

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -455,7 +455,11 @@ export class Contents implements IContents {
           size: content.length,
         };
       } else {
-        let content = this._handleBinaryChunk(options.content, originalContent, chunked);
+        let content = this._handleBinaryChunk(
+          options.content,
+          originalContent,
+          chunked,
+        );
 
         if (lastChunk) {
           content = btoa(content);
@@ -616,7 +620,7 @@ export class Contents implements IContents {
     chunked?: boolean,
   ): string {
     const base64Decoded = atob(newContent);
-    const padEscaped = base64Decoded.replace(/=+$/, '')
+    const padEscaped = base64Decoded.replace(/=+$/, '');
     const content = chunked ? originalContent + padEscaped : padEscaped;
     return content;
   }

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -455,11 +455,16 @@ export class Contents implements IContents {
           size: content.length,
         };
       } else {
-        const content = options.content;
+        let content = this._handleBinaryChunk(options.content, originalContent, chunked);
+
+        if (lastChunk) {
+          content = btoa(content);
+        }
+
         item = {
           ...item,
           content,
-          size: atob(content).length,
+          size: content.length,
         };
       }
     }
@@ -592,6 +597,27 @@ export class Contents implements IContents {
   ): string {
     const escaped = decodeURIComponent(escape(atob(newContent)));
     const content = chunked ? originalContent + escaped : escaped;
+    return content;
+  }
+
+  /**
+   * Handle a chunk of a binary file.
+   * each chunk is base64 encoded, so we need to decode it and append it to the
+   * original content.
+   * if the chunk has padding, we need to remove it before appending.
+   * @param content the content to process
+   *
+   * @returns the decoded string, appended to the original content if chunked
+   * /
+   */
+  private _handleBinaryChunk(
+    newContent: string,
+    originalContent: string,
+    chunked?: boolean,
+  ): string {
+    const base64Decoded = atob(newContent);
+    const padEscaped = base64Decoded.replace(/=+$/, '')
+    const content = chunked ? originalContent + padEscaped : padEscaped;
     return content;
   }
 


### PR DESCRIPTION

## References

fix #1153

## Code changes

- Support chunk loading for binary data
- Since each chunk is Base64 encoded, I ensured proper concatenation by taking padding into account

## User-facing changes

large binary file can be uploaded

## Backwards-incompatible changes

none