### PR TITLE
Use ErronoError instead of genericErrors in the lookup function

### DIFF
--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -326,7 +326,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
     const path = this.fs.PATH.join2(this.fs.realPath(node), name);
     const result = this.fs.API.lookup(path);
     if (!result.ok) {
-      throw this.fs.FS.genericErrors[this.fs.ERRNO_CODES['ENOENT']];
+      throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['ENOENT']);
     }
     return this.fs.createNode(node, name, result.mode!, 0);
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Fixes #1567 
## Code changes

<!-- Describe the code changes and how they address the issue. -->

Discussing with Sam Clegg, the maintainer at emscripten, he says that `genericErrors`, and all the places it is used were removed in 3.1.73 through https://github.com/emscripten-core/emscripten/pull/22914

We should just use `ErrnoError` instead of `genericErrors` if possible !

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->

None
