### PR TITLE
Use Node.js 24 / npm 11 to publish releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,6 +20,8 @@ jobs:
       id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '24'
 
       - uses: actions/create-github-app-token@v2
         id: app-token


### PR DESCRIPTION

## References

Temporary use node 24 here until the npm 11 issue in the jupyter releaser is fixed and released: https://github.com/jupyter-server/jupyter_releaser/issues/617

This will allow using the npm trusted publishers. See the following issues for more details:
- https://github.com/jupyterlab/jupyterlab/issues/17993
- https://github.com/jupyter/notebook/issues/7745

## Code changes

Update to Node 24 in the publish-release workflow.

## User-facing changes

None

## Backwards-incompatible changes

None