### PR TITLE
Fix typo in CLI addons doc

### DIFF
--- a/docs/howto/extensions/cli-addons.md
+++ b/docs/howto/extensions/cli-addons.md
@@ -56,7 +56,7 @@ At its very simplest, an Addon is initialized with a signature like:
 class MyAddon:
     __all__ = ["status"]
 
-    def status(self, maanger):
+    def status(self, manager):
         yield dict(name="hello", actions=[lambda: print("world")])
 ```
 


### PR DESCRIPTION
Note: this does not really matter since `manager` variable is not used in the code.