### PR TITLE
Add a loading indicator

### DIFF
--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -38,6 +38,58 @@ function getOption(name) {
   return _CONFIG_DATA[name] || '';
 }
 
+/**
+ * Apply theme to loading indicator based on saved settings in IndexedDB
+ */
+async function applyThemeToAppLoadingIndicator() {
+  try {
+    const baseUrl = getOption('baseUrl');
+    const defaultStorageName = `JupyterLite Storage - ${baseUrl}`;
+    const storageName = getOption('settingsStorageName') || defaultStorageName;
+
+    const localforageModule = await import('localforage');
+    const localforage = localforageModule.default;
+
+    const settingsDB = localforage.createInstance({
+      name: storageName,
+      storeName: 'settings'
+    });
+
+    const key = '@jupyterlab/apputils-extension:themes';
+    const settings = await settingsDB.getItem(key);
+
+    let isDarkTheme = false;
+
+    if (settings) {
+      // Use regex to find "theme": "name of theme" pattern, since the
+      // settings are stored as a raw string
+      const themeRegex = /"theme"\s*:\s*"([^"]+)"/i;
+      const matches = settings.match(themeRegex);
+
+      if (matches && matches[1]) {
+        const themeName = matches[1].toLowerCase();
+        isDarkTheme =
+          themeName.includes('dark') ||
+          themeName.includes('night') ||
+          themeName.includes('black');
+      }
+    }
+
+    document.body.classList.remove('jp-mod-dark', 'jp-mod-light');
+
+    if (isDarkTheme) {
+      document.body.classList.add('jp-mod-dark');
+    } else {
+      document.body.classList.add('jp-mod-light');
+    }
+  } catch (e) {
+    console.warn('Could not apply theme to loading indicator:', e);
+    // Fallback to light theme on error
+    document.body.classList.remove('jp-mod-dark');
+    document.body.classList.add('jp-mod-light');
+  }
+}
+
 // eslint-disable-next-line no-undef
 __webpack_public_path__ = getOption('fullStaticUrl') + '/';
 
@@ -63,6 +115,8 @@ async function loadComponent(url, scope) {
 }
 
 void (async function bootstrap() {
+  await applyThemeToAppLoadingIndicator();
+
   // This is all the data needed to load and activate plugins. This should be
   // gathered by the server and put onto the initial page template.
   const extension_data = getOption('federated_extensions');

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -42,6 +42,11 @@ function getOption(name) {
  * Apply theme to loading indicator based on saved settings in IndexedDB
  */
 async function applyThemeToAppLoadingIndicator() {
+  const indicator = document.getElementById('jupyterlite-loading-indicator');
+  if (!indicator) {
+    return; // Not on lab page, no need to apply theme
+  }
+
   try {
     const baseUrl = getOption('baseUrl');
     const defaultStorageName = `JupyterLite Storage - ${baseUrl}`;

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -58,8 +58,13 @@ function hideAppLoadingIndicator() {
  */
 async function applyThemeToAppLoadingIndicator() {
   const indicator = document.getElementById('jupyterlite-loading-indicator');
-  if (!indicator) {
-    return; // Not on lab page, no need to apply theme
+
+  const showLoadingIndicator = getOption('showLoadingIndicator');
+  if (showLoadingIndicator !== true) {
+    if (indicator) {
+      indicator.remove();
+    }
+    return;
   }
 
   try {

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -58,12 +58,18 @@ function hideAppLoadingIndicator() {
  */
 async function applyThemeToAppLoadingIndicator() {
   const indicator = document.getElementById('jupyterlite-loading-indicator');
+  if (!indicator) {
+    return;
+  }
+
+  // Hide the indicator by default
+  indicator.classList.add('hidden');
 
   const showLoadingIndicator = getOption('showLoadingIndicator');
-  if (showLoadingIndicator !== true) {
-    if (indicator) {
-      indicator.remove();
-    }
+  // Only show the indicator if explicitly set to true
+  if (showLoadingIndicator === true) {
+    indicator.classList.remove('hidden');
+  } else {
     return;
   }
 

--- a/app/bootstrap.js
+++ b/app/bootstrap.js
@@ -39,6 +39,21 @@ function getOption(name) {
 }
 
 /**
+ * Hide the loading indicator once the app is fully loaded
+ */
+function hideAppLoadingIndicator() {
+  const indicator = document.getElementById('jupyterlite-loading-indicator');
+  if (indicator) {
+    indicator.classList.add('hidden');
+    indicator.addEventListener('animationend', () => {
+      indicator.remove();
+      // Remove theme classes after the loading indicator is removed
+      document.body.classList.remove('jp-mod-dark', 'jp-mod-light');
+    }, { once: true });
+  }
+}
+
+/**
  * Apply theme to loading indicator based on saved settings in IndexedDB
  */
 async function applyThemeToAppLoadingIndicator() {
@@ -148,5 +163,7 @@ void (async function bootstrap() {
   // Now that all federated containers are initialized with the main
   // container, we can import the main function.
   let main = (await import('./index.js')).main;
-  void main();
+  await main();
+
+  hideAppLoadingIndicator();
 })();

--- a/app/index.template.html
+++ b/app/index.template.html
@@ -107,13 +107,10 @@
   </head>
   {{#unless (ispage name 'tree')}}
   <body class="jp-ThemedContainer" data-notebook="{{ name }}">
-    {{#if (ispage name 'lab')}}
-    <!-- Loading indicator - only shown on lab page -->
     <div id="jupyterlite-loading-indicator">
       <div class="jupyterlite-loading-indicator-spinner"></div>
       <div class="jupyterlite-loading-indicator-text">Loading JupyterLite...</div>
     </div>
-    {{/if}}
     <noscript>
       <div style="text-align: center; padding: 20px;">
           JupyterLite requires JavaScript to be enabled in your browser.

--- a/app/index.template.html
+++ b/app/index.template.html
@@ -56,8 +56,20 @@
         transform: translate(-50%, -50%);
         text-align: center;
         z-index: 1000;
-        opacity: 1;
+        opacity: 0; /* Hidden by default */
         transition: opacity 0.5s ease-out;
+        display: none; /* Hidden by default */
+      }
+
+      #jupyterlite-loading-indicator.hidden {
+        animation: fadeOut 0.5s ease-out forwards;
+        pointer-events: none;
+      }
+
+      /* Show the indicator when needed */
+      #jupyterlite-loading-indicator:not(.hidden) {
+        opacity: 1;
+        display: block;
       }
 
       .jupyterlite-loading-indicator-spinner {
@@ -98,16 +110,11 @@
         0% { opacity: 1; }
         100% { opacity: 0; }
       }
-
-      #jupyterlite-loading-indicator.hidden {
-        animation: fadeOut 0.5s ease-out forwards;
-        pointer-events: none;
-      }
     </style>
   </head>
   {{#unless (ispage name 'tree')}}
   <body class="jp-ThemedContainer" data-notebook="{{ name }}">
-    <div id="jupyterlite-loading-indicator">
+    <div id="jupyterlite-loading-indicator" class="hidden">
       <div class="jupyterlite-loading-indicator-spinner"></div>
       <div class="jupyterlite-loading-indicator-text">Loading JupyterLite...</div>
     </div>

--- a/app/index.template.html
+++ b/app/index.template.html
@@ -33,20 +33,17 @@
       }.call(this));
     </script>
     <style>
-      /* Loading indicator styles */
       body {
         margin: 0;
         padding: 0;
         transition: background-color 0.3s ease;
       }
 
-      /* Light theme (default) */
       body {
         background-color: #fff;
         color: #000;
       }
 
-      /* Dark theme */
       body.jp-mod-dark {
         background-color: #111;
         color: #fff;
@@ -73,7 +70,6 @@
         animation: jupyter-spin 1s linear infinite;
       }
 
-      /* Dark theme indicator adjustments */
       body.jp-mod-dark .jupyterlite-loading-indicator-spinner {
         border: 6px solid rgba(255, 255, 255, 0.1);
         border-top: 6px solid #FFDC00;

--- a/app/index.template.html
+++ b/app/index.template.html
@@ -107,11 +107,13 @@
   </head>
   {{#unless (ispage name 'tree')}}
   <body class="jp-ThemedContainer" data-notebook="{{ name }}">
-    <!-- Loading indicator -->
+    {{#if (ispage name 'lab')}}
+    <!-- Loading indicator - only shown on lab page -->
     <div id="jupyterlite-loading-indicator">
       <div class="jupyterlite-loading-indicator-spinner"></div>
       <div class="jupyterlite-loading-indicator-text">Loading JupyterLite...</div>
     </div>
+    {{/if}}
     <noscript>
       <div style="text-align: center; padding: 20px;">
           JupyterLite requires JavaScript to be enabled in your browser.

--- a/app/index.template.html
+++ b/app/index.template.html
@@ -32,14 +32,95 @@
         );
       }.call(this));
     </script>
+    <style>
+      /* Loading indicator styles */
+      body {
+        margin: 0;
+        padding: 0;
+        transition: background-color 0.3s ease;
+      }
+
+      /* Light theme (default) */
+      body {
+        background-color: #fff;
+        color: #000;
+      }
+
+      /* Dark theme */
+      body.jp-mod-dark {
+        background-color: #111;
+        color: #fff;
+      }
+
+      #jupyterlite-loading-indicator {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        text-align: center;
+        z-index: 1000;
+        opacity: 1;
+        transition: opacity 0.5s ease-out;
+      }
+
+      .jupyterlite-loading-indicator-spinner {
+        width: 60px;
+        height: 60px;
+        margin: 0 auto 20px;
+        border: 6px solid rgba(0, 0, 0, 0.1);
+        border-top: 6px solid #FFDC00; /* Bright yellow color */
+        border-radius: 50%;
+        animation: jupyter-spin 1s linear infinite;
+      }
+
+      /* Dark theme indicator adjustments */
+      body.jp-mod-dark .jupyterlite-loading-indicator-spinner {
+        border: 6px solid rgba(255, 255, 255, 0.1);
+        border-top: 6px solid #FFDC00;
+      }
+
+      .jupyterlite-loading-indicator-text {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+        font-size: 16px;
+      }
+
+      /* Adjust text color based on theme */
+      body.jp-mod-light .jupyterlite-loading-indicator-text {
+        color: #000000;
+      }
+
+      body.jp-mod-dark .jupyterlite-loading-indicator-text {
+        color: #ffffff;
+      }
+
+      @keyframes jupyter-spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+
+      @keyframes fadeOut {
+        0% { opacity: 1; }
+        100% { opacity: 0; }
+      }
+
+      #jupyterlite-loading-indicator.hidden {
+        animation: fadeOut 0.5s ease-out forwards;
+        pointer-events: none;
+      }
+    </style>
   </head>
   {{#unless (ispage name 'tree')}}
-  <body class="jp-ThemedContainer" data-notebook="{{ name }}"></body>
+  <body class="jp-ThemedContainer" data-notebook="{{ name }}">
+    <!-- Loading indicator -->
+    <div id="jupyterlite-loading-indicator">
+      <div class="jupyterlite-loading-indicator-spinner"></div>
+      <div class="jupyterlite-loading-indicator-text">Loading JupyterLite...</div>
+    </div>
     <noscript>
       <div style="text-align: center; padding: 20px;">
           JupyterLite requires JavaScript to be enabled in your browser.
       </div>
-  </noscript>
+    </noscript>
   </body>
   {{/unless}}
 </html>

--- a/app/index.template.js
+++ b/app/index.template.js
@@ -181,7 +181,5 @@ export async function main() {
 
   // 4. Start the application, which will activate the other plugins
   await app.start();
-
   await app.restored;
-
 }

--- a/app/index.template.js
+++ b/app/index.template.js
@@ -30,19 +30,6 @@ async function createModule(scope, module) {
 }
 
 /**
- * Hide the loading indicator once the app is fully loaded
- */
-function hideAppLoadingIndicator() {
-  const indicator = document.getElementById('jupyterlite-loading-indicator');
-  if (indicator) {
-    indicator.classList.add('hidden');
-    indicator.addEventListener('animationend', () => {
-      indicator.remove();
-    }, { once: true });
-  }
-}
-
-/**
  * The main entry point for the application.
  */
 export async function main() {
@@ -194,9 +181,6 @@ export async function main() {
 
   // 4. Start the application, which will activate the other plugins
   await app.start();
-
-  // Hide loading indicator after the app has started
-  hideAppLoadingIndicator();
 
   await app.restored;
 

--- a/app/index.template.js
+++ b/app/index.template.js
@@ -35,10 +35,7 @@ async function createModule(scope, module) {
 function hideAppLoadingIndicator() {
   const indicator = document.getElementById('jupyterlite-loading-indicator');
   if (indicator) {
-    // Add hidden class to trigger fade-out animation
     indicator.classList.add('hidden');
-
-    // Listen for the end of the animation before removing the element
     indicator.addEventListener('animationend', () => {
       indicator.remove();
     }, { once: true });

--- a/app/index.template.js
+++ b/app/index.template.js
@@ -30,6 +30,22 @@ async function createModule(scope, module) {
 }
 
 /**
+ * Hide the loading indicator once the app is fully loaded
+ */
+function hideAppLoadingIndicator() {
+  const indicator = document.getElementById('jupyterlite-loading-indicator');
+  if (indicator) {
+    // Add hidden class to trigger fade-out animation
+    indicator.classList.add('hidden');
+
+    // Listen for the end of the animation before removing the element
+    indicator.addEventListener('animationend', () => {
+      indicator.remove();
+    }, { once: true });
+  }
+}
+
+/**
  * The main entry point for the application.
  */
 export async function main() {
@@ -181,5 +197,10 @@ export async function main() {
 
   // 4. Start the application, which will activate the other plugins
   await app.start();
+
+  // Hide loading indicator after the app has started
+  hideAppLoadingIndicator();
+
   await app.restored;
+
 }

--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -105,6 +105,11 @@
           "type": "string",
           "default": "JupyterLite Storage"
         },
+        "showLoadingIndicator": {
+          "description": "Whether to show the loading indicator during app initialization",
+          "type": "boolean",
+          "default": false
+        },
         "settingsStorageDrivers": {
           "description": "names of the localforage driver for settings, or `null` for the best available",
           "$ref": "#/definitions/localforage-driver-set"

--- a/app/lab/jupyter-lite.json
+++ b/app/lab/jupyter-lite.json
@@ -3,6 +3,7 @@
   "jupyter-config-data": {
     "appUrl": "/lab",
     "settingsUrl": "../build/schemas",
+    "showLoadingIndicator": true,
     "themesUrl": "./build/themes"
   }
 }

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -9,7 +9,7 @@ test.describe('Page Tests', () => {
 
     const context = page.context();
     const cdpSession = await context.newCDPSession(page);
-    // simulate a slow CPU to the loading of the page takes longer
+    // simulate a slow CPU so the loading of the page takes longer
     await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 6 });
   });
 

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -29,4 +29,19 @@ test.describe('Page Tests', () => {
     await page.locator('#jupyterlab-splash').waitFor({ state: 'detached' });
     await page.locator('.jp-Launcher').waitFor({ state: 'visible' });
   });
+
+  test('Dark theme', async ({ page }) => {
+    await page.goto('lab/index.html');
+    await page.locator('.jp-Launcher').waitFor({ state: 'visible' });
+
+    await page.getByRole('menuitem', { name: 'Settings' }).click();
+    await page.locator('li[data-type=submenu]', { hasText: /^Theme$/ }).click();
+    await page.getByRole('menuitem', { name: 'JupyterLab Dark', exact: true }).click();
+
+    await page.reload();
+
+    // Check if the dark theme class is applied to the body
+    await expect(page.locator('body')).toHaveClass(/jp-mod-dark/, { timeout: 30000 });
+    await expect(page.locator('body')).toHaveCSS('background-color', 'rgb(17, 17, 17)');
+  });
 });

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -31,6 +31,17 @@ test.describe('Page Tests', () => {
     await page.locator('.jp-Launcher').waitFor({ state: 'visible' });
   });
 
+  test('No Loading Indicator on REPL Page', async ({ page }) => {
+    await page.goto('repl/index.html');
+
+    const loadingIndicator = page.locator('#jupyterlite-loading-indicator');
+
+    const isIndicatorVisible = await loadingIndicator.isVisible().catch(() => false);
+    expect(isIndicatorVisible).toBeFalsy();
+
+    await expect(page.locator('.jp-CodeConsole')).toBeVisible({ timeout: 30000 });
+  });
+
   test('Dark theme', async ({ page }) => {
     await page.goto('lab/index.html');
     await page.locator('.jp-Launcher').waitFor({ state: 'visible' });

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -1,0 +1,32 @@
+// Copyright (c) JupyterLite Contributors
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('Page Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    const context = page.context();
+    const cdpSession = await context.newCDPSession(page);
+    // simulate a slow CPU to the loading of the page takes longer
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: 6 });
+  });
+
+  // Use plain Playwright for these tests since Galata waits for a JupyterLab element
+  // to be visible before it considers the page loaded.
+  test('Loading Indicator', async ({ page }) => {
+    await page.goto('lab/index.html');
+
+    const loadingIndicator = page.locator('#jupyterlite-loading-indicator');
+    await loadingIndicator.waitFor({ state: 'visible' });
+
+    expect(loadingIndicator.getByText('Loading JupyterLite...')).toBeTruthy();
+
+    await loadingIndicator.waitFor({ state: 'hidden' });
+
+    expect(await loadingIndicator.isVisible()).toBeFalsy();
+
+    // check JupyterLab loads properly
+    await page.locator('#jupyterlab-splash').waitFor({ state: 'detached' });
+    await page.locator('.jp-Launcher').waitFor({ state: 'visible' });
+  });
+});

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -4,7 +4,9 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Page Tests', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'This test only runs on Chromium');
+
     const context = page.context();
     const cdpSession = await context.newCDPSession(page);
     // simulate a slow CPU to the loading of the page takes longer

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -21,8 +21,7 @@ test.describe('Page Tests', () => {
     const loadingIndicator = page.locator('#jupyterlite-loading-indicator');
     await loadingIndicator.waitFor({ state: 'visible' });
 
-    expect(loadingIndicator.getByText('Loading JupyterLite...')).toBeTruthy();
-
+    await expect(loadingIndicator.getByText('Loading JupyterLite...')).toBeVisible();
     await loadingIndicator.waitFor({ state: 'hidden' });
 
     expect(await loadingIndicator.isVisible()).toBeFalsy();


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/619

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Show a loading indicator before the actual app starts
- [x] Check if a theme is already saved in IndexedDB to theme the indicator properly and avoid bright flashes on page refresh
- [x] New `showLoadingIndicator` option which defaults to `false`, but is enabled for the `lab` app by default
- [x] Add UI test

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Using a CPU slowdown in the dev tools to have the time to look at the loading indicator:

![image](https://github.com/user-attachments/assets/4cf27c21-727f-4fac-b355-0833cc1dfe00)



https://github.com/user-attachments/assets/a46f7434-b4d0-4a68-b71c-8227f1a74f4c



<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
