### PR TITLE
Update to `jupyterlite-pyodide-kernel==0.7.0a3`

### DIFF
--- a/ui-tests/requirements.txt
+++ b/ui-tests/requirements.txt
@@ -1,6 +1,6 @@
-https://jupyterlite-pyodide-kernel--221.org.readthedocs.build/en/221/_static/jupyterlite_pyodide_kernel-0.7.0a2-py3-none-any.whl
 jupyterlab-language-pack-fr-FR
 jupyterlite-javascript-kernel==0.4.0a0
 jupyterlite-p5-kernel==0.1.1
+jupyterlite-pyodide-kernel==0.7.0a3
 notebook==7.5.0a3
 theme-darcula==4.0.0


### PR DESCRIPTION

## References

Update to https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.7.0a3

## Code changes

- [x] Update UI test dependency
- [ ] Update RTD dependency for the demo site

## User-facing changes

None

## Backwards-incompatible changes

None