### PR TITLE
Base64-encode images from local storage for Markdown rendering

### DIFF
--- a/packages/apputils-extension/src/index.tsx
+++ b/packages/apputils-extension/src/index.tsx
@@ -39,6 +39,8 @@ import {
 
 import { kernelStatusPlugin } from './kernelstatus';
 
+import { urlResolverPlugin } from './urlresolver';
+
 /**
  * The command IDs used by the apputils extension.
  */
@@ -249,6 +251,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   workspaces,
   kernelStatusPlugin,
   resolver,
+  urlResolverPlugin,
 ];
 
 export default plugins;

--- a/packages/apputils-extension/src/urlresolver.ts
+++ b/packages/apputils-extension/src/urlresolver.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { PathExt } from '@jupyterlab/coreutils';
+import { RenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
+import { Contents } from '@jupyterlab/services';
+
+class UrlResolver extends RenderMimeRegistry.UrlResolver {
+  constructor(options: RenderMimeRegistry.IUrlResolverOptions) {
+    super(options);
+    this._manager = options.contents;
+  }
+  private readonly _mimeTypes: Record<string, string> = {
+    svg: 'image/svg+xml',
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    bmp: 'image/bmp',
+    ico: 'image/x-icon',
+    tiff: 'image/tiff',
+  };
+
+  async resolveUrl(url: string) {
+    if (this.isLocal(url)) {
+      const cwd = encodeURI(PathExt.dirname(this.path));
+      url = PathExt.resolve(cwd, url);
+
+      const extension = url.split('.').pop()?.toLowerCase();
+      if (extension && this._mimeTypes[extension]) {
+        const reply = await this._manager.get(url);
+        const encoded = window.btoa(reply.content);
+        return `data:${this._mimeTypes[extension]};base64,${encoded}`;
+      }
+    }
+    return super.resolveUrl(url);
+  }
+  private _manager: Contents.IManager;
+}
+
+export const urlResolverPlugin: JupyterFrontEndPlugin<IUrlResolverFactory> = {
+  id: '@jupyterlite/apputils-extension:url-resolver',
+  autoStart: true,
+  description:
+    'A URL resolver which converts supported image URLs into base64 encoded data strings.',
+  provides: IUrlResolverFactory,
+  activate: (app: JupyterFrontEnd): IUrlResolverFactory => {
+    app.serviceManager.contents;
+    return {
+      createResolver: (options) => new UrlResolver(options),
+    };
+  },
+};


### PR DESCRIPTION
## References

- Fixes #1699
- Requires a new JupyterLab prerelease (I will do it early tomorrow) & update of dependencies to include https://github.com/jupyterlab/jupyterlab/pull/17784

## Code changes

- adds new `@jupyterlite/apputils-extension:url-resolver` plugin

## User-facing changes

Images uploaded to local storage render correctly in Markdown cells and files.

## Backwards-incompatible changes

None
