### PR TITLE
Refresh specs when new JupyterLite kernels are added

### DIFF
--- a/packages/kernel/src/kernelspecs.ts
+++ b/packages/kernel/src/kernelspecs.ts
@@ -2,7 +2,9 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import { KernelSpec } from '@jupyterlab/services';
 
-import { IKernel, IKernelSpecs, FALLBACK_KERNEL } from './tokens';
+import { ISignal, Signal } from '@lumino/signaling';
+
+import { FALLBACK_KERNEL, IKernel, IKernelSpecs } from './tokens';
 
 /**
  * A class to register in-browser kernel specs.
@@ -45,6 +47,13 @@ export class KernelSpecs implements IKernelSpecs {
   }
 
   /**
+   * Signal emitted when the specs change.
+   */
+  get changed(): ISignal<IKernelSpecs, KernelSpec.ISpecModels | null> {
+    return this._changed;
+  }
+
+  /**
    * Register a new kernel.
    *
    * @param options The options to register a new kernel.
@@ -53,10 +62,14 @@ export class KernelSpecs implements IKernelSpecs {
     const { spec, create } = options;
     this._specs.set(spec.name, spec);
     this._factories.set(spec.name, create);
+
+    // notify a new spec has been added
+    this._changed.emit(this.specs);
   }
 
   private _specs = new Map<string, KernelSpec.ISpecModel>();
   private _factories = new Map<string, KernelSpecs.KernelFactory>();
+  private _changed = new Signal<this, KernelSpec.ISpecModels | null>(this);
 }
 
 /**

--- a/packages/kernel/src/tokens.ts
+++ b/packages/kernel/src/tokens.ts
@@ -146,6 +146,11 @@ export interface IKernelSpecs {
   readonly factories: KernelSpecs.KernelFactories;
 
   /**
+   * Signal emitted when the specs change.
+   */
+  readonly changed: ISignal<IKernelSpecs, KernelSpec.ISpecModels | null>;
+
+  /**
    * Register a new kernel spec
    *
    * @param options The kernel spec options.

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -171,13 +171,24 @@ const kernelSpecManagerPlugin: ServiceManagerPlugin<KernelSpec.IManager> = {
   autoStart: true,
   provides: IKernelSpecManager,
   requires: [IKernelSpecClient],
-  optional: [IServerSettings],
+  optional: [IKernelSpecs, IServerSettings],
   activate: (
     _: null,
     kernelSpecAPIClient: IKernelSpecClient,
+    kernelSpecs: IKernelSpecs | null,
     serverSettings: ServerConnection.ISettings | undefined,
   ): KernelSpec.IManager => {
-    return new KernelSpecManager({ kernelSpecAPIClient, serverSettings });
+    const kernelSpecManager = new KernelSpecManager({
+      kernelSpecAPIClient,
+      serverSettings,
+    });
+    if (kernelSpecs) {
+      // refresh the kernel spec manager when new lite specs are added
+      kernelSpecs.changed.connect(() => {
+        void kernelSpecManager.refreshSpecs();
+      });
+    }
+    return kernelSpecManager;
   },
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

This should help make the lite kernels visible in the UI immediately.

And remove the need for a manual spec refresh, as currently done in `jupyterlite-xeus`: https://github.com/jupyterlite/xeus/blob/1e9372e9ff6801ca1679cf4b259d9056f419c151/packages/xeus-extension/src/index.ts#L129

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Automatically refresh the kernel manager specs when new lite specs are added.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Less likely to see missing kernels in the UI.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
