### PR TITLE
Remove `registerPluginModule` methods from `SingleAppWidget`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -194,8 +194,7 @@ The following classes and interfaces have been removed:
 #### `@jupyterlite/application`
 
 The `registerPluginModule` and `registerPluginModules` methods have been removed from
-the `SingleWidgetApp` class. These methods were used to register plugins by importing
-modules dynamically.
+the `SingleWidgetApp` class.
 
 If you were creating your own `SingleWidgetApp` instance and using these methods to
 register plugins, you should now use a `PluginRegistry` instead. The `PluginRegistry` is

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -191,6 +191,21 @@ The following classes and interfaces have been removed:
 - `JupyterLiteServerPlugin`
 - `Router`
 
+#### `@jupyterlite/application`
+
+The `registerPluginModule` and `registerPluginModules` methods have been removed from
+the `SingleWidgetApp` class. These methods were used to register plugins by importing
+modules dynamically.
+
+If you were creating your own `SingleWidgetApp` instance and using these methods to
+register plugins, you should now use a `PluginRegistry` instead. The `PluginRegistry` is
+now the central mechanism for managing and resolving plugins in JupyterLab 4.4 and
+JupyterLite 0.6.0.
+
+The `PluginRegistry` provides a more centralized approach to plugin management, allowing
+you to register plugins before creating the application instance and resolve services
+through the registry.
+
 #### `@jupyterlite/kernel`
 
 The previous `Kernels` class (and its `IKernels` interface), used for managing kernels

--- a/packages/application/src/singleWidgetApp.ts
+++ b/packages/application/src/singleWidgetApp.ts
@@ -85,40 +85,6 @@ export class SingleWidgetApp extends JupyterFrontEnd<ISingleWidgetShell> {
       },
     };
   }
-
-  /**
-   * Register plugins from a plugin module.
-   *
-   * @param mod - The plugin module to register.
-   */
-  registerPluginModule(mod: SingleWidgetApp.IPluginModule): void {
-    let data = mod.default;
-    // Handle commonjs exports.
-    if (!Object.prototype.hasOwnProperty.call(mod, '__esModule')) {
-      data = mod as any;
-    }
-    if (!Array.isArray(data)) {
-      data = [data];
-    }
-    data.forEach((item) => {
-      try {
-        this.registerPlugin(item);
-      } catch (error) {
-        console.error(error);
-      }
-    });
-  }
-
-  /**
-   * Register the plugins from multiple plugin modules.
-   *
-   * @param mods - The plugin modules to register.
-   */
-  registerPluginModules(mods: SingleWidgetApp.IPluginModule[]): void {
-    mods.forEach((mod) => {
-      this.registerPluginModule(mod);
-    });
-  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlite/jupyterlite/pull/1590 and the switch to using a `PluginRegistry`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Remove `registerPluginModule` methods from `SingleAppWidget`
- [x] Mention in the migration guide

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

This is quite unlikely that some downstreams would create their `SingleAppWidget`, so we can just go ahead and remove the methods for `0.6.0` directly instead of going through a deprecation period first.
