### PR TITLE
Fix concurrent file system access from multiple tabs

### DIFF
--- a/packages/server/src/service-worker-manager.ts
+++ b/packages/server/src/service-worker-manager.ts
@@ -180,10 +180,6 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       browsingContextId: string;
     }>,
   ): Promise<void> => {
-    if (!this._broadcastChannel || !this._driveContentsProcessor) {
-      return;
-    }
-
     const { data, browsingContextId } = event.data;
 
     if (browsingContextId !== this._browsingContextId) {
@@ -192,7 +188,11 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     }
 
     const response = await this._driveContentsProcessor.processDriveRequest(data);
-    this._broadcastChannel.postMessage(response);
+    // pass the browsingContextId along so the Service Worker can identify the request
+    this._broadcastChannel.postMessage({
+      response,
+      browsingContextId: this._browsingContextId,
+    });
   };
 
   private _registration: ServiceWorkerRegistration | null = null;
@@ -202,6 +202,6 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
   private _ready = new PromiseDelegate<void>();
   private _broadcastChannel: BroadcastChannel;
   private _browsingContextId: string;
-  private _contents: Contents.IManager | undefined;
-  private _driveContentsProcessor: DriveContentsProcessor | undefined;
+  private _contents: Contents.IManager;
+  private _driveContentsProcessor: DriveContentsProcessor;
 }

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -139,8 +139,7 @@ async function broadcastOne(request: Request): Promise<Response> {
   const promise = new Promise<Response>((resolve) => {
     const messageHandler = (event: MessageEvent) => {
       const data = event.data;
-      const browsingContextId = data.browsingContextId;
-      if (browsingContextId !== message.browsingContextId) {
+      if (data.browsingContextId !== message.browsingContextId) {
         // bail if the message is not for us
         return;
       }

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -137,7 +137,7 @@ function shouldDrop(request: Request, url: URL): boolean {
 async function broadcastOne(request: Request): Promise<Response> {
   const message = await request.json();
   const promise = new Promise<Response>((resolve) => {
-    broadcast.onmessage = (event) => {
+    const messageHandler = (event: MessageEvent) => {
       const data = event.data;
       const browsingContextId = data.browsingContextId;
       if (browsingContextId !== message.browsingContextId) {
@@ -146,7 +146,10 @@ async function broadcastOne(request: Request): Promise<Response> {
       }
       const response = data.response;
       resolve(new Response(JSON.stringify(response)));
+      broadcast.removeEventListener('message', messageHandler);
     };
+
+    broadcast.addEventListener('message', messageHandler);
   });
 
   broadcast.postMessage(message);

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -135,13 +135,20 @@ function shouldDrop(request: Request, url: URL): boolean {
  * Forward request to main using the broadcast channel
  */
 async function broadcastOne(request: Request): Promise<Response> {
+  const message = await request.json();
   const promise = new Promise<Response>((resolve) => {
     broadcast.onmessage = (event) => {
-      resolve(new Response(JSON.stringify(event.data)));
+      const data = event.data;
+      const browsingContextId = data.browsingContextId;
+      if (browsingContextId !== message.browsingContextId) {
+        // bail if the message is not for us
+        return;
+      }
+      const response = data.response;
+      resolve(new Response(JSON.stringify(response)));
     };
   });
 
-  const message = await request.json();
   broadcast.postMessage(message);
 
   return await promise;

--- a/ui-tests/contents/file-access-1.ipynb
+++ b/ui-tests/contents/file-access-1.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f578200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "for i in range(1000):\n",
+    "    Path('test1.txt').write_text('1')\n",
+    "\n",
+    "    if i % 10 == 0:\n",
+    "        print(i)\n",
+    "\n",
+    "print('done')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/contents/file-access-1.ipynb
+++ b/ui-tests/contents/file-access-1.ipynb
@@ -10,12 +10,12 @@
     "from pathlib import Path\n",
     "\n",
     "for i in range(1000):\n",
-    "    Path('test1.txt').write_text('1')\n",
+    "    Path(\"test1.txt\").write_text(\"1\")\n",
     "\n",
     "    if i % 10 == 0:\n",
     "        print(i)\n",
     "\n",
-    "print('done')"
+    "print(\"done\")"
    ]
   }
  ],

--- a/ui-tests/contents/file-access-2.ipynb
+++ b/ui-tests/contents/file-access-2.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3c4d1de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "for i in range(1000):\n",
+    "    Path('test2.txt').write_text('1')\n",
+    "\n",
+    "    if i % 10 == 0:\n",
+    "        print(i)\n",
+    "\n",
+    "print('done')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/contents/file-access-2.ipynb
+++ b/ui-tests/contents/file-access-2.ipynb
@@ -10,7 +10,7 @@
     "from pathlib import Path\n",
     "\n",
     "for i in range(1000):\n",
-    "    Path(\"test2.txt\").write_text(\"1\")\n",
+    "    Path(\"test2.txt\").write_text(\"2\")\n",
     "\n",
     "    if i % 10 == 0:\n",
     "        print(i)\n",

--- a/ui-tests/contents/file-access-2.ipynb
+++ b/ui-tests/contents/file-access-2.ipynb
@@ -10,12 +10,12 @@
     "from pathlib import Path\n",
     "\n",
     "for i in range(1000):\n",
-    "    Path('test2.txt').write_text('1')\n",
+    "    Path(\"test2.txt\").write_text(\"1\")\n",
     "\n",
     "    if i % 10 == 0:\n",
     "        print(i)\n",
     "\n",
-    "print('done')"
+    "print(\"done\")"
    ]
   }
  ],

--- a/ui-tests/contents/file-access.ipynb
+++ b/ui-tests/contents/file-access.ipynb
@@ -44,7 +44,7 @@
     "folder = Path(DIR_NAME)\n",
     "folder.mkdir(exist_ok=True)\n",
     "\n",
-    "for i in range(100):\n",
+    "for i in range(1000):\n",
     "    data = np.random.randn(int(1e1))\n",
     "    np.save(folder / f\"data_{i}.npy\", data)\n",
     "\n",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1626

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Better handle requests in the Service Worker
- [x] UI test

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Hopefully less issues.

It should be possible to work on two notebooks in two different browser tabs at the same time:

https://github.com/user-attachments/assets/6cb61b02-0be2-40ad-861b-10b7e5052886

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
