### PR TITLE
Add basic interrupt functionality

### DIFF
--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -155,7 +155,7 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     execution_count: 0,
                   },
                   metadata: {
-                    casuse: 'interrupt',
+                    cause: 'interrupt',
                   },
                 }),
               );
@@ -260,7 +260,7 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
         const executeReplyMsg = msg as KernelMessage.IExecuteReplyMsg;
         if (
           executeReplyMsg.content.status === 'error' &&
-          executeReplyMsg.metadata.casuse !== 'interrupt'
+          executeReplyMsg.metadata.cause !== 'interrupt'
         ) {
           this._cancelReason.set(mutex, 'error');
           mutex.cancel();

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -115,6 +115,11 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                 cancelReason === 'interrupt-subsequent') &&
               msg.header.msg_type === 'execute_request'
             ) {
+              if (cancelReason === 'interrupt') {
+                // Change cancel reason so that only one cell includes the error.
+                // Needs to go before await for mutex.
+                this._cancelReason.set(mutex, 'interrupt-subsequent');
+              }
               await mutex.waitForUnlock();
               // Send interrupt error to all clients
               const content: KernelMessage.IReplyErrorContent = {
@@ -138,8 +143,6 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     content,
                   }),
                 );
-                // Change cancel reason so that only one cell includes the error.
-                this._cancelReason.set(mutex, 'interrupt-subsequent');
               }
               /*
               sendMessage(

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -163,7 +163,7 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                 KernelMessage.createMessage<KernelMessage.IStatusMsg>({
                   channel: 'iopub',
                   session: clientId,
-                  parentHeader: (msg as KernelMessage.IExecuteRequestMsg).header,
+                  parentHeader: msg.header,
                   msgType: 'status',
                   content: {
                     execution_state: 'idle',

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -341,6 +341,9 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
       throw Error(`Kernel ${kernelId} does not exist`);
     }
 
+    // Wait for kernel to be ready
+    await kernel.ready;
+
     // Cancel execution of following cells
     const mutex = this._mutexMap.get(kernelId);
     if (!mutex) {

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -144,7 +144,6 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                   }),
                 );
               }
-              /*
               sendMessage(
                 KernelMessage.createMessage<KernelMessage.IExecuteReplyMsg>({
                   channel: 'shell',
@@ -155,9 +154,11 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     ...content,
                     execution_count: 0,
                   },
+                  metadata: {
+                    casuse: 'interrupt',
+                  },
                 }),
               );
-              */
               sendMessage(
                 KernelMessage.createMessage<KernelMessage.IStatusMsg>({
                   channel: 'iopub',
@@ -257,7 +258,10 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
       // to match the JupyterLab behavior
       if (msg.header.msg_type === 'execute_reply') {
         const executeReplyMsg = msg as KernelMessage.IExecuteReplyMsg;
-        if (executeReplyMsg.content.status === 'error') {
+        if (
+          executeReplyMsg.content.status === 'error' &&
+          executeReplyMsg.metadata.casuse !== 'interrupt'
+        ) {
           this._cancelReason.set(mutex, 'error');
           mutex.cancel();
         }

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -131,11 +131,11 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     parent_header: msg.header,
                     header: {
                       date,
-                      msg_id: '-',
-                      msg_type: 'error',
+                      msg_id: UUID.uuid4(),
+                      msg_type: 'execute_reply',
                       session: clientId,
-                      username: 'jupyterlite',
-                      version: '5.3',
+                      username: msg.header.username,
+                      version: msg.header.version,
                     },
                     metadata: {},
                   });

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -124,6 +124,12 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                 traceback: [],
               };
               for (const clientId of clients) {
+                const headerBase = {
+                  date,
+                  session: clientId,
+                  username: msg.header.username,
+                  version: msg.header.version,
+                };
                 const sendMessage = this._kernelSends.get(kernelId);
                 if (sendMessage !== undefined) {
                   sendMessage({
@@ -131,12 +137,9 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     content,
                     parent_header: msg.header,
                     header: {
-                      date,
                       msg_id: UUID.uuid4(),
                       msg_type: 'error',
-                      session: clientId,
-                      username: msg.header.username,
-                      version: msg.header.version,
+                      ...headerBase,
                     },
                     metadata: {},
                   });
@@ -145,12 +148,22 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                     content,
                     parent_header: msg.header,
                     header: {
-                      date,
                       msg_id: UUID.uuid4(),
                       msg_type: 'execute_reply',
-                      session: clientId,
-                      username: msg.header.username,
-                      version: msg.header.version,
+                      ...headerBase,
+                    },
+                    metadata: {},
+                  });
+                  sendMessage({
+                    channel: 'iopub',
+                    content: {
+                      execution_state: 'idle',
+                    },
+                    parent_header: msg.header,
+                    header: {
+                      msg_id: UUID.uuid4(),
+                      msg_type: 'status',
+                      ...headerBase,
                     },
                     metadata: {},
                   });

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -127,6 +127,20 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
                 const sendMessage = this._kernelSends.get(kernelId);
                 if (sendMessage !== undefined) {
                   sendMessage({
+                    channel: 'iopub',
+                    content,
+                    parent_header: msg.header,
+                    header: {
+                      date,
+                      msg_id: UUID.uuid4(),
+                      msg_type: 'error',
+                      session: clientId,
+                      username: msg.header.username,
+                      version: msg.header.version,
+                    },
+                    metadata: {},
+                  });
+                  sendMessage({
                     channel: msg.channel,
                     content,
                     parent_header: msg.header,

--- a/packages/kernel/src/client.ts
+++ b/packages/kernel/src/client.ts
@@ -113,6 +113,7 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
             if (cancelReason === 'interrupt') {
               // Clear cancel reason so that only one cell includes error.
               this._cancelReason.delete(mutex);
+              await mutex.waitForUnlock();
               // Send interrupt error to all clients
               const clients = this._kernelClients.get(kernelId) ?? new Set();
               const date = new Date().toISOString();

--- a/ui-tests/contents/runall-interrupt.ipynb
+++ b/ui-tests/contents/runall-interrupt.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "651e71b1-c7a1-4f5e-9d2f-598cd8a09e4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f824aa3-2ec3-4b36-ba1f-ffe51f4ae794",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(5)\n",
+    "2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a556841d-e9f6-4bf2-911b-d935c6b2d2f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(2)\n",
+    "3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7914e533-2849-4a7e-b8d7-60d8de37f0a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(2)\n",
+    "4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1b4f6f8-6b2f-4b7b-8a3f-04f76fe25d06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(2)\n",
+    "5"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "python",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/contents/runall-interrupt.ipynb
+++ b/ui-tests/contents/runall-interrupt.ipynb
@@ -8,6 +8,7 @@
    "outputs": [],
    "source": [
     "from time import sleep\n",
+    "\n",
     "1"
    ]
   },

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -354,17 +354,22 @@ test.describe('Kernels', () => {
     await page.menu.clickMenuItem('Kernel>Interrupt Kernel');
 
     // Wait for the interruption error to show up
+    const errorMessage = 'Kernel Interrupt: Interrupted';
     const interruptionError = page.locator(
       '.jp-OutputArea-output[data-mime-type="application/vnd.jupyter.stderr"]',
     );
     await interruptionError.waitFor();
 
     // Expect text explaining the error
-    expect(interruptionError).toHaveText('Kernel Interrupt: Interrupted');
+    expect(interruptionError).toHaveText(errorMessage);
 
     // Expect the second cell to have produced an output
-    const output = await page.notebook.getCellTextOutput(2);
+    const output = await page.notebook.getCellTextOutput(1);
     expect(output![0]).toBe('2');
+
+    // Expect the error to show up on the third cell
+    const error = await page.notebook.getCellTextOutput(2);
+    expect(error![0]).toBe(errorMessage);
 
     // Expect all remaining cells to have cleared execution status
     const idleCells = page.locator('.jp-InputArea-prompt >> text="[ ]:"');

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -378,7 +378,7 @@ test.describe('Kernels', () => {
     // Expect the remaining cells to not have any output
     for (const i of [3, 4, 5]) {
       const cancelledCellOutput = await page.notebook.getCellTextOutput(i);
-      expect(cancelledCellOutput![0]).toBe('');
+      expect(cancelledCellOutput).toBeNull();
     }
   });
 });

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -398,9 +398,6 @@ test.describe('Kernels', () => {
     // Interrupt the kernel before the first cell executed
     await page.menu.clickMenuItem('Kernel>Interrupt Kernel');
 
-    // Wait for the execution of the first cell to complete
-    await page.locator('.jp-InputArea-prompt >> text="[1]:"').waitFor();
-
     // Wait for the interruption error to show up
     const errorMessage = 'Kernel Interrupt: Interrupted';
     const interruptionError = page.locator(
@@ -411,9 +408,9 @@ test.describe('Kernels', () => {
     // Expect text explaining the error
     expect(interruptionError).toHaveText(errorMessage);
 
-    // Expect all remaining cells to have cleared execution status
+    // Expect all cells to have cleared execution status
     const idleCells = page.locator('.jp-InputArea-prompt >> text="[ ]:"');
-    expect(idleCells).toHaveCount(4);
+    expect(idleCells).toHaveCount(5);
   });
 });
 

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -376,7 +376,7 @@ test.describe('Kernels', () => {
     expect(idleCells).toHaveCount(3);
 
     // Expect the remaining cells to not have any output
-    for (const i of [3, 4, 5]) {
+    for (const i of [3, 4]) {
       const cancelledCellOutput = await page.notebook.getCellTextOutput(i);
       expect(cancelledCellOutput).toBeNull();
     }

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -374,6 +374,12 @@ test.describe('Kernels', () => {
     // Expect all remaining cells to have cleared execution status
     const idleCells = page.locator('.jp-InputArea-prompt >> text="[ ]:"');
     expect(idleCells).toHaveCount(3);
+
+    // Expect the remaining cells to not have any output
+    for (const i of [3, 4, 5]) {
+      const cancelledCellOutput = await page.notebook.getCellTextOutput(i);
+      expect(cancelledCellOutput![0]).toBe('');
+    }
   });
 });
 


### PR DESCRIPTION
## References

While I ultimately I would love to solve #459, I wonder if we could just cancel the execution of following cells for now?

## Code changes

Cancel execution of following cells.

It would have been cleaner if we could specify cancellation reason in `async-mutex` (https://github.com/DirtyHairy/async-mutex/issues/89)

## User-facing changes

Interruption stops execution of the cells scheduled to execute after the cell currently executing. It does not interrupt execution of the currently executing cell.

| Before | After |
|--|--|
| interrupt does nothing, all cells run | interrupt stops execution of following cells |
| ![image](https://github.com/user-attachments/assets/9cf43016-2224-40b1-b3f1-f1da0275bf60) |![image](https://github.com/user-attachments/assets/ef63db26-d92c-496c-8f22-5842728efc97) |


## Backwards-incompatible changes

None