### PR TITLE
Fix: Drive issue when writing a previously created + deleted file

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -2,7 +2,7 @@
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
-      "https://jupyterlite-pyodide-kernel--209.org.readthedocs.build/en/209/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl",
+      "https://jupyterlite-pyodide-kernel--210.org.readthedocs.build/en/210/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl",
       "https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycanvas-0.13.2-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2",

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -2,7 +2,7 @@
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
-      "https://conda.anaconda.org/conda-forge/label/jupyterlite_pyodide_kernel_alpha/noarch/jupyterlite-pyodide-kernel-0.7.0a1-pyh648cf7c_0.conda",
+      "https://jupyterlite-pyodide-kernel--209.org.readthedocs.build/en/209/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl",
       "https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycanvas-0.13.2-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2",

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -2,7 +2,7 @@
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
-      "https://jupyterlite-pyodide-kernel--210.org.readthedocs.build/en/210/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl",
+      "https://jupyterlite-pyodide-kernel--211.org.readthedocs.build/en/211/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl",
       "https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycanvas-0.13.2-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2",

--- a/packages/contents/src/drivecontents.ts
+++ b/packages/contents/src/drivecontents.ts
@@ -207,9 +207,14 @@ export class DriveContentsProcessor implements IDriveContentsProcessor {
   }
 
   async get(request: TDriveRequest<'get'>): Promise<TDriveResponse<'get'>> {
-    const model = await this.contentsManager.get(request.path, { content: true });
+    let model: Contents.IModel;
+    try {
+      model = await this.contentsManager.get(request.path, { content: true });
+    } catch (e) {
+      return null;
+    }
 
-    let response;
+    let response = null;
 
     if (model.type !== 'directory') {
       response = {

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -171,14 +171,14 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
 
         // if writing
         const flags = stream.flags ?? stream.shared.flags;
-        const accmode = flags & 3; // mask with O_ACCMODE
-        if (
-          accmode === 1 || // O_WRONLY (write only)
-          accmode === 2 || // O_RDWR (read/write)
-          flags & 0x200 || // O_TRUNC
-          flags & 0x400 || // O_APPEND
-          flags & 0x40 // O_CREAT
-        ) {
+        let parsedFlags = typeof flags === 'string' ? parseInt(flags, 10) : flags;
+        parsedFlags &= 0x1fff;
+
+        let needsWrite = true;
+        if (parsedFlags in flagNeedsWrite) {
+          needsWrite = flagNeedsWrite[parsedFlags];
+        }
+        if (needsWrite) {
           stream.node = this.fs.node_ops.mknod(
             stream.node.parent,
             stream.node.name,

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -98,19 +98,17 @@ type TDriveResponses = {
   lookup: DriveFS.ILookup;
   mknod: null;
   getattr: IStats;
-  get:
-    | {
-        /**
-         * The returned file content
-         */
-        content: any;
+  get: {
+    /**
+     * The returned file content
+     */
+    content: any;
 
-        /**
-         * The content format
-         */
-        format: Contents.FileFormat;
-      }
-    | undefined;
+    /**
+     * The content format
+     */
+    format: Contents.FileFormat;
+  } | null;
   put: null;
 };
 
@@ -161,8 +159,38 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
 
   open(stream: IDriveStream): void {
     const path = this.fs.realPath(stream.node);
+
     if (this.fs.FS.isFile(stream.node.mode)) {
-      stream.file = this.fs.API.get(path);
+      try {
+        const file = this.fs.API.get(path);
+        stream.file = file;
+      } catch (e) {
+        // If we're opening a file for writing and the file does not exist, create it! Otherwise, throw the proper error
+        // We need to do this because the current thread is thinking a file exist (isFile returns true)
+        // whilst it was actually deleted in the main thread
+
+        // if writing
+        const flags = stream.flags ?? stream.shared.flags;
+        const accmode = flags & 3; // mask with O_ACCMODE
+        if (
+          accmode === 1 || // O_WRONLY (write only)
+          accmode === 2 || // O_RDWR (read/write)
+          flags & 0x200 || // O_TRUNC
+          flags & 0x400 || // O_APPEND
+          flags & 0x40 // O_CREAT
+        ) {
+          stream.node = this.fs.node_ops.mknod(
+            stream.node.parent,
+            stream.node.name,
+            stream.node.mode,
+            0, // dev should be 0 for regular files
+          );
+          const file = this.fs.API.get(path);
+          stream.file = file;
+        } else {
+          throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['ENOENT']);
+        }
+      }
     }
   }
 
@@ -173,7 +201,7 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
 
     const path = this.fs.realPath(stream.node);
 
-    const flags = stream.flags;
+    const flags = stream.flags ?? stream.shared.flags;
     let parsedFlags = typeof flags === 'string' ? parseInt(flags, 10) : flags;
     parsedFlags &= 0x1fff;
 
@@ -236,7 +264,7 @@ export class DriveFSEmscriptenStreamOps implements IEmscriptenStreamOps {
   llseek(stream: IDriveStream, offset: number, whence: number): number {
     let position = offset;
     if (whence === SEEK_CUR) {
-      position += stream.position;
+      position += stream.position ?? stream.shared.position;
     } else if (whence === SEEK_END) {
       if (this.fs.FS.isFile(stream.node.mode)) {
         if (stream.file !== undefined) {
@@ -294,7 +322,14 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
           const size = value;
           const path = this.fs.realPath(node);
           if (this.fs.FS.isFile(node.mode) && size >= 0) {
-            const file = this.fs.API.get(path);
+            let file;
+            try {
+              file = this.fs.API.get(path);
+            } catch (e) {
+              // TODO: Should do anything here? Should we create the file?
+              break;
+            }
+
             const oldData = file.data ? file.data : new Uint8Array();
             if (size !== oldData.length) {
               if (size < oldData.length) {

--- a/packages/contents/src/emscripten.ts
+++ b/packages/contents/src/emscripten.ts
@@ -51,8 +51,12 @@ export interface IEmscriptenFSNode {
 export interface IEmscriptenStream {
   node: IEmscriptenFSNode;
   nfd: any;
-  flags: string;
-  position: number;
+  flags?: number;
+  position?: number;
+  shared: {
+    flags: number;
+    position: number;
+  };
 }
 
 export function instanceOfStream(

--- a/ui-tests/contents/file-access-4.ipynb
+++ b/ui-tests/contents/file-access-4.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3c4d1de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = R\"\"\"\n",
+    "{\n",
+    "  \"args\": {}\n",
+    "}\n",
+    "\"\"\"\n",
+    "import json\n",
+    "\n",
+    "data = json.loads(s)\n",
+    "with open(\"data.json\", \"w\") as f:\n",
+    "    json.dump(data, f)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
 jupyterlab-language-pack-fr-FR
 jupyterlite-javascript-kernel==0.4.0a0
 jupyterlite-p5-kernel==0.1.1
-https://jupyterlite-pyodide-kernel--210.org.readthedocs.build/en/210/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl
+https://jupyterlite-pyodide-kernel--211.org.readthedocs.build/en/211/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl
 notebook==7.5.0a2
 theme-darcula==4.0.0

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
 jupyterlab-language-pack-fr-FR
 jupyterlite-javascript-kernel==0.4.0a0
 jupyterlite-p5-kernel==0.1.1
-https://jupyterlite-pyodide-kernel--209.org.readthedocs.build/en/209/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl
+https://jupyterlite-pyodide-kernel--210.org.readthedocs.build/en/210/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl
 notebook==7.5.0a2
 theme-darcula==4.0.0

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
 jupyterlab-language-pack-fr-FR
 jupyterlite-javascript-kernel==0.4.0a0
 jupyterlite-p5-kernel==0.1.1
-jupyterlite-pyodide-kernel==0.7.0a1
+https://jupyterlite-pyodide-kernel--209.org.readthedocs.build/en/209/_static/jupyterlite_pyodide_kernel-0.7.0a1-py3-none-any.whl
 notebook==7.5.0a2
 theme-darcula==4.0.0

--- a/ui-tests/test/service-worker.spec.ts
+++ b/ui-tests/test/service-worker.spec.ts
@@ -104,4 +104,20 @@ test.describe('Service Worker Tests', () => {
     await page.notebook.open(notebook);
     await page.notebook.runCellByCell();
   });
+
+  test('Recreate a file that was deleted from the UI', async ({ page }) => {
+    const notebook = 'file-access-4.ipynb';
+
+    await page.menu.clickMenuItem('Settings>Autosave Documents');
+
+    // Create the file once
+    await page.notebook.open(notebook);
+    await page.notebook.runCellByCell();
+
+    // Delete it from the UI
+    await page.filebrowser.contents.deleteFile('data.json');
+
+    // Recreate it
+    await page.notebook.runCellByCell();
+  });
 });


### PR DESCRIPTION
## References

Fixing https://github.com/jupyterlite/xeus/issues/273

The issue was that the kernel worker thinks the file still exists (it's not aware that the main thread removed the file) and it still has a in-memory `node` mentioning the existence of the removed file, so when it tries to `open` the removed file, it does it on the outdated `node`. 

The fix is about manually re-creating the file upon `open`, in case the `open` is triggered for writing.

This PR fixes also the case for reading a deleted file. This was also making the kernel crash, instead of properly reporting a FileNotFound error

https://github.com/user-attachments/assets/0da1c079-6c1f-4a91-8c9d-cffeae57dee5

