### PR TITLE
Expose more REPL options via query string parameters

### DIFF
--- a/docs/quickstart/embed-repl.md
+++ b/docs/quickstart/embed-repl.md
@@ -98,3 +98,68 @@ pip install jupyterlab-gt-coar-theme
 
 See the [how-to guides](../howto/index.md) for more details on how to customize the
 environment and add more themes and extensions.
+
+### Clear cells on execute
+
+To automatically clear the previously executed cells on execute, set the
+`clearCellsOnExecute` parameter to `1`:
+
+```html
+<iframe
+  src="https://jupyterlite.github.io/demo/repl/index.html?clearCellsOnExecute=1"
+  width="100%"
+  height="100%"
+></iframe>
+```
+
+### Clear code content on execute
+
+To automatically clear the code content in the prompt cell on execute, set the
+`clearCodeContentOnExecute` parameter to `1`:
+
+```html
+<iframe
+  src="https://jupyterlite.github.io/demo/repl/index.html?clearCodeContentOnExecute=1"
+  width="100%"
+  height="100%"
+></iframe>
+```
+
+### Hide code input
+
+To hide the input cell of the executed cells, set the `hideCodeInput` parameter to `1`:
+
+```html
+<iframe
+  src="https://jupyterlite.github.io/demo/repl/index.html?hideCodeInput=1"
+  width="100%"
+  height="100%"
+></iframe>
+```
+
+### Prompt cell position
+
+To change where the prompt cell is placed, set the `promptCellPosition` parameter to
+`top`, `bottom`, `left`, or `right`:
+
+```html
+<iframe
+  src="https://jupyterlite.github.io/demo/repl/index.html?promptCellPosition=left"
+  width="100%"
+  height="100%"
+></iframe>
+```
+
+### Show or hide the kernel banner
+
+By default the REPL shows the kernel banner.
+
+To hide the banner, set the `showBanner` parameter to `0`:
+
+```html
+<iframe
+  src="https://jupyterlite.github.io/demo/repl/index.html?showBanner=0"
+  width="100%"
+  height="100%"
+></iframe>
+```

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -95,7 +95,7 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
     const clearCellsOnExecute =
       urlParams.get('clearCellsOnExecute') === '1' || undefined;
     const clearCodeContentOnExecute =
-      urlParams.get('clearCodeContentOnExecute') === '1' || undefined;
+      urlParams.get('clearCodeContentOnExecute') === '0' ? false : undefined;
     const hideCodeInput = urlParams.get('hideCodeInput') === '1' || undefined;
     const showBanner = urlParams.get('showBanner') === '0' ? false : undefined;
 

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 import { IThemeManager, IToolbarWidgetRegistry } from '@jupyterlab/apputils';
 
-import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
+import { CodeConsole, ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 
 import { ITranslator } from '@jupyterlab/translation';
 
@@ -91,6 +91,20 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
     const theme = urlParams.get('theme')?.trim();
     const toolbar = urlParams.get('toolbar');
 
+    // normalize config options
+    const clearCellsOnExecute =
+      urlParams.get('clearCellsOnExecute') === '1' || undefined;
+    const clearCodeContentOnExecute =
+      urlParams.get('clearCodeContentOnExecute') === '1' || undefined;
+    const hideCodeInput = urlParams.get('hideCodeInput') === '1' || undefined;
+    const showBanner = urlParams.get('showBanner') === '0' ? false : undefined;
+
+    const position = urlParams.get('promptCellPosition') ?? '';
+    const validPositions = ['top', 'bottom', 'left', 'right'];
+    const promptCellPosition = validPositions.includes(position)
+      ? (position as CodeConsole.PromptCellPosition)
+      : undefined;
+
     Promise.all([started, serviceManager.ready]).then(async () => {
       commands.execute('console:create', { kernelPreference: { name: kernel } });
     });
@@ -117,6 +131,14 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
           code.forEach((line) => console.inject(line));
         }
       }
+
+      console.setConfig({
+        clearCellsOnExecute,
+        clearCodeContentOnExecute,
+        hideCodeInput,
+        promptCellPosition,
+        showBanner,
+      });
     });
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1572.

Leaving https://github.com/jupyterlite/jupyterlite/issues/503 for another PR for now, as this could be implemented separately.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Expose more REPL options so they can be controlled via query string parameters.
- [x] Add documentation

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users can tweak more options of their embedded REPL via a single URL directly, without having to do a full deploy with a custom `overrides.json`.

Example with https://jupyterlite--1573.org.readthedocs.build/en/1573/_static/repl/index.html?toolbar=1&kernel=python&promptCellPosition=left&clearCellsOnExecute=1&hideCodeInput=1&clearCodeContentOnExecute=0

![image](https://github.com/user-attachments/assets/3ce0c7f8-33af-4790-baeb-ccb438608afe)

Handling of the `showBanner` option may not yet work as expected due to the current handling of the kernel banner: https://github.com/jupyterlab/jupyterlab/pull/17322

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
