### PR TITLE
fix file size handling in drivefs

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -421,6 +421,7 @@ export class Contents implements IContents {
     item = {
       ...item,
       ...options,
+      size: options.content?.length || 0,
       last_modified: modified,
     };
 
@@ -472,8 +473,6 @@ export class Contents implements IContents {
         };
       }
     }
-
-    item = { ...item, size: item.content.length };
 
     await (await this.storage).setItem(path, item);
     return item;

--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -473,6 +473,8 @@ export class Contents implements IContents {
       }
     }
 
+    item = { ...item, size: item.content.length };
+
     await (await this.storage).setItem(path, item);
     return item;
   }

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -291,6 +291,9 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
         case 'timestamp':
           node.timestamp = value;
           break;
+        case 'size':
+          node.size = value;
+          break;
         default:
           console.warn('setattr', key, 'of', value, 'on', node, 'not yet implemented');
           break;

--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -43,6 +43,7 @@ export interface IEmscriptenFSNode {
   id: number;
   name: string;
   mode: number;
+  size: number;
   parent: IEmscriptenFSNode;
   mount: { opts: { root: string } };
   stream_ops: IEmscriptenStreamOps;


### PR DESCRIPTION
## References

add `size` property to drivefs
details in #1508

- comlink.worker.ts in jupyterlite-pyodide-kernel also needs to refer this build
- truncate logic for scenarios such as opening existing files in write mode is not included

## Code changes

- add `size` property to `IEmscriptenFSNode`
- set size property when creating new file
- ~~handling size property when creating/modifying content (WIP)~~

## User-facing changes



## Backwards-incompatible changes

None