### PR TITLE
Document usage of `pyodide-http` with xeus-python

### DIFF
--- a/docs/howto/content/python.md
+++ b/docs/howto/content/python.md
@@ -133,3 +133,15 @@ pyodide_http.patch_all()
 data = pd.read_csv("https://raw.githubusercontent.com/jupyterlite/jupyterlite/main/examples/data/iris.csv")
 data
 ```
+
+````{tip}
+If you are using the [xeus-python kernel](../xeus-python/preinstalled_packages.md), you can install `pyodide-http` using:
+
+```py
+%pip install pyodide_http
+```
+
+Or add it to the `environment.yml` file with the other dependencies.
+
+Then use it the same way as shown in the example above.
+````


### PR DESCRIPTION


## References

Fixes https://github.com/jupyterlite/xeus/issues/284

Since there is already documentation about this in the main JupyterLite documentation, you can directly consolidate the existing docs.

## Code changes

- [x] Document usage of `pyodide-http` with xeus-python

## User-facing changes

Useful to end users who need to access remote data.

<img width="1502" height="530" alt="image" src="https://github.com/user-attachments/assets/d6b60b96-33b6-4f15-b2ac-e5cb835856d1" />


## Backwards-incompatible changes

None
