### PR TITLE
remove top copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, JupyterLite Contributors
+Copyright (c) 2021-, JupyterLite Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 """documentation for jupyterlite"""
 
-import datetime
 import json
 import os
 import subprocess
@@ -29,7 +28,7 @@ sys.path += [str(ROOT / "py/jupyterlite/src")]
 # metadata
 author = APP_DATA["author"]
 project = author.replace("Contributors", "").strip()
-copyright = f"{datetime.datetime.now(tz=datetime.timezone.utc).year}, {author}"
+copyright = f"2021-, {author}"
 
 # The full version, including alpha/beta/rc tags
 release = APP_DATA["version"]

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -154,7 +154,7 @@ const about: JupyterFrontEndPlugin<void> = {
         );
         const copyright = (
           <span className="jp-About-copyright">
-            {trans.__('© 2021-2022 JupyterLite Contributors')}
+            {trans.__('© 2021-, JupyterLite Contributors')}
           </span>
         );
         const body = (

--- a/py/jupyterlite-core/LICENSE
+++ b/py/jupyterlite-core/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, JupyterLite Contributors
+Copyright (c) 2021-, JupyterLite Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/py/jupyterlite/LICENSE
+++ b/py/jupyterlite/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, JupyterLite Contributors
+Copyright (c) 2021-, JupyterLite Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
## References

- noted on https://github.com/jupyter/try-jupyter/issues/62#issuecomment-2936852798

## Code changes

- [x] remove all hardcoded "latest" year copyright dates
  - > if `curl` does it, can't be _entirely_ wrong: https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/
- [x] remove dynamic copyright date from `conf.py`

## User-facing changes

- visitors to JupyterLite sites (and the documentation site) will see an accurate copyright date

## Backwards-incompatible changes

- n/a