### PR TITLE
Add .pixi to default ignore_contents

### DIFF
--- a/py/jupyterlite-core/jupyterlite_core/config.py
+++ b/py/jupyterlite-core/jupyterlite_core/config.py
@@ -182,6 +182,7 @@ class LiteBuildConfig(LoggingConfigurable):
             r"/\.env",
             r"/\.git",
             r"/\.ipynb_checkpoints",
+            r"/\.pixi",
             r"/build/",
             r"/dist/",
             r"/envs/",


### PR DESCRIPTION
Fixes #1765

This PR adds `'/\\.pixi'` to the default `ignore_contents` list in `LiteBuildConfig` to ignore `.pixi` directories when building JupyterLite sites.

## Changes
- Added `r"/\.pixi"` pattern to the `_default_ignore_files` method in `jupyterlite_core/config.py`
- Placed it logically with other dot-prefixed directory patterns like `.git` and `.ipynb_checkpoints`

## Verification
- ✅ No linting errors
- ✅ Pattern matches existing format conventions
- ✅ Follows the same pattern as other dot-prefixed directories

This ensures that `.pixi` directories (used by the Pixi package manager) are ignored by default, consistent with other common build/development directories.