### PR TITLE
Remove triple slash references

### DIFF
--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -13,8 +13,6 @@
  * Ideally, much more of these would be taken from `@types/emscripten`.
  */
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../../node_modules/@types/emscripten/index.d.ts" preserve="true" />
 type EmscriptenFS = typeof FS;
 
 export const DIR_MODE = 16895; // 040777

--- a/packages/contents/tsconfig.json
+++ b/packages/contents/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["@types/emscripten"]
   },
   "include": ["src/**/*"],
   "references": [{ "path": "../localforage" }]

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -56,6 +56,7 @@
     "@lumino/application": "^2.4.4",
     "@lumino/coreutils": "^2.2.1",
     "@lumino/signaling": "^2.1.4",
+    "@types/emscripten": "^1.39.6",
     "mock-socket": "^9.3.1"
   },
   "devDependencies": {

--- a/packages/server/src/service-worker.ts
+++ b/packages/server/src/service-worker.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../../../node_modules/@types/serviceworker/index.d.ts" preserve="true" />
-
 /**
  * The name of the cache
  */

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["@types/emscripten", "@types/serviceworker"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4909,6 +4909,7 @@ __metadata:
     "@lumino/application": ^2.4.4
     "@lumino/coreutils": ^2.2.1
     "@lumino/signaling": ^2.1.4
+    "@types/emscripten": ^1.39.6
     "@types/jest": ^29.5.3
     "@types/serviceworker": ^0.0.56
     jest: ^29.6.2


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlite/xeus/pull/221 started failing with:
```
      ../../node_modules/@jupyterlite/contents/lib/emscripten.d.ts(1,22): error TS6053: File '/home/runner/work/xeus/xeus/node_modules/node_modules/@types/emscripten/index.d.ts' not found.
```

This is due to the wrong triple slash reference, which results in having the local path being incorrect as soon as @jupyterlite/contents is used in another project.
