### PR TITLE
Stop execution when an error occurs on "Restart Kernel and Run All Cells"

### DIFF
--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -103,7 +103,14 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
             await kernel.handleMessage(msg);
           });
         } catch (error) {
-          // expected to throw when mutex.cancel() is called below
+          if (
+            error instanceof Error &&
+            error.message.includes('request for lock canceled')
+          ) {
+            // expected to throw when mutex.cancel() is called below
+          } else {
+            throw error;
+          }
         }
       };
 

--- a/ui-tests/contents/runall-error.ipynb
+++ b/ui-tests/contents/runall-error.ipynb
@@ -1,0 +1,95 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "name": "python",
+      "display_name": "Python (Pyodide)",
+      "language": "python"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "python",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8"
+    }
+  },
+  "nbformat_minor": 5,
+  "nbformat": 4,
+  "cells": [
+    {
+      "id": "651e71b1-c7a1-4f5e-9d2f-598cd8a09e4d",
+      "cell_type": "code",
+      "source": "foo = 1\nfoo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "9f824aa3-2ec3-4b36-ba1f-ffe51f4ae794",
+      "cell_type": "code",
+      "source": "foo = 2\nfoo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "a556841d-e9f6-4bf2-911b-d935c6b2d2f8",
+      "cell_type": "code",
+      "source": "foo = 3\nfoo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "7914e533-2849-4a7e-b8d7-60d8de37f0a8",
+      "cell_type": "code",
+      "source": "err",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "e1b4f6f8-6b2f-4b7b-8a3f-04f76fe25d06",
+      "cell_type": "code",
+      "source": "foo = 4\nfoo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "1578d032-14c2-4b13-9602-d3a8d2d11185",
+      "cell_type": "code",
+      "source": "foo = 5\nfoo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "id": "98133984-6c55-461a-a43a-a298875f4bc0",
+      "cell_type": "code",
+      "source": "foo",
+      "metadata": {
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -288,13 +288,13 @@ test.describe('Kernels', () => {
 
     // Verify that cells 4, 5, 6 have no output
     const cell4Output = await page.notebook.getCellTextOutput(4);
-    expect(cell4Output).toEqual(null);
+    expect(cell4Output).toBeNull();
 
     const cell5Output = await page.notebook.getCellTextOutput(5);
-    expect(cell5Output).toEqual(null);
+    expect(cell5Output).toBeNull();
 
     const cell6Output = await page.notebook.getCellTextOutput(6);
-    expect(cell6Output).toEqual(null);
+    expect(cell6Output).toBeNull();
 
     // Verify the kernel status shows it's idle (not busy) after the error
     await page.locator('.jp-KernelStatus-success').waitFor();

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -205,6 +205,9 @@ test.describe('Kernels', () => {
   test('Restart Kernel and Run All Cells with error stops execution', async ({
     page,
   }) => {
+    // this test can sometimes take longer to run as it uses the Pyodide kernel
+    test.setTimeout(120000);
+
     const notebook = 'runall-error.ipynb';
 
     await page.goto('lab/index.html');
@@ -298,6 +301,9 @@ test.describe('Kernels', () => {
   });
 
   test('Manual run after error works correctly', async ({ page }) => {
+    // this test can sometimes take longer to run as it uses the Pyodide kernel
+    test.setTimeout(120000);
+
     const notebook = 'runall-error.ipynb';
 
     await page.goto('lab/index.html');


### PR DESCRIPTION

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/750
Fixes https://github.com/jupyterlite/jupyterlite/issues/801

## Code changes

- [x] Cancel other cell executions on error
- [x] Add UI test

## User-facing changes

Fix the "Run All" behavior so it matches the one from JupyterLab:

https://github.com/user-attachments/assets/a1b16e60-bf0a-484d-b4be-8c0cbb36a87d

## Backwards-incompatible changes

None