### PR TITLE
Remove top-level `resolutions`

### DIFF
--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -111,7 +111,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -167,8 +167,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -110,7 +110,7 @@
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -117,7 +117,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -179,8 +179,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -116,7 +116,7 @@
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/app/lab/package.json
+++ b/app/lab/package.json
@@ -120,7 +120,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "mock-socket": "^9.3.1",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/app/lab/package.json
+++ b/app/lab/package.json
@@ -121,7 +121,7 @@
     "es6-promise": "^4.2.8",
     "mock-socket": "^9.3.1",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -181,8 +181,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -120,7 +120,7 @@
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -121,7 +121,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -186,8 +186,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/app/repl/package.json
+++ b/app/repl/package.json
@@ -89,7 +89,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -127,8 +127,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "yjs": "^13.5.40"
   },
   "jupyterlab": {

--- a/app/repl/package.json
+++ b/app/repl/package.json
@@ -88,7 +88,7 @@
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -103,7 +103,7 @@
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
+    "react-dom": "^18.3.1",
     "yjs": "^13.6.7"
   },
   "dependencies": {
@@ -153,8 +153,8 @@
     "@jupyterlite/types": "^0.6.0-alpha.8",
     "@jupyterlite/ui-components": "^0.6.0-alpha.8",
     "es6-promise": "~4.2.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
   },
   "jupyterlab": {
     "title": "Jupyter Notebook - Tree",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -102,7 +102,7 @@
     "@microsoft/fast-element": "^1.12.0",
     "@microsoft/fast-foundation": "^2.49.5",
     "es6-promise": "^4.2.8",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "yjs": "^13.6.7"
   },

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -9,5 +9,5 @@ py/jupyterlite-core
 ```{toctree}
 :caption: TypeScript API
 :maxdepth: 2
-ts/index
+ts/index/README.md
 ```

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -9,5 +9,5 @@ py/jupyterlite-core
 ```{toctree}
 :caption: TypeScript API
 :maxdepth: 2
-ts/index/README.md
+ts/README
 ```

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -8,6 +8,5 @@ py/jupyterlite-core
 
 ```{toctree}
 :caption: TypeScript API
-:maxdepth: 2
 ts/README
 ```

--- a/dodo.py
+++ b/dodo.py
@@ -464,7 +464,7 @@ def task_docs():
             *P.DOCS_MD,
             *P.DOCS_PY,
             *P.DOCS_IPYNB,
-            B.DOCS_APP_ARCHIVE,
+            # B.DOCS_APP_ARCHIVE,
             B.DOCS_TS_MYST_INDEX,
         ],
         actions=[U.do("sphinx-build", *C.SPHINX_ARGS, "-b", "html", P.DOCS, B.DOCS)],
@@ -1126,12 +1126,6 @@ class U:
             out_text = re.sub(
                 r"^((Implementation of|Overrides|Inherited from):)",
                 "_\\1_",
-                out_text,
-                flags=re.M | re.S,
-            )
-            out_text = re.sub(
-                r"^Defined in: ([^\n]+)$",
-                "_Defined in:_ `\\1`",
                 out_text,
                 flags=re.M | re.S,
             )

--- a/dodo.py
+++ b/dodo.py
@@ -1138,7 +1138,6 @@ class U:
 
             out_doc.write_text(out_text, **C.ENC)
 
-
     def validate(schema_path, instance_path=None, instance_obj=None, ref=None):
         import jsonschema
 

--- a/dodo.py
+++ b/dodo.py
@@ -924,7 +924,7 @@ class B:
     DOCS_TS_MYST_INTERFACES = DOCS_TS / "interfaces.md"
     DOCS_TS_MYST_CLASSES = DOCS_TS / "classes.md"
     DOCS_TS_MODULES = [
-        P.ROOT / f"docs/reference/api/ts/modules/@jupyterlite/{parent}/README.md"
+        P.ROOT / f"docs/reference/api/ts/modules/@jupyterlite/{parent}/index.md"
         for parent in P.PACKAGE_JSONS
         if parent not in C.NO_TYPEDOC
     ]
@@ -1106,8 +1106,6 @@ class U:
         for doc in sorted(B.DOCS_RAW_TYPEDOC.rglob("*.md")):
             if doc.parent == B.DOCS_RAW_TYPEDOC:
                 continue
-            if doc.name == "README.md":
-                continue
             doc_text = doc.read_text(**C.ENC)
             doc_lines = doc_text.splitlines()
 
@@ -1116,7 +1114,7 @@ class U:
             if not out_doc.parent.exists():
                 out_doc.parent.mkdir(parents=True)
 
-            out_text = "\n".join([*doc_lines[1:], ""]).replace("README.md", "index.md")
+            out_text = "\n".join([*doc_lines[1:], ""])
             out_text = re.sub(
                 r"## Table of contents(.*?)\n## ",
                 "\n## ",

--- a/dodo.py
+++ b/dodo.py
@@ -464,7 +464,7 @@ def task_docs():
             *P.DOCS_MD,
             *P.DOCS_PY,
             *P.DOCS_IPYNB,
-            B.DOCS_APP_ARCHIVE,
+            # B.DOCS_APP_ARCHIVE,
             B.DOCS_TS_MYST_INDEX,
         ],
         actions=[U.do("sphinx-build", *C.SPHINX_ARGS, "-b", "html", P.DOCS, B.DOCS)],
@@ -944,7 +944,7 @@ class BB:
     # not exhaustive, because of per-class API pages
     ALL_DOCS_HTML = [
         (B.DOCS / src.parent.relative_to(P.DOCS) / (src.name.rsplit(".", 1)[0] + ".html"))
-        for src in [*P.DOCS_MD, *P.DOCS_IPYNB, *B.DOCS_TS_MODULES]
+        for src in [*P.DOCS_MD, *P.DOCS_IPYNB]
         if P.DOCS in src.parents and C.NOT_SKIP_LINT(src)
     ]
 
@@ -1136,7 +1136,9 @@ class U:
 
         index_text = B.DOCS_TS_MYST_INDEX.read_text(**C.ENC)
         all_docs_text = "\n".join(
-            str(d.relative_to(B.DOCS_RAW_TYPEDOC)) for d in all_docs if d != B.DOCS_TS_MYST_INDEX
+            str(d.relative_to(B.DOCS_RAW_TYPEDOC))
+            for d in all_docs
+            if str(d.relative_to(B.DOCS_RAW_TYPEDOC)) != "README.md"
         )
         B.DOCS_TS_MYST_INDEX.write_text(
             index_text

--- a/dodo.py
+++ b/dodo.py
@@ -924,7 +924,7 @@ class B:
     DOCS_TS_MYST_INTERFACES = DOCS_TS / "interfaces.md"
     DOCS_TS_MYST_CLASSES = DOCS_TS / "classes.md"
     DOCS_TS_MODULES = [
-        P.ROOT / f"docs/reference/api/ts/modules/jupyterlite_{parent.replace('-', '_')}.md"
+        P.ROOT / f"docs/reference/api/ts/modules/@jupyterlite/{parent}/README.md"
         for parent in P.PACKAGE_JSONS
         if parent not in C.NO_TYPEDOC
     ]

--- a/dodo.py
+++ b/dodo.py
@@ -1135,6 +1135,9 @@ class U:
             out_doc.write_text(out_text, **C.ENC)
 
         index_text = B.DOCS_TS_MYST_INDEX.read_text(**C.ENC)
+        all_docs_text = "\n".join(
+            str(d.relative_to(B.DOCS_RAW_TYPEDOC)) for d in all_docs if d != B.DOCS_TS_MYST_INDEX
+        )
         B.DOCS_TS_MYST_INDEX.write_text(
             index_text
             + "\n\n"
@@ -1144,7 +1147,7 @@ class U:
                     "```{toctree}",
                     ":maxdepth: 1",
                     ":glob:",
-                    f"{'\n'.join(str(d.relative_to(B.DOCS_RAW_TYPEDOC)) for d in all_docs)}",
+                    f"{all_docs_text}",
                     "```",
                 ]
             )

--- a/dodo.py
+++ b/dodo.py
@@ -1107,18 +1107,16 @@ class U:
             if doc.parent == B.DOCS_RAW_TYPEDOC:
                 continue
             doc_text = doc.read_text(**C.ENC)
-            doc_lines = doc_text.splitlines()
 
             # rewrite doc and write back out
             out_doc = B.DOCS_TS / doc.relative_to(B.DOCS_RAW_TYPEDOC)
             if not out_doc.parent.exists():
                 out_doc.parent.mkdir(parents=True)
 
-            out_text = "\n".join([*doc_lines[1:], ""])
             out_text = re.sub(
                 r"## Table of contents(.*?)\n## ",
                 "\n## ",
-                out_text,
+                doc_text,
                 flags=re.M | re.S,
             )
             out_text = re.sub("^# Module: (.*)$", r"# `\1`", out_text, flags=re.M)

--- a/dodo.py
+++ b/dodo.py
@@ -919,12 +919,9 @@ class B:
     DOCS_RAW_TYPEDOC = BUILD / "typedoc"
     DOCS_RAW_TYPEDOC_README = DOCS_RAW_TYPEDOC / "README.md"
     DOCS_TS = P.DOCS / "reference/api/ts"
-    DOCS_TS_MYST_INDEX = DOCS_TS / "index.md"
-    DOCS_TS_MYST_MODULES = DOCS_TS / "modules.md"
-    DOCS_TS_MYST_INTERFACES = DOCS_TS / "interfaces.md"
-    DOCS_TS_MYST_CLASSES = DOCS_TS / "classes.md"
+    DOCS_TS_MYST_INDEX = DOCS_TS / "README.md"
     DOCS_TS_MODULES = [
-        P.ROOT / f"docs/reference/api/ts/modules/@jupyterlite/{parent}/index.md"
+        P.ROOT / f"docs/reference/api/ts/modules/@jupyterlite/{parent}/README.md"
         for parent in P.PACKAGE_JSONS
         if parent not in C.NO_TYPEDOC
     ]
@@ -1104,8 +1101,6 @@ class U:
             return f"""**`{unescaped}`**"""
 
         for doc in sorted(B.DOCS_RAW_TYPEDOC.rglob("*.md")):
-            if doc.parent == B.DOCS_RAW_TYPEDOC:
-                continue
             doc_text = doc.read_text(**C.ENC)
 
             # rewrite doc and write back out
@@ -1143,40 +1138,6 @@ class U:
 
             out_doc.write_text(out_text, **C.ENC)
 
-        for index in [
-            B.DOCS_TS_MYST_INTERFACES,
-            B.DOCS_TS_MYST_MODULES,
-            B.DOCS_TS_MYST_CLASSES,
-        ]:
-            name = index.name[:-3]
-            index.write_text(
-                "\n".join(
-                    [
-                        f"# {name.title()}",
-                        "\n",
-                        "```{toctree}",
-                        ":maxdepth: 1",
-                        ":glob:",
-                        f"{name}/*",
-                        "```",
-                    ]
-                )
-            )
-
-        B.DOCS_TS_MYST_INDEX.write_text(
-            "\n".join(
-                [
-                    "# `@jupyterlite`\n",
-                    "```{toctree}",
-                    ":maxdepth: 1",
-                    "modules",
-                    "interfaces",
-                    "classes",
-                    "```",
-                ]
-            ),
-            **C.ENC,
-        )
 
     def validate(schema_path, instance_path=None, instance_obj=None, ref=None):
         import jsonschema

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "shell-quote": "^1.8.1",
     "svgo": "^3.0.1",
     "typedoc": "~0.23.21",
-    "typedoc-plugin-markdown": "~3.14.0",
+    "typedoc-plugin-markdown": "~4.6.1",
     "typescript": "~5.5.4"
   },
   "packageManager": "yarn@3.5.0"

--- a/package.json
+++ b/package.json
@@ -63,17 +63,6 @@
     "proseWrap": "always",
     "singleQuote": true
   },
-  "resolutions": {
-    "@types/react": "^18.0.26",
-    "json-schema": "^0.4.0",
-    "prettier": "^3.0.0",
-    "react": "^18.2.0",
-    "schema-utils": "^4.0.0",
-    "typescript": "~5.1.6",
-    "uuid": "^9.0.0",
-    "validator": "^13.7.0",
-    "yjs": "^13.5.40"
-  },
   "devDependencies": {
     "@jupyterlab/buildutils": "~4.4.0",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "shell-quote": "^1.8.1",
     "svgo": "^3.0.1",
     "typedoc": "~0.28.2",
-    "typedoc-plugin-markdown": "~4.6.1",
+    "typedoc-plugin-markdown": "~4.6.2",
     "typescript": "~5.5.4"
   },
   "packageManager": "yarn@3.5.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rimraf": "^5.0.1",
     "shell-quote": "^1.8.1",
     "svgo": "^3.0.1",
-    "typedoc": "~0.23.21",
+    "typedoc": "~0.28.2",
     "typedoc-plugin-markdown": "~4.6.1",
     "typescript": "~5.5.4"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -25,7 +25,5 @@
   "out": "build/typedoc",
   "readme": "none",
   "tsconfig": "tsconfig.typedoc.json",
-  "plugin": [
-    "typedoc-plugin-markdown"
-  ]
+  "plugin": ["typedoc-plugin-markdown"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -24,5 +24,8 @@
   "name": "@jupyterlite",
   "out": "build/typedoc",
   "readme": "none",
-  "tsconfig": "tsconfig.typedoc.json"
+  "tsconfig": "tsconfig.typedoc.json",
+  "plugin": [
+    "typedoc-plugin-markdown"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4871,7 +4871,7 @@ __metadata:
     shell-quote: ^1.8.1
     svgo: ^3.0.1
     typedoc: ~0.28.2
-    typedoc-plugin-markdown: ~4.6.1
+    typedoc-plugin-markdown: ~4.6.2
     typescript: ~5.5.4
   languageName: unknown
   linkType: soft
@@ -19542,12 +19542,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:~4.6.1":
-  version: 4.6.1
-  resolution: "typedoc-plugin-markdown@npm:4.6.1"
+"typedoc-plugin-markdown@npm:~4.6.2":
+  version: 4.6.2
+  resolution: "typedoc-plugin-markdown@npm:4.6.2"
   peerDependencies:
     typedoc: 0.28.x
-  checksum: 6fc9c0c5d4f6ed7fccb81a48f13469444e09a52312b98ab19a3c2831395bcb20519705e89292ca2ee4c4b0523127e19cf72a5f1821dff3d439bcbd45494b8a97
+  checksum: bbe2dba5890f35377e422127fe8fadaff27cfa46d322fa66595bc7e5179227ea1dc927ebc24fa4f42a2692b2f8ed1c8a6482c4227dea18fe70a0da183177229b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4314,8 +4314,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -4382,8 +4382,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -4448,8 +4448,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -4519,8 +4519,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -4563,8 +4563,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
     yjs: ^13.5.40
   languageName: unknown
   linkType: soft
@@ -4619,8 +4619,8 @@ __metadata:
     "@jupyterlite/types": ^0.6.0-alpha.8
     "@jupyterlite/ui-components": ^0.6.0-alpha.8
     es6-promise: ~4.2.8
-    react: ^18.2.0
-    react-dom: ^18.2.0
+    react: ^18.3.0
+    react-dom: ^18.3.0
   languageName: unknown
   linkType: soft
 
@@ -17286,15 +17286,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^18.2.0, react-dom@npm:^18.3.0":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-    scheduler: ^0.23.0
+    scheduler: ^0.23.2
   peerDependencies:
-    react: ^18.2.0
-  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
   languageName: node
   linkType: hard
 
@@ -17351,7 +17351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:>=17.0.0 <19.0.0, react@npm:^18.2.0":
+"react@npm:>=17.0.0 <19.0.0, react@npm:^18.2.0, react@npm:^18.3.0":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -17995,12 +17995,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4858,7 +4858,7 @@ __metadata:
     shell-quote: ^1.8.1
     svgo: ^3.0.1
     typedoc: ~0.23.21
-    typedoc-plugin-markdown: ~3.14.0
+    typedoc-plugin-markdown: ~4.6.1
     typescript: ~5.5.4
   languageName: unknown
   linkType: soft
@@ -19457,14 +19457,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:~3.14.0":
-  version: 3.14.0
-  resolution: "typedoc-plugin-markdown@npm:3.14.0"
-  dependencies:
-    handlebars: ^4.7.7
+"typedoc-plugin-markdown@npm:~4.6.1":
+  version: 4.6.1
+  resolution: "typedoc-plugin-markdown@npm:4.6.1"
   peerDependencies:
-    typedoc: ">=0.23.0"
-  checksum: 6205600052185b4b193ab8a253d9df5ccbc95002c948a07f9024bcd26f0f23fbcc089fda4d6b4c8f4172f4eaca2bf9c32129989f6baaace7261cf4a0e41c976b
+    typedoc: 0.28.x
+  checksum: 6fc9c0c5d4f6ed7fccb81a48f13469444e09a52312b98ab19a3c2831395bcb20519705e89292ca2ee4c4b0523127e19cf72a5f1821dff3d439bcbd45494b8a97
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,6 +1790,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gerrit0/mini-shiki@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@gerrit0/mini-shiki@npm:3.2.2"
+  dependencies:
+    "@shikijs/engine-oniguruma": ^3.2.1
+    "@shikijs/langs": ^3.2.1
+    "@shikijs/themes": ^3.2.1
+    "@shikijs/types": ^3.2.1
+    "@shikijs/vscode-textmate": ^10.0.2
+  checksum: 7395b061554410d8699e54480e2d1f86378204b90546f482c04f17db54c14545f7e179f37d8fde0b6a27d32bd8e22e2283b8be422e20db8d5b334643c5cdf855
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.10":
   version: 0.11.10
   resolution: "@humanwhocodes/config-array@npm:0.11.10"
@@ -4857,7 +4870,7 @@ __metadata:
     rimraf: ^5.0.1
     shell-quote: ^1.8.1
     svgo: ^3.0.1
-    typedoc: ~0.23.21
+    typedoc: ~0.28.2
     typedoc-plugin-markdown: ~4.6.1
     typescript: ~5.5.4
   languageName: unknown
@@ -6074,6 +6087,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/engine-oniguruma@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@shikijs/engine-oniguruma@npm:3.2.1"
+  dependencies:
+    "@shikijs/types": 3.2.1
+    "@shikijs/vscode-textmate": ^10.0.2
+  checksum: 7be39f6cb89e83173c634a9135a40a046addbfd9c01e98163ea8fd14e3fefef33fd617600863ac2c8518b29ab2b2836c98e21bd67788c642599d3f75b22606e5
+  languageName: node
+  linkType: hard
+
+"@shikijs/langs@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@shikijs/langs@npm:3.2.1"
+  dependencies:
+    "@shikijs/types": 3.2.1
+  checksum: 864ce53a33acf1226319cb33ee0166e575c11c2deb00fb08d75ae18a44d959baaff5d1bb0c582dd1ee3384295000d3329521d2d67a26e60eb1f843f59b246602
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@shikijs/themes@npm:3.2.1"
+  dependencies:
+    "@shikijs/types": 3.2.1
+  checksum: 406ca4c9da5372ac11451eccf9d8edab2462d6ac2c8236b64e2ddfd95c8fca76cc17d38b425f9b9af848c090bfcf72e66d51943945162fd1c20db83bc3575ced
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.2.1, @shikijs/types@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@shikijs/types@npm:3.2.1"
+  dependencies:
+    "@shikijs/vscode-textmate": ^10.0.2
+    "@types/hast": ^3.0.4
+  checksum: 3eaf77b6e21fed1ec3e96cb93c5fa4f9f7b72bc24d9e21db13f7fa1a168091af7bf8e27286c79c8ebf22f1108a6d3b9b59052e797b8698aff7602478aa3cef96
+  languageName: node
+  linkType: hard
+
+"@shikijs/vscode-textmate@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@shikijs/vscode-textmate@npm:10.0.2"
+  checksum: e68f27a3dc1584d7414b8acafb9c177a2181eb0b06ef178d8609142f49d28d85fd10ab129affde40a45a7d9238997e457ce47931b3a3815980e2b98b2d26724c
+  languageName: node
+  linkType: hard
+
 "@sigstore/bundle@npm:^1.0.0":
   version: 1.0.0
   resolution: "@sigstore/bundle@npm:1.0.0"
@@ -6571,6 +6629,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hast@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/hast@npm:3.0.4"
+  dependencies:
+    "@types/unist": "*"
+  checksum: 7a973e8d16fcdf3936090fa2280f408fb2b6a4f13b42edeb5fbd614efe042b82eac68e298e556d50f6b4ad585a3a93c353e9c826feccdc77af59de8dd400d044
+  languageName: node
+  linkType: hard
+
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -6776,6 +6843,13 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*":
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 96e6453da9e075aaef1dc22482463898198acdc1eeb99b465e65e34303e2ec1e3b1ed4469a9118275ec284dc98019f63c3f5d49422f0e4ac707e5ab90fb3b71a
   languageName: node
   linkType: hard
 
@@ -7786,13 +7860,6 @@ __metadata:
   version: 6.0.1
   resolution: "ansi-regex@npm:6.0.1"
   checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
-  languageName: node
-  linkType: hard
-
-"ansi-sequence-parser@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "ansi-sequence-parser@npm:1.1.1"
-  checksum: ead5b15c596e8e85ca02951a844366c6776769dcc9fd1bd3a0db11bb21364554822c6a439877fb599e7e1ffa0b5f039f1e5501423950457f3dcb2f480c30b188
   languageName: node
   linkType: hard
 
@@ -14010,7 +14077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.2.0, jsonc-parser@npm:^3.2.0":
+"jsonc-parser@npm:3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
@@ -14379,6 +14446,15 @@ __metadata:
   version: 2.0.3
   resolution: "lines-and-columns@npm:2.0.3"
   checksum: 5955363dfd7d3d7c476d002eb47944dbe0310d57959e2112dce004c0dc76cecfd479cf8c098fd479ff344acdf04ee0e82b455462a26492231ac152f6c48d17a1
+  languageName: node
+  linkType: hard
+
+"linkify-it@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "linkify-it@npm:5.0.0"
+  dependencies:
+    uc.micro: ^2.0.0
+  checksum: b0b86cadaf816b64c947a83994ceaad1c15f9fe7e079776ab88699fb71afd7b8fc3fd3d0ae5ebec8c92c1d347be9ba257b8aef338c0ebf81b0d27dcf429a765a
   languageName: node
   linkType: hard
 
@@ -14803,6 +14879,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "markdown-it@npm:14.1.0"
+  dependencies:
+    argparse: ^2.0.1
+    entities: ^4.4.0
+    linkify-it: ^5.0.0
+    mdurl: ^2.0.0
+    punycode.js: ^2.3.1
+    uc.micro: ^2.1.0
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 07296b45ebd0b13a55611a24d1b1ad002c6729ec54f558f597846994b0b7b1de79d13cd99ff3e7b6e9e027f36b63125cdcf69174da294ecabdd4e6b9fff39e5d
+  languageName: node
+  linkType: hard
+
 "markdown-to-jsx@npm:^7.3.2":
   version: 7.3.2
   resolution: "markdown-to-jsx@npm:7.3.2"
@@ -14841,15 +14933,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.2.12":
-  version: 4.3.0
-  resolution: "marked@npm:4.3.0"
-  bin:
-    marked: bin/marked.js
-  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
-  languageName: node
-  linkType: hard
-
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -14873,6 +14956,13 @@ __metadata:
   version: 2.0.28
   resolution: "mdn-data@npm:2.0.28"
   checksum: f51d587a6ebe8e426c3376c74ea6df3e19ec8241ed8e2466c9c8a3904d5d04397199ea4f15b8d34d14524b5de926d8724ae85207984be47e165817c26e49e0aa
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 880bc289ef668df0bb34c5b2b5aaa7b6ea755052108cdaf4a5e5968ad01cf27e74927334acc9ebcc50a8628b65272ae6b1fd51fae1330c130e261c0466e1a3b2
   languageName: node
   linkType: hard
 
@@ -15105,7 +15195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:7.4.6, minimatch@npm:^7.1.3":
+"minimatch@npm:7.4.6":
   version: 7.4.6
   resolution: "minimatch@npm:7.4.6"
   dependencies:
@@ -15141,12 +15231,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "minimatch@npm:9.0.5"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  checksum: 2c035575eda1e50623c731ec6c14f65a85296268f749b9337005210bb2b34e2705f8ef1a358b188f69892286ab99dc42c8fb98a57bde55c8d81b3023c19cea28
   languageName: node
   linkType: hard
 
@@ -17060,6 +17150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 13466d7ed5e8dacdab8c4cc03837e7dd14218a59a40eb14a837f1f53ca396e18ef2c4ee6d7766b8ed2fc391d6a3ac489eebf2de83b3596f5a54e86df4a251b72
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
@@ -18101,18 +18198,6 @@ __metadata:
   version: 1.8.1
   resolution: "shell-quote@npm:1.8.1"
   checksum: 5f01201f4ef504d4c6a9d0d283fa17075f6770bfbe4c5850b074974c68062f37929ca61700d95ad2ac8822e14e8c4b990ca0e6e9272e64befd74ce5e19f0736b
-  languageName: node
-  linkType: hard
-
-"shiki@npm:^0.14.1":
-  version: 0.14.3
-  resolution: "shiki@npm:0.14.3"
-  dependencies:
-    ansi-sequence-parser: ^1.1.0
-    jsonc-parser: ^3.2.0
-    vscode-oniguruma: ^1.7.0
-    vscode-textmate: ^8.0.0
-  checksum: a4dd98e3b2a5dd8be207448f111ffb9ad2ed6c530f215714d8b61cbf91ec3edbabb09109b8ec58a26678aacd24e8161d5a9bc0c1fa1b4f64b27ceb180cbd0c89
   languageName: node
   linkType: hard
 
@@ -19466,19 +19551,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:~0.23.21":
-  version: 0.23.28
-  resolution: "typedoc@npm:0.23.28"
+"typedoc@npm:~0.28.2":
+  version: 0.28.2
+  resolution: "typedoc@npm:0.28.2"
   dependencies:
+    "@gerrit0/mini-shiki": ^3.2.2
     lunr: ^2.3.9
-    marked: ^4.2.12
-    minimatch: ^7.1.3
-    shiki: ^0.14.1
+    markdown-it: ^14.1.0
+    minimatch: ^9.0.5
+    yaml: ^2.7.1
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
   bin:
     typedoc: bin/typedoc
-  checksum: 40eb4e207aac1b734e09400cf03f543642cc7b11000895198dd5a0d3166315759ccf4ac30a2915153597c5c186101c72bac2f1fc12b428184a9274d3a0e44c5e
+  checksum: 3733091fb6d40e66ef0e1cc83f099feb6b7879e10e02dcd3af758ae66921302456d9ab7abbe348c0d7905eb31545cf985bf2efe682747524dd5e7c99e5fccf15
   languageName: node
   linkType: hard
 
@@ -19529,6 +19615,13 @@ __metadata:
     csstype: 3.0.10
     free-style: 3.1.0
   checksum: 8b4f02c24f67b594f98507b15a753dabd4db5eb0af007e1d310527c64030e11e9464b25b5a6bc65fb5eec9a4459a8336050121ecc29063ac87b8b47a6d698893
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2
   languageName: node
   linkType: hard
 
@@ -20457,20 +20550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-oniguruma@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "vscode-oniguruma@npm:1.7.0"
-  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
-  languageName: node
-  linkType: hard
-
-"vscode-textmate@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "vscode-textmate@npm:8.0.0"
-  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
-  languageName: node
-  linkType: hard
-
 "vscode-uri@npm:~3.0.8":
   version: 3.0.8
   resolution: "vscode-uri@npm:3.0.8"
@@ -21035,6 +21114,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "yaml@npm:2.7.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 385f8115ddfafdf8e599813cca8b2bf4e3f6a01b919fff5ae7da277e164df684d7dfe558b4085172094792b5a04786d3c55fa8b74abb0ee029873f031150bb80
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,10 +6631,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.9":
-  version: 7.0.12
-  resolution: "@types/json-schema@npm:7.0.12"
-  checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
   languageName: node
   linkType: hard
 
@@ -7715,6 +7715,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "ajv-keywords@npm:3.5.2"
+  peerDependencies:
+    ajv: ^6.9.1
+  checksum: 7dc5e5931677a680589050f79dcbe1fefbb8fea38a955af03724229139175b433c63c68f7ae5f86cf8f65d55eb7c25f75a046723e2e58296707617ca690feae9
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^5.1.0":
   version: 5.1.0
   resolution: "ajv-keywords@npm:5.1.0"
@@ -7738,7 +7747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.12.4":
+"ajv@npm:^6.1.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -13957,7 +13966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema@npm:^0.4.0":
+"json-schema@npm:0.4.0, json-schema@npm:^0.4.0":
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
   checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
@@ -16838,6 +16847,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:~2.6.0":
+  version: 2.6.2
+  resolution: "prettier@npm:2.6.2"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 48d08dde8e9fb1f5bccdd205baa7f192e9fc8bc98f86e1b97d919de804e28c806b0e6cc685e4a88211aa7987fa9668f30baae19580d87ced3ed0f2ec6572106f
+  languageName: node
+  linkType: hard
+
 "pretty-error@npm:^4.0.0":
   version: 4.0.0
   resolution: "pretty-error@npm:4.0.0"
@@ -17236,12 +17254,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:>=17.0.0 <19.0.0, react@npm:^18.2.0":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
   languageName: node
   linkType: hard
 
@@ -17886,6 +17904,38 @@ __metadata:
   dependencies:
     loose-envify: ^1.1.0
   checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^0.4.0":
+  version: 0.4.7
+  resolution: "schema-utils@npm:0.4.7"
+  dependencies:
+    ajv: ^6.1.0
+    ajv-keywords: ^3.1.0
+  checksum: acee0b7aee127374099846114ee01e3e0eec057e27f8451b2dbdfa43f17ea42ed1e6af876f2a28f5212cb5adef263f99661d0475208417226e5c83c648235b0e
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^2.6.5, schema-utils@npm:^2.7.0":
+  version: 2.7.1
+  resolution: "schema-utils@npm:2.7.1"
+  dependencies:
+    "@types/json-schema": ^7.0.5
+    ajv: ^6.12.4
+    ajv-keywords: ^3.5.2
+  checksum: 32c62fc9e28edd101e1bd83453a4216eb9bd875cc4d3775e4452b541908fa8f61a7bbac8ffde57484f01d7096279d3ba0337078e85a918ecbeb72872fb09fb2b
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.1, schema-utils@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "schema-utils@npm:3.3.0"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: ea56971926fac2487f0757da939a871388891bc87c6a82220d125d587b388f1704788f3706e7f63a7b70e49fc2db974c41343528caea60444afd5ce0fe4b85c0
   languageName: node
   linkType: hard
 
@@ -19434,23 +19484,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.1.6":
-  version: 5.1.6
-  resolution: "typescript@npm:5.1.6"
+"typescript@npm:^3 || ^4":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.1.6#~builtin<compat/typescript>":
-  version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=85af82"
+"typescript@npm:~5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
+  checksum: b309040f3a1cd91c68a5a58af6b9fdd4e849b8c42d837b2c2e73f9a4f96a98c4f1ed398a9aab576ee0a4748f5690cf594e6b99dbe61de7839da748c41e6d6ca8
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^3 || ^4#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~5.5.4#~builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=85af82"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
   languageName: node
   linkType: hard
 
@@ -19671,12 +19741,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
+"uuid@npm:8.3.2, uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
   bin:
     uuid: dist/bin/uuid
-  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 840f19758543c4631e58a29439e51b5b669d5f34b4dd2700b6a1d15c5708c7a6e0c3e2c8c4a2eae761a3a7caa7e9884d00c86c02622ba91137bd3deade6b4b4a
   languageName: node
   linkType: hard
 
@@ -19775,10 +19854,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:^13.7.0":
-  version: 13.9.0
-  resolution: "validator@npm:13.9.0"
-  checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c
+"validator@npm:13.12.0":
+  version: 13.12.0
+  resolution: "validator@npm:13.12.0"
+  checksum: fb8f070724770b1449ea1a968605823fdb112dbd10507b2802f8841cda3e7b5c376c40f18c84e6a7b59de320a06177e471554101a85f1fa8a70bac1a84e48adf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Remove top-level `resolutions`, as they don't appear to be needed anymore.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Not sure why they were defined in the first place, but these resolutions were preventing the use of the new TypeScript version.

Also had to bump `typedoc` and make some changes to `dodo.py` to make the build pass and unblock this. It looks like we would better off keeping the typedoc build as-is and not try to post-process it, to avoid spending a lot of time trying to maintain the myst integration... And instead just link to the raw output, use the default typedoc theme.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
