### PR TITLE
Align kernel URL for server with client kernel URL

### DIFF
--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -122,7 +122,7 @@ export class Kernels implements IKernels {
       Kernels.WS_BASE_URL,
       KernelAPI.KERNEL_SERVICE_URL,
       encodeURIComponent(kernelId),
-      'channels'
+      'channels',
     );
     const runningKernel = this._kernels.get(kernelId);
     if (runningKernel) {

--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -1,6 +1,6 @@
 import { ObservableMap } from '@jupyterlab/observables';
 
-import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { KernelAPI, Kernel, KernelMessage } from '@jupyterlab/services';
 
 import { deserialize, serialize } from '@jupyterlab/services/lib/kernel/serialize';
 
@@ -14,7 +14,7 @@ import { IKernel, IKernels, IKernelSpecs } from './tokens';
 
 import { Mutex } from 'async-mutex';
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 /**
  * Use the default kernel wire protocol.
@@ -118,7 +118,12 @@ export class Kernels implements IKernels {
     const kernelId = id ?? UUID.uuid4();
 
     // There is one server per kernel which handles multiple clients
-    const kernelUrl = `${Kernels.WS_BASE_URL}api/kernels/${kernelId}/channels`;
+    const kernelUrl = URLExt.join(
+      Kernels.WS_BASE_URL,
+      KernelAPI.KERNEL_SERVICE_URL,
+      encodeURIComponent(kernelId),
+      'channels'
+    );
     const runningKernel = this._kernels.get(kernelId);
     if (runningKernel) {
       return {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
The mock-socket library check the requested ws URL matches one of the created server. Slight discrepancy may arise due to the server URL definition being built slightly differently than the one in the `KernelConnection`.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Align the construction of the kernel URL with the construction done in the client

https://github.com/jupyterlab/jupyterlab/blob/090fe7383422b59588f0337fe0b5ee0d74899204/packages/services/src/kernel/default.ts#L1248

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
None