### PR TITLE
Missing dependency from @jupyterlite/apputils on @jupyterlab/pluginmanager

### DIFF
--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/coreutils": "~6.5.0",
     "@jupyterlab/nbformat": "~4.5.0",
     "@jupyterlab/observables": "~5.5.0",
+    "@jupyterlab/pluginmanager": "~4.5.0",
     "@jupyterlab/services": "~7.5.0",
     "@jupyterlab/settingregistry": "~4.5.0",
     "@jupyterlab/statedb": "~4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,6 +4800,7 @@ __metadata:
     "@jupyterlab/coreutils": ~6.5.0
     "@jupyterlab/nbformat": ~4.5.0
     "@jupyterlab/observables": ~5.5.0
+    "@jupyterlab/pluginmanager": ~4.5.0
     "@jupyterlab/services": ~7.5.0
     "@jupyterlab/settingregistry": ~4.5.0
     "@jupyterlab/statedb": ~4.5.0


### PR DESCRIPTION
## References

Discovered while updating jupyterlite-xeus with latest