### PR TITLE
Remove custom `IServerSettings` plugin

### DIFF
--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -325,7 +325,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -341,7 +341,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/app/lab/package.json
+++ b/app/lab/package.json
@@ -329,7 +329,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -350,7 +350,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/app/repl/package.json
+++ b/app/repl/package.json
@@ -264,7 +264,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -311,7 +311,6 @@
       "@jupyterlab/services-extension:kernel-manager",
       "@jupyterlab/services-extension:kernel-spec-manager",
       "@jupyterlab/services-extension:nbconvert-manager",
-      "@jupyterlab/services-extension:server-settings",
       "@jupyterlab/services-extension:session-manager",
       "@jupyterlab/services-extension:setting-manager",
       "@jupyterlab/services-extension:user-manager",

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -131,7 +131,15 @@ const kernelManagerPlugin: ServiceManagerPlugin<Kernel.IManager> = {
     kernelSpecAPIClient: IKernelSpecClient,
     serverSettings: ServerConnection.ISettings | undefined,
   ): Kernel.IManager => {
-    return new KernelManager({ kernelAPIClient, kernelSpecAPIClient, serverSettings });
+    return new KernelManager({
+      kernelAPIClient,
+      kernelSpecAPIClient,
+      serverSettings: {
+        ...ServerConnection.makeSettings(),
+        ...serverSettings,
+        WebSocket,
+      },
+    });
   },
 };
 
@@ -188,7 +196,10 @@ const kernelClientPlugin: ServiceManagerPlugin<Kernel.IKernelAPIClient> = {
     kernelSpecs: IKernelSpecs,
     serverSettings?: ServerConnection.ISettings,
   ): IKernelClient => {
-    return new LiteKernelClient({ kernelSpecs, serverSettings });
+    return new LiteKernelClient({
+      kernelSpecs,
+      serverSettings,
+    });
   },
 };
 
@@ -245,31 +256,6 @@ const nbConvertManagerPlugin: ServiceManagerPlugin<NbConvert.IManager> = {
     })({ serverSettings });
 
     return nbConvertManager;
-  },
-};
-
-/**
- * The default server settings plugin.
- */
-const serverSettingsPlugin: ServiceManagerPlugin<ServerConnection.ISettings> = {
-  id: '@jupyterlite/services-extension:server-settings',
-  description: 'The default server settings plugin.',
-  autoStart: true,
-  provides: IServerSettings,
-  activate: (_: null): ServerConnection.ISettings => {
-    return {
-      ...ServerConnection.makeSettings(),
-      WebSocket,
-      fetch: async (
-        req: RequestInfo,
-        init?: RequestInit | null | undefined,
-      ): Promise<Response> => {
-        const request = new Request(req, init ?? undefined);
-        const url = new URL(request.url);
-        console.error(`Unhandled fetch request path: ${url.pathname}`);
-        return new Response(JSON.stringify({}));
-      },
-    };
   },
 };
 
@@ -362,7 +348,6 @@ export default [
   liteKernelSpecManagerPlugin,
   localforagePlugin,
   nbConvertManagerPlugin,
-  serverSettingsPlugin,
   sessionManagerPlugin,
   settingsPlugin,
   userManagerPlugin,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to:

- https://github.com/jupyterlite/jupyterlite/pull/1590
- https://github.com/jupyterlite/jupyterlite/pull/1597

Now that JupyterLite instantiates and provides its own kernel manager, replacing the default `IServerSettings` should not be needed anymore.

Instead we can just provide the `WebSocket` from `mock-socket` when instantiating the `KernelManager`.

Removing the custom `IServerSettings` should help avoid interfering with the built-in `WebSocket` and `fetch` too much.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Remove `IServerSettings`, use the core plugin instead
- Provide `WebSocket` to the `serverSettings` of the `KernelManager`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
