### PR TITLE
Update download logic so that it relies on mimetype instead of solely content.type

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -243,7 +243,15 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           });
         }
         await context.save();
-        await downloadContent(context.path, context.path);
+        try {
+          await downloadContent(context.path, context.path);
+        } catch (e) {
+          return showDialog({
+            title: trans.__('Cannot Download!!!'),
+            body: JSON.stringify(e),
+            buttons: [Dialog.okButton({ label: trans.__('OK') })],
+          });
+        }
       },
     });
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -189,6 +189,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     };
 
     const downloadContent = async (contentPath: string, fileName: string) => {
+      console.log('TRYING TO DOWNLOAD CONTENT', contentPath, fileName);
       const model = await contents.get(contentPath, { content: true });
       const element = document.createElement('a');
       if (

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -189,7 +189,6 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     };
 
     const downloadContent = async (contentPath: string, fileName: string) => {
-      console.log('TRYING TO DOWNLOAD CONTENT', contentPath, fileName);
       const model = await contents.get(contentPath, { content: true });
       const element = document.createElement('a');
       if (
@@ -201,20 +200,23 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
         const content = JSON.stringify(model.content, null, 2);
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(content)}`;
       } else if (
+        model.format === 'text' ||
+        model.mimetype === 'text/plain'
+      ) {
+        const mime = model.mimetype ?? 'text/plain';
+        element.href = `data:${mime};charset=utf-8,${encodeURIComponent(
+          model.content,
+        )}`;
+      } else if (
         model.format === 'base64' ||
         model.mimetype === 'application/octet-stream'
       ) {
         const mime = model.mimetype ?? 'application/octet-stream';
         element.href = `data:${mime};base64,${model.content}`;
-      } else if (model.mimetype === 'text/plain') {
-        element.href = `data:${model.mimetype};charset=utf-8,${encodeURIComponent(
-          model.content,
-        )}`;
       } else {
-        console.log(
+        throw new Error(
           `Content whose mimetype is "${model.mimetype}" cannot be downloaded`,
         );
-        return;
       }
       element.download = fileName;
       document.body.appendChild(element);

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -244,7 +244,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           await downloadContent(context.path, context.path);
         } catch (e) {
           return showDialog({
-            title: trans.__('Cannot Download!!!'),
+            title: trans.__('Cannot Download'),
             body: JSON.stringify(e),
             buttons: [Dialog.okButton({ label: trans.__('OK') })],
           });
@@ -275,7 +275,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
                 await downloadContent(item.path, item.name);
               } catch (e) {
                 return showDialog({
-                  title: trans.__('Cannot Download!!!'),
+                  title: trans.__('Cannot Download'),
                   body: JSON.stringify(e),
                   buttons: [Dialog.okButton({ label: trans.__('OK') })],
                 });

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -210,9 +210,10 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           model.content,
         )}`;
       } else {
-        throw new Error(
+        console.log(
           `Content whose mimetype is "${model.mimetype}" cannot be downloaded`,
         );
+        return;
       }
       element.download = fileName;
       document.body.appendChild(element);

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -191,22 +191,19 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     const downloadContent = async (contentPath: string, fileName: string) => {
       const model = await contents.get(contentPath, { content: true });
       const element = document.createElement('a');
-      if (model.type === 'notebook' || model.format === 'json') {
+      if (model.type === 'notebook' || model.format === 'json' || model.mimetype == 'text/json') {
         const mime = model.mimetype ?? 'text/json';
         const content = JSON.stringify(model.content, null, 2);
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(content)}`;
-      } else if (model.type === 'file') {
-        if (model.format === 'base64') {
-          const mime = model.mimetype ?? 'application/octet-stream';
-          element.href = `data:${mime};base64,${model.content}`;
-        } else {
-          const mime = model.mimetype ?? 'text/plain';
-          element.href = `data:${mime};charset=utf-8,${encodeURIComponent(
-            model.content,
-          )}`;
-        }
+      } else if (model.format === 'base64' || model.mimetype === 'application/octet-stream') {
+        const mime = model.mimetype ?? 'application/octet-stream';
+        element.href = `data:${mime};base64,${model.content}`;
+      } else if (model.mimetype === 'text/plain') {
+        element.href = `data:${model.mimetype};charset=utf-8,${encodeURIComponent(
+          model.content,
+        )}`;
       } else {
-        throw new Error(`Content whose type is "${model.type}" cannot be downloaded`);
+        throw new Error(`Content whose mimetype is "${model.mimetype}" cannot be downloaded`);
       }
       element.download = fileName;
       document.body.appendChild(element);

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -199,10 +199,7 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
         const mime = model.mimetype ?? 'text/json';
         const content = JSON.stringify(model.content, null, 2);
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(content)}`;
-      } else if (
-        model.format === 'text' ||
-        model.mimetype === 'text/plain'
-      ) {
+      } else if (model.format === 'text' || model.mimetype === 'text/plain') {
         const mime = model.mimetype ?? 'text/plain';
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(
           model.content,

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -191,11 +191,18 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
     const downloadContent = async (contentPath: string, fileName: string) => {
       const model = await contents.get(contentPath, { content: true });
       const element = document.createElement('a');
-      if (model.type === 'notebook' || model.format === 'json' || model.mimetype == 'text/json') {
+      if (
+        model.type === 'notebook' ||
+        model.format === 'json' ||
+        model.mimetype === 'text/json'
+      ) {
         const mime = model.mimetype ?? 'text/json';
         const content = JSON.stringify(model.content, null, 2);
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(content)}`;
-      } else if (model.format === 'base64' || model.mimetype === 'application/octet-stream') {
+      } else if (
+        model.format === 'base64' ||
+        model.mimetype === 'application/octet-stream'
+      ) {
         const mime = model.mimetype ?? 'application/octet-stream';
         element.href = `data:${mime};base64,${model.content}`;
       } else if (model.mimetype === 'text/plain') {
@@ -203,7 +210,9 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           model.content,
         )}`;
       } else {
-        throw new Error(`Content whose mimetype is "${model.mimetype}" cannot be downloaded`);
+        throw new Error(
+          `Content whose mimetype is "${model.mimetype}" cannot be downloaded`,
+        );
       }
       element.download = fileName;
       document.body.appendChild(element);

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -262,7 +262,15 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
           const selected = Array.from(widget.selectedItems());
           selected.forEach(async (item) => {
             if (item.type !== 'directory') {
-              await downloadContent(item.path, item.name);
+              try {
+                await downloadContent(item.path, item.name);
+              } catch (e) {
+                return showDialog({
+                  title: trans.__('Cannot Download!!!'),
+                  body: JSON.stringify(e),
+                  buttons: [Dialog.okButton({ label: trans.__('OK') })],
+                });
+              }
             }
           });
         },

--- a/ui-tests/contents/test.customfile
+++ b/ui-tests/contents/test.customfile
@@ -1,4 +1,4 @@
 {
-  "hello": 'coucou',
+  "hello": "coucou",
   "coucou": []
 }

--- a/ui-tests/contents/test.customfile
+++ b/ui-tests/contents/test.customfile
@@ -1,0 +1,4 @@
+{
+  "hello": 'coucou',
+  "coucou": []
+}

--- a/ui-tests/jupyter_lite_config.json
+++ b/ui-tests/jupyter_lite_config.json
@@ -1,6 +1,14 @@
 {
   "LiteBuildConfig": {
     "contents": ["../examples", "contents"],
-    "output_dir": "ui-tests-app"
+    "output_dir": "ui-tests-app",
+    "extra_file_types": {
+      "customfile": {
+        "name": "customfile",
+        "extensions": [".customfile"],
+        "mimeTypes": ["text/plain"],
+        "fileFormat": "text"
+      }
+    }
   }
 }

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -172,6 +172,7 @@ test.describe('Contents Tests', () => {
   });
 
   test('Download a custom file type', async ({ page }) => {
+    await refreshFilebrowser({ page });
     const path = await download({ page, path: 'test.customfile' });
     expect(path).toBeTruthy();
 

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -173,6 +173,7 @@ test.describe('Contents Tests', () => {
 
   test('Download a custom file type', async ({ page }) => {
     await refreshFilebrowser({ page });
+    await page.filebrowser.open('test.customfile');
     const path = await download({ page, path: 'test.customfile' });
     expect(path).toBeTruthy();
 

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -165,21 +165,21 @@ test.describe('Contents Tests', () => {
 
     expect(parsed.cells[0].source).toEqual(source);
   });
-});
 
-test('Download a custom file type', async ({ page }) => {
-  const path = await download({ page, path: 'test.customfile' });
-  expect(path).toBeTruthy();
+  test('Download a custom file type', async ({ page }) => {
+    const path = await download({ page, path: 'test.customfile' });
+    expect(path).toBeTruthy();
 
-  const content = await fs.readFile(path, { encoding: 'utf-8' });
-  const lines = content.split('\n');
+    const content = await fs.readFile(path, { encoding: 'utf-8' });
+    const lines = content.split('\n');
 
-  // check the file is correctly formatted
-  expect(lines.length).toBeGreaterThan(1);
+    // check the file is correctly formatted
+    expect(lines.length).toBeGreaterThan(1);
 
-  const parsed = JSON.parse(content);
+    const parsed = JSON.parse(content);
 
-  expect(parsed.hello).toEqual('coucou');
+    expect(parsed.hello).toEqual('coucou');
+  });
 });
 
 test.describe('Copy shareable link', () => {

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -27,7 +27,8 @@ test.use({
 
 test.describe('Contents Tests', () => {
   test.beforeEach(async ({ page }) => {
-    page.on('console', message => {
+    page.on('console', (message) => {
+      // eslint-disable-next-line no-console
       console.log('CONSOLE MSG', message.text());
     });
 

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -27,11 +27,6 @@ test.use({
 
 test.describe('Contents Tests', () => {
   test.beforeEach(async ({ page }) => {
-    page.on('console', (message) => {
-      // eslint-disable-next-line no-console
-      console.log('CONSOLE MSG', message.text());
-    });
-
     await page.goto('lab/index.html');
   });
 

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -167,6 +167,21 @@ test.describe('Contents Tests', () => {
   });
 });
 
+test('Download a custom file type', async ({ page }) => {
+  const path = await download({ page, path: 'test.customfile' });
+  expect(path).toBeTruthy();
+
+  const content = await fs.readFile(path, { encoding: 'utf-8' });
+  const lines = content.split('\n');
+
+  // check the file is correctly formatted
+  expect(lines.length).toBeGreaterThan(1);
+
+  const parsed = JSON.parse(content);
+
+  expect(parsed.hello).toEqual('coucou');
+});
+
 test.describe('Copy shareable link', () => {
   // Playwright allows setting clipboard permissions only for Chromium
   // https://github.com/microsoft/playwright/issues/13037

--- a/ui-tests/test/contents.test.ts
+++ b/ui-tests/test/contents.test.ts
@@ -27,6 +27,10 @@ test.use({
 
 test.describe('Contents Tests', () => {
   test.beforeEach(async ({ page }) => {
+    page.on('console', message => {
+      console.log('CONSOLE MSG', message.text());
+    });
+
     await page.goto('lab/index.html');
   });
 

--- a/ui-tests/test/utils.ts
+++ b/ui-tests/test/utils.ts
@@ -22,6 +22,7 @@ export async function download({
   path: string;
 }): Promise<string> {
   await page.evaluate(async (path: string) => {
+    // TODO Fix this. There is no such thing as passing a `path` here, the filebrowser will download any selected file
     await window.galata.app.commands.execute('filebrowser:download', { path });
   }, path);
 


### PR DESCRIPTION
## References

Looking into fixing https://github.com/jupytercad/JupyterCAD/issues/544

## Code changes

The downloading logic was relying on the `content.type` (only `notebook`, `json` and default `file` was downloadable). 

This means that custom file types (jcad, jgis etc) would not be downloadable.

I change the logic to rely on the mimetype instead, so that other file types can be downloaded if they have a supported mimetype.  

## User-facing changes

None