### PR TITLE
Correct use of EINVAL

### DIFF
--- a/packages/contents/src/drivefs.ts
+++ b/packages/contents/src/drivefs.ts
@@ -425,7 +425,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
   };
 
   readlink = (node: IEmscriptenFSNode | IEmscriptenStream): string => {
-    throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EINVAR']);
+    throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EINVAL']);
   };
 }
 

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -264,6 +264,9 @@ test.describe('Contents Tests', () => {
   });
 
   test('DriveFS readlink raises error 28 (EINVAL)', async ({ page }) => {
+    // this test can sometimes take longer to run as it uses the Pyodide kernel
+    test.setTimeout(120000);
+
     const notebook = 'empty.ipynb';
     await page.notebook.open(notebook);
 

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -263,7 +263,7 @@ test.describe('Contents Tests', () => {
     await newTab.close();
   });
 
-  test('DriveFS readlink raises error 28 (EINVAR)', async ({ page }) => {
+  test('DriveFS readlink raises error 28 (EINVAL)', async ({ page }) => {
     const notebook = 'empty.ipynb';
     await page.notebook.open(notebook);
 


### PR DESCRIPTION
Correct the fix introduced in #1723, it should be `EINVAL` not `EINVAR`.