### PR TITLE
Implement ContentProviderRegistry interface

### DIFF
--- a/packages/contents/src/drive.ts
+++ b/packages/contents/src/drive.ts
@@ -43,7 +43,7 @@ const decoder = new TextDecoder('utf-8');
 /**
  * A custom drive to store files in the browser storage.
  */
-export class BrowserStorageDrive implements IDrive {
+export class BrowserStorageDrive implements Contents.IDrive {
   /**
    * Construct a new localForage-powered contents provider
    */


### PR DESCRIPTION
## References

This new experimental `ContentProviderRegistry` is required by jupyter-collaboration.

See more context in https://github.com/geojupyter/jupytergis/pull/848

Waiting for [the upstream change to export the `ContentProviderRegistry` class](https://github.com/jupyterlab/jupyterlab/pull/17940) before making the PR ready for review

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
