### PR TITLE
Throw EINVAL (28) in `DriveFSEmscriptenNodeOps.readlink`

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -2,7 +2,7 @@
   "LiteBuildConfig": {
     "contents": ["."],
     "federated_extensions": [
-      "https://conda.anaconda.org/conda-forge/label/jupyterlite_pyodide_kernel_alpha/noarch/jupyterlite-pyodide-kernel-0.7.0a2-pyh7ca27dd_0.conda",
+      "https://jupyterlite-pyodide-kernel--221.org.readthedocs.build/en/221/_static/jupyterlite_pyodide_kernel-0.7.0a2-py3-none-any.whl",
       "https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.43-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycanvas-0.13.2-pyhd8ed1ab_0.conda",
       "https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.3.3-pyhd8ed1ab_1.tar.bz2",

--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -425,7 +425,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
   };
 
   readlink = (node: IEmscriptenFSNode | IEmscriptenStream): string => {
-    throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EPERM']);
+    throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EINVAR']);
   };
 }
 

--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
+https://jupyterlite-pyodide-kernel--221.org.readthedocs.build/en/221/_static/jupyterlite_pyodide_kernel-0.7.0a2-py3-none-any.whl
 jupyterlab-language-pack-fr-FR
 jupyterlite-javascript-kernel==0.4.0a0
 jupyterlite-p5-kernel==0.1.1
-jupyterlite-pyodide-kernel==0.7.0a2
 notebook==7.5.0a2
 theme-darcula==4.0.0

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -263,7 +263,6 @@ test.describe('Contents Tests', () => {
     await newTab.close();
   });
 
-  /*
   test('DriveFS readlink raises error 28 (EINVAR)', async ({ page }) => {
     const notebook = 'empty.ipynb';
     await page.notebook.open(notebook);
@@ -283,7 +282,6 @@ test.describe('Contents Tests', () => {
     const output1 = await page.notebook.getCellTextOutput(1);
     expect(output1![0]).toMatch("OSError: [Errno 28] Invalid argument: '/drive'");
   });
-  */
 });
 
 test.describe('Copy shareable link', () => {

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -263,6 +263,7 @@ test.describe('Contents Tests', () => {
     await newTab.close();
   });
 
+  /*
   test('DriveFS readlink raises error 28 (EINVAR)', async ({ page }) => {
     const notebook = 'empty.ipynb';
     await page.notebook.open(notebook);
@@ -282,6 +283,7 @@ test.describe('Contents Tests', () => {
     const output1 = await page.notebook.getCellTextOutput(1);
     expect(output1![0]).toMatch("OSError: [Errno 28] Invalid argument: '/drive'");
   });
+  */
 });
 
 test.describe('Copy shareable link', () => {

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -262,6 +262,26 @@ test.describe('Contents Tests', () => {
 
     await newTab.close();
   });
+
+  test('DriveFS readlink raises error 28 (EINVAR)', async ({ page }) => {
+    const notebook = 'empty.ipynb';
+    await page.notebook.open(notebook);
+
+    // readlink call on directory in DriveFS.
+    await page.notebook.setCell(0, 'code', 'import os; os.readlink("/")');
+
+    // readlink call on directory not in DriveFS.
+    await page.notebook.addCell('code', 'os.readlink("/drive")');
+
+    await page.notebook.runCellByCell();
+
+    const output0 = await page.notebook.getCellTextOutput(0);
+    expect(output0).toBeTruthy();
+    expect(output0![0]).toMatch("OSError: [Errno 28] Invalid argument: '/'");
+
+    const output1 = await page.notebook.getCellTextOutput(1);
+    expect(output1![0]).toMatch("OSError: [Errno 28] Invalid argument: '/drive'");
+  });
 });
 
 test.describe('Copy shareable link', () => {


### PR DESCRIPTION
Throw EINVAL (28) in `DriveFSEmscriptenNodeOps.readlink` rather than EPERM (63).

## References

Fixes issue #1722.

## Code changes

Simple one-line fix.

Added test.

## User-facing changes

No user-facing changes.

## Backwards-incompatible changes

No backwards-incompatible changes.