### PR TITLE
Fix memoryStorageDriver in jupyterlite.schema.v0.json

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -298,7 +298,7 @@
           "title": "memory",
           "description": "use the memory-based, volatile store: must be enabled with enableMemoryStorage",
           "type": "string",
-          "enum": ["localStorageWrapper"]
+          "enum": ["memoryStorageDriver"]
         }
       ]
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Without knowing the details, while researching for https://github.com/jupyterlite/jupyterlite/issues/1047 (which I would still be interested in), I stumbled across this:

https://github.com/jupyterlite/jupyterlite/blob/db7eec412c417581b5155055c758f6838fa209ae/app/jupyterlite.schema.v0.json#L291-L302

Comparing to [documentation](https://jupyterlite.readthedocs.io/en/latest/howto/configure/storage.html#local-storage-drivers), the second `localStorageWrapper` string looks like it actually should be `memoryStorageDriver`. Therefore suggesting that in this PR just in case this is actually a bug.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
