### PR TITLE
Increase nbformat_minor to 5 in contents package

### DIFF
--- a/packages/contents/src/contents.ts
+++ b/packages/contents/src/contents.ts
@@ -872,7 +872,7 @@ namespace Private {
     metadata: {
       orig_nbformat: 4,
     },
-    nbformat_minor: 4,
+    nbformat_minor: 5,
     nbformat: 4,
     cells: [],
   };


### PR DESCRIPTION
The default notebook contents were set in the Jupyter Lite contents package with nbformat_minor 4. The current Jupyter lab starts with nbformat_minor 5. This patch also changes the default in Jupyter Lite to 5. ng_format_minor 5 enables features such as cell preservation in Jupyter Lite.

<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlite/jupyterlite/issues/1549

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Just increase the version number of the default template.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
User will get notebooks in the newer format.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
None.
