### PR TITLE
Fix handling of contents when multiple lite sites are shared under the same host

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -101,7 +101,7 @@
           "$ref": "#/definitions/localforage-driver-set"
         },
         "contentsStorageName": {
-          "description": "name used to store Jupyter contents in the browser",
+          "description": "Name used to store Jupyter contents in the browser. The baseUrl is appended to the default value",
           "type": "string",
           "default": "JupyterLite Storage"
         },
@@ -110,7 +110,7 @@
           "$ref": "#/definitions/localforage-driver-set"
         },
         "settingsStorageName": {
-          "description": "name used to store Jupyter settings in the browser",
+          "description": "Name used to store Jupyter settings in the browser. The baseUrl is appended to the default value",
           "type": "string",
           "default": "JupyterLite Storage"
         },

--- a/docs/howto/configure/storage.md
+++ b/docs/howto/configure/storage.md
@@ -8,7 +8,7 @@ preferences.
 By default, all of a user's settings on the same domain will be available to all
 JupyterLite instances hosted there. To create separate settings stores, change the
 `jupyter-lite.json#jupyter-config-data/settingsStorageName` from the default of
-`JupyterLite Storage`.
+`JupyterLite Storage - <baseUrl>`.
 
 By default, the best available, persistent storage driver will be used. One may force a
 particular set of drivers to try with

--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -40,7 +40,7 @@ server contents, even if the server contents are newer.
 By default, all of a user's contents on the same domain will be available to all
 JupyterLite instances hosted there. To create separate content stores, change the
 `jupyter-lite.json#jupyter-config-data/contentsStorageName` from the default of
-`JupyterLite Storage`.
+`JupyterLite Storage - <baseUrl>`.
 
 By default, the best available, persistent storage driver will be used. One may force a
 particular set of drivers to try with

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,9 +5,9 @@ follow to update JupyterLite from one version to another.
 
 ## `0.5.0` to `0.6.0`
 
-⚠️ JupyterLite 0.6.0 comes with a couple of major changes, that may be considered as
-breaking depending on your JupyterLite setup. Please read the following sections
-carefully to check if you are impacted by them ⚠️
+⚠️ JupyterLite 0.6.0 comes with a couple of major changes that may be considered
+breaking, depending on your JupyterLite setup. Please read the following sections
+carefully to check if you are impacted by these changes ⚠️
 
 ### Extensions
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,6 +5,10 @@ follow to update JupyterLite from one version to another.
 
 ## `0.5.0` to `0.6.0`
 
+⚠️ JupyterLite 0.6.0 comes with a couple of major changes, that may be considered as
+breaking depending on your JupyterLite setup. Please read the following sections
+carefully to check if you are impacted by them ⚠️
+
 ### Extensions
 
 JupyterLite 0.6.0 is based on JupyterLab 4.4 and Jupyter Notebook 7.4 packages.
@@ -23,6 +27,41 @@ difficult to debug issues with missing content and files.
 
 In JupyterLite 0.6.0, the build now fails if the `contents` option is provided when the
 `jupyter-server` is not installed.
+
+### Contents
+
+Previously, the default contents manager was storing files in the browser's local
+storage (IndexedDB by default), under the "JupyterLite Storage" key. This had the effect
+of "sharing" files across different deployments of JupyterLite under the same origin,
+leading to some confusions for the users.
+
+Starting with JupyterLite 0.6.0, the default contents manager now uses the base URL in
+the storage key. For example if you have the following two JupyterLite deployments under
+the same origin:
+
+- `https://example.com/lite1`
+- `https://example.com/lite2`
+
+The contents will be stored under the following keys:
+
+- `JupyterLite Storage - /lite1`
+- `JupyterLite Storage - /lite2`
+
+This means that if you or your users had previously created files in one of the
+deployments, they will not be available anymore.
+
+To use the same default name for the contents storage as before, you can set the
+`contentsStorageName` option in your `jupyter-lite.json` file to `JupyterLite Storage`.
+For example:
+
+```json
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "contentsStorageName": "JupyterLite Storage"
+  }
+}
+```
 
 ### API Changes
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,7 +18,7 @@ introduced in JupyterLab 4.4 and Notebook 7.4.
 
 ### Contents
 
-#### Handling of the `jupyter-server` dependency
+#### File indexing with `jupyter-server`
 
 Previously, running a build with the contents option specified (for example with
 `jupyter lite build --contents contents`) would simply log a warning in the build logs
@@ -28,7 +28,7 @@ difficult to debug issues with missing content and files.
 In JupyterLite 0.6.0, the build now fails if the `contents` option is provided when the
 `jupyter-server` is not installed.
 
-### Contents
+#### Browser Storage
 
 Previously, the default contents manager was storing files in the browser's local
 storage (IndexedDB by default), under the "JupyterLite Storage" key. This had the effect

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -63,6 +63,25 @@ For example:
 }
 ```
 
+### Settings
+
+Similar to the contents storage mentioned in the section above, the default settings
+storage is now using the base URL in the storage key. This means that if you or your
+users had previously changed a few settings in the interface, for example the theme,
+those settings will not be applied after the update to JupyterLite 0.6.0.
+
+To configure a custom settings storage name, you can set the `settingsStorageName`
+option in your `jupyter-lite.json` file. For example:
+
+```json
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "settingsStorageName": "JupyterLite Storage"
+  }
+}
+```
+
 ### API Changes
 
 Prior to version 0.6.0, JupyterLite divided extensions into two categories:

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -87,7 +87,7 @@ const defaultDrivePlugin: ServiceManagerPlugin<Contents.IDrive> = {
     const baseUrl = PageConfig.getOption('baseUrl');
     const defaultStorageName = `JupyterLite Storage - ${baseUrl}`;
     const storageName =
-      PageConfig.getOption('contentsStorageName') ?? defaultStorageName;
+      PageConfig.getOption('contentsStorageName') || defaultStorageName;
     const storageDrivers = JSON.parse(
       PageConfig.getOption('contentsStorageDrivers') || 'null',
     );

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -84,7 +84,10 @@ const defaultDrivePlugin: ServiceManagerPlugin<Contents.IDrive> = {
   provides: IDefaultDrive,
   requires: [ILocalForage],
   activate: async (_: null, forage: ILocalForage): Promise<Contents.IDrive> => {
-    const storageName = PageConfig.getOption('contentsStorageName');
+    const baseUrl = PageConfig.getOption('baseUrl');
+    const defaultStorageName = `JupyterLite Storage - ${baseUrl}`;
+    const storageName =
+      PageConfig.getOption('contentsStorageName') ?? defaultStorageName;
     const storageDrivers = JSON.parse(
       PageConfig.getOption('contentsStorageDrivers') || 'null',
     );

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -315,7 +315,10 @@ const settingsPlugin: ServiceManagerPlugin<Setting.IManager> = {
     forage: ILocalForage,
     serverSettings: ServerConnection.ISettings | null,
   ) => {
-    const storageName = PageConfig.getOption('settingsStorageName');
+    const baseUrl = PageConfig.getOption('baseUrl');
+    const defaultStorageName = `JupyterLite Storage - ${baseUrl}`;
+    const storageName =
+      PageConfig.getOption('settingsStorageName') || defaultStorageName;
     const storageDrivers = JSON.parse(
       PageConfig.getOption('settingsStorageDrivers') || 'null',
     );


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1601

So multiple deployments under the same domain, for example the same user or GitHub organization, do not share files.

## Code changes

- [x] Use `baseUrl` as part of the default `contentsStorageName` for the drive
- [x] Add to the migration guide

This is what it looks like in the dev tools for this PR:

![image](https://github.com/user-attachments/assets/46b6c3ac-9ea6-4cbf-9bce-6d2c15cfd640)


## User-facing changes

Existing deployments may not find their previous content stored in the browser anymore, since the default storage name will have changed.

## Backwards-incompatible changes

