### PR TITLE
Fix handling of the showBanner REPL parameter

### DIFF
--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -136,11 +136,11 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
         clearCodeContentOnExecute,
         hideCodeInput,
         promptCellPosition,
-        // TODO: handling of the showBanner may not work as expected for now
-        // due to the assumption there should be a banner upstream:
-        // https://github.com/jupyterlab/jupyterlab/pull/17322
         showBanner,
       });
+
+      // TODO: find a better way to make sure the banner is removed if showBanner is false
+      widget['_onKernelChanged']();
     });
 
     if (theme && themeManager) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1584

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The fix is not pretty, but it does the job.

We may want to have a look upstream to make it easier to remove an existing banner.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Passing `?showBanner=0` as a REPL parameter should work as expected.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
