### PR TITLE
Disable the notebook export plugin

### DIFF
--- a/app/consoles/package.json
+++ b/app/consoles/package.json
@@ -316,6 +316,7 @@
       "@jupyterlab/help-extension:about",
       "@jupyterlab/help-extension:open",
       "@jupyterlab/lsp-extension:plugin",
+      "@jupyterlab/notebook-extension:export",
       "@jupyterlab/notebook-extension:execution-indicator",
       "@jupyterlab/notebook-extension:kernel-status",
       "@jupyterlab/services-extension:config-section-manager",

--- a/app/edit/package.json
+++ b/app/edit/package.json
@@ -332,6 +332,7 @@
       "@jupyterlab/help-extension:about",
       "@jupyterlab/help-extension:open",
       "@jupyterlab/lsp-extension:plugin",
+      "@jupyterlab/notebook-extension:export",
       "@jupyterlab/notebook-extension:execution-indicator",
       "@jupyterlab/notebook-extension:kernel-status",
       "@jupyterlab/services-extension:config-section-manager",

--- a/app/lab/package.json
+++ b/app/lab/package.json
@@ -322,6 +322,7 @@
       "@jupyterlab/filebrowser-extension:share-file",
       "@jupyterlab/help-extension:about",
       "@jupyterlab/lsp-extension:plugin",
+      "@jupyterlab/notebook-extension:export",
       "@jupyterlab/services-extension:config-section-manager",
       "@jupyterlab/services-extension:connection-status",
       "@jupyterlab/services-extension:default-drive",

--- a/app/notebooks/package.json
+++ b/app/notebooks/package.json
@@ -342,6 +342,7 @@
       "@jupyterlab/help-extension:about",
       "@jupyterlab/help-extension:open",
       "@jupyterlab/lsp-extension:plugin",
+      "@jupyterlab/notebook-extension:export",
       "@jupyterlab/notebook-extension:execution-indicator",
       "@jupyterlab/notebook-extension:kernel-status",
       "@jupyterlab/services-extension:config-section-manager",

--- a/app/tree/package.json
+++ b/app/tree/package.json
@@ -298,6 +298,7 @@
       "@jupyterlab/help-extension:about",
       "@jupyterlab/help-extension:open",
       "@jupyterlab/lsp-extension:plugin",
+      "@jupyterlab/notebook-extension:export",
       "@jupyterlab/notebook-extension:execution-indicator",
       "@jupyterlab/notebook-extension:kernel-status",
       "@jupyterlab/notebook-extension:language-server",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1364

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Disable the `@jupyterlab/notebook-extension:export` plugin in all relevant apps.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

For end users, this has the effect of not showing the "Save and Export Notebook As..." menu item anymore.

This menu item didn't have any submenu anyway, so until there is a way to properly export a notebook.

![image](https://github.com/user-attachments/assets/961d53b9-065d-4390-bb0f-0aac2ffcac87)

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
