### PR TITLE
Add `.pixi` to default `ignore_contents`

### DIFF
--- a/py/jupyterlite-core/jupyterlite_core/config.py
+++ b/py/jupyterlite-core/jupyterlite_core/config.py
@@ -182,6 +182,7 @@ class LiteBuildConfig(LoggingConfigurable):
             r"/\.env",
             r"/\.git",
             r"/\.ipynb_checkpoints",
+            r"/\.pixi",
             r"/build/",
             r"/dist/",
             r"/envs/",


### PR DESCRIPTION
Fixes #1765

Adds '/\.pixi' pattern to the default ignore_contents list in LiteBuildConfig to ignore .pixi directories when building JupyterLite sites.

<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

Sibling of https://github.com/jupyterlite/jupyterlite/pull/1766 since the contributor of https://github.com/jupyterlite/jupyterlite/pull/1766 probably disabled pushes their branch (https://github.com/jupyterlite/jupyterlite/pull/1766#issuecomment-3491484065).

Closes https://github.com/jupyterlite/jupyterlite/pull/1766

## Code changes

- Add `.pixi` to default `ignore_contents`

## User-facing changes



## Backwards-incompatible changes

None
