### PR TITLE
Add the download entry to the file menu

### DIFF
--- a/packages/application-extension/schema/download.json
+++ b/packages/application-extension/schema/download.json
@@ -2,6 +2,22 @@
   "title": "File Browser Download",
   "description": "File Browser Download settings.",
   "jupyter.lab.menus": {
+    "main": [
+      {
+        "id": "jp-mainmenu-file",
+        "items": [
+          { "type": "separator", "rank": 6 },
+          {
+            "command": "docmanager:download",
+            "rank": 6,
+            "args": {
+              "isMenu": true
+            }
+          },
+          { "type": "separator", "rank": 6 }
+        ]
+      }
+    ],
     "context": [
       {
         "command": "filebrowser:download",

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -354,7 +354,10 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
             }
           });
         },
-        icon: downloadIcon.bindprops({ stylesheet: 'menuItem' }),
+        icon: (args) =>
+          args['isMenu']
+            ? undefined
+            : downloadIcon.bindprops({ stylesheet: 'menuItem' }),
         label: trans.__('Download'),
       });
     }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1771


## Code changes

- [x] Add `docmanager:download` command to the file menu

## User-facing changes

<img height="500" alt="image" src="https://github.com/user-attachments/assets/024a1826-b0f0-49b5-bfff-382c53bb3bb9" />


## Backwards-incompatible changes

None