### PR TITLE
Linter: Enforce type imports when applicable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,13 @@ module.exports = {
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'separate-type-imports',
+      },
+    ],
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/quotes': [
       'error',

--- a/packages/application-extension/src/clear-data-dialog.tsx
+++ b/packages/application-extension/src/clear-data-dialog.tsx
@@ -3,7 +3,7 @@
 
 import { ReactWidget } from '@jupyterlab/apputils';
 
-import { ITranslator } from '@jupyterlab/translation';
+import type { ITranslator } from '@jupyterlab/translation';
 
 import React from 'react';
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -1,20 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  ILabShell,
-  IRouter,
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-} from '@jupyterlab/application';
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { ILabShell, IRouter, JupyterFrontEnd } from '@jupyterlab/application';
 
-import {
-  Clipboard,
-  Dialog,
-  ICommandPalette,
-  SessionContext,
-  showDialog,
-} from '@jupyterlab/apputils';
+import type { SessionContext } from '@jupyterlab/apputils';
+import { Clipboard, Dialog, ICommandPalette, showDialog } from '@jupyterlab/apputils';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
@@ -30,13 +21,11 @@ import {
 } from '@jupyterlab/lsp';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import type { Contents, Setting, Workspace } from '@jupyterlab/services';
 import {
-  Contents,
   IDefaultDrive,
   ISettingManager,
   IWorkspaceManager,
-  Setting,
-  Workspace,
 } from '@jupyterlab/services';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -64,7 +53,8 @@ import '@jupyterlite/server';
 
 import { filter } from '@lumino/algorithm';
 
-import { DockPanel, Widget } from '@lumino/widgets';
+import type { DockPanel } from '@lumino/widgets';
+import { Widget } from '@lumino/widgets';
 
 import React from 'react';
 

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IRouter, Router } from '@jupyterlab/application';
+import type { IRouter } from '@jupyterlab/application';
+import { Router } from '@jupyterlab/application';
 import { Token } from '@lumino/coreutils';
 
 /**

--- a/packages/application/src/singleWidgetApp.ts
+++ b/packages/application/src/singleWidgetApp.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import { createRendermimePlugins } from '@jupyterlab/application/lib/mimerenderers';
 
@@ -9,9 +10,10 @@ import { LabStatus } from '@jupyterlab/application/lib/status';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
-import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
-import { ISingleWidgetShell, SingleWidgetShell } from './singleWidgetShell';
+import type { ISingleWidgetShell } from './singleWidgetShell';
+import { SingleWidgetShell } from './singleWidgetShell';
 
 /**
  * App is the main application class. It is instantiated once and shared.

--- a/packages/application/src/singleWidgetShell.ts
+++ b/packages/application/src/singleWidgetShell.ts
@@ -1,17 +1,19 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEnd } from '@jupyterlab/application';
+import type { JupyterFrontEnd } from '@jupyterlab/application';
 
-import { DocumentRegistry } from '@jupyterlab/docregistry';
+import type { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { find } from '@lumino/algorithm';
 
 import { Token } from '@lumino/coreutils';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
-import { FocusTracker, Panel, Widget, PanelLayout } from '@lumino/widgets';
+import type { FocusTracker } from '@lumino/widgets';
+import { Panel, Widget, PanelLayout } from '@lumino/widgets';
 
 /**
  * The single widget application shell token.

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { SingleWidgetShell, ISingleWidgetShell } from '@jupyterlite/application';
+import type { ISingleWidgetShell } from '@jupyterlite/application';
+import { SingleWidgetShell } from '@jupyterlite/application';
 
 import { Widget } from '@lumino/widgets';
 

--- a/packages/apputils-extension/src/index.tsx
+++ b/packages/apputils-extension/src/index.tsx
@@ -3,12 +3,8 @@
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-  JupyterLab,
-  IRouter,
-} from '@jupyterlab/application';
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { JupyterFrontEnd, JupyterLab, IRouter } from '@jupyterlab/application';
 
 import {
   ILicensesClient,
@@ -18,7 +14,8 @@ import {
   IWindowResolver,
 } from '@jupyterlab/apputils';
 
-import { IPluginManager, PluginListModel, Plugins } from '@jupyterlab/pluginmanager';
+import type { PluginListModel } from '@jupyterlab/pluginmanager';
+import { IPluginManager, Plugins } from '@jupyterlab/pluginmanager';
 
 import {
   ITranslator,

--- a/packages/apputils-extension/src/kernelstatus.tsx
+++ b/packages/apputils-extension/src/kernelstatus.tsx
@@ -1,17 +1,19 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import type { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 
 import { IToolbarWidgetRegistry, ReactWidget } from '@jupyterlab/apputils';
 
-import { NotebookPanel } from '@jupyterlab/notebook';
+import type { NotebookPanel } from '@jupyterlab/notebook';
 
-import { ILoggerRegistry, ILogOutputModel } from '@jupyterlab/logconsole';
+import type { ILogOutputModel } from '@jupyterlab/logconsole';
+import { ILoggerRegistry } from '@jupyterlab/logconsole';
 
-import { Kernel } from '@jupyterlab/services';
+import type { Kernel } from '@jupyterlab/services';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
 import React, { useState, useEffect } from 'react';
 

--- a/packages/apputils-extension/src/urlresolver.ts
+++ b/packages/apputils-extension/src/urlresolver.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import type { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
 import { RenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
-import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
-import { Contents } from '@jupyterlab/services';
+import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import type { Contents } from '@jupyterlab/services';
 
 class UrlResolver extends RenderMimeRegistry.UrlResolver {
   constructor(options: RenderMimeRegistry.IUrlResolverOptions) {

--- a/packages/apputils/src/licenses.ts
+++ b/packages/apputils/src/licenses.ts
@@ -5,7 +5,7 @@ import { Licenses } from '@jupyterlab/apputils';
 
 import { URLExt, PageConfig } from '@jupyterlab/coreutils';
 
-import { IFederatedExtension } from '@jupyterlite/types';
+import type { IFederatedExtension } from '@jupyterlite/types';
 
 /**
  * A license bundle is a collection of packages and their licenses.

--- a/packages/apputils/src/pluginmanager.ts
+++ b/packages/apputils/src/pluginmanager.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IEntry, PluginListModel } from '@jupyterlab/pluginmanager';
+import type { IEntry } from '@jupyterlab/pluginmanager';
+import { PluginListModel } from '@jupyterlab/pluginmanager';
 
 /**
  * Custom PluginModel for use in JupyterLite

--- a/packages/apputils/src/service-worker-manager.ts
+++ b/packages/apputils/src/service-worker-manager.ts
@@ -1,18 +1,17 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { Contents } from '@jupyterlab/services';
+import type { Contents } from '@jupyterlab/services';
 
-import {
-  DriveContentsProcessor,
-  TDriveMethod,
-  TDriveRequest,
-} from '@jupyterlite/services';
+import type { TDriveMethod, TDriveRequest } from '@jupyterlite/services';
+import { DriveContentsProcessor } from '@jupyterlite/services';
 
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
-import { IServiceWorkerManager, WORKER_NAME } from './tokens';
+import type { IServiceWorkerManager } from './tokens';
+import { WORKER_NAME } from './tokens';
 
 /**
  * The service-worker broadcast channel id

--- a/packages/apputils/src/statedb.ts
+++ b/packages/apputils/src/statedb.ts
@@ -1,6 +1,6 @@
 import { PromiseDelegate } from '@lumino/coreutils';
 
-import { IDataConnector } from '@jupyterlab/statedb';
+import type { IDataConnector } from '@jupyterlab/statedb';
 
 import type localforage from 'localforage';
 

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -1,8 +1,8 @@
 import { Token } from '@lumino/coreutils';
 
-import { ISignal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
 
-import { Contents } from '@jupyterlab/services';
+import type { Contents } from '@jupyterlab/services';
 
 import SW_URL from './service-worker?text';
 

--- a/packages/apputils/src/translation.ts
+++ b/packages/apputils/src/translation.ts
@@ -3,7 +3,11 @@
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { DataConnector } from '@jupyterlab/statedb';
-import { ILanguageList, ITranslatorConnector, Language } from '@jupyterlab/translation';
+import type {
+  ILanguageList,
+  ITranslatorConnector,
+  Language,
+} from '@jupyterlab/translation';
 
 /**
  * A fake locale to retrieve all the language packs.

--- a/packages/apputils/src/workspaces.ts
+++ b/packages/apputils/src/workspaces.ts
@@ -1,4 +1,5 @@
-import { ServerConnection, Workspace } from '@jupyterlab/services';
+import type { Workspace } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 import { IndexedDBDataConnector } from './statedb';

--- a/packages/iframe-extension/src/index.ts
+++ b/packages/iframe-extension/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 

--- a/packages/localforage/src/typings.d.ts
+++ b/packages/localforage/src/typings.d.ts
@@ -1,5 +1,5 @@
 declare module 'localforage-memoryStorageDriver' {
-  import { LocalForageDriver } from 'localforage';
+  import type { LocalForageDriver } from 'localforage';
   const memoryStorageDriver: LocalForageDriver;
   export default memoryStorageDriver;
 }

--- a/packages/notebook-application-extension/src/index.ts
+++ b/packages/notebook-application-extension/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEndPlugin, JupyterFrontEnd } from '@jupyterlab/application';
+import type { JupyterFrontEndPlugin, JupyterFrontEnd } from '@jupyterlab/application';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 

--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  ILabStatus,
-  IRouter,
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-  Router,
-} from '@jupyterlab/application';
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { ILabStatus, IRouter, JupyterFrontEnd, Router } from '@jupyterlab/application';
 
 import { IThemeManager, IToolbarWidgetRegistry } from '@jupyterlab/apputils';
 
-import { CodeConsole, ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
+import type { CodeConsole, ConsolePanel } from '@jupyterlab/console';
+import { IConsoleTracker } from '@jupyterlab/console';
 
 import { ITranslator } from '@jupyterlab/translation';
 

--- a/packages/services-extension/src/configsection.ts
+++ b/packages/services-extension/src/configsection.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
+import type {
   ConfigSection,
   ConfigSectionManager,
   IConfigSection,
-  ServerConnection,
 } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 
-import { JSONObject } from '@lumino/coreutils';
+import type { JSONObject } from '@lumino/coreutils';
 
 /**
  * A class to manager config sections in the browser.

--- a/packages/services-extension/src/event.ts
+++ b/packages/services-extension/src/event.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Event, ServerConnection } from '@jupyterlab/services';
+import type { Event } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 
 import { Signal, Stream } from '@lumino/signaling';
 

--- a/packages/services-extension/src/index.ts
+++ b/packages/services-extension/src/index.ts
@@ -3,10 +3,20 @@
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
-import {
-  ConfigSection,
+import type {
   Contents,
   Event,
+  Kernel,
+  KernelSpec,
+  NbConvert,
+  ServiceManagerPlugin,
+  Session,
+  Setting,
+  User,
+  Workspace,
+} from '@jupyterlab/services';
+import {
+  ConfigSection,
   IConfigSectionManager,
   IContentsManager,
   IDefaultDrive,
@@ -19,19 +29,11 @@ import {
   ISettingManager,
   IUserManager,
   IWorkspaceManager,
-  Kernel,
   KernelManager,
-  KernelSpec,
   KernelSpecManager,
-  NbConvert,
   ServerConnection,
-  ServiceManagerPlugin,
-  Session,
   SessionManager,
-  Setting,
-  User,
   UserManager,
-  Workspace,
 } from '@jupyterlab/services';
 
 import { LiteWorkspaceManager } from '@jupyterlite/apputils';

--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -1,14 +1,16 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { Contents, Drive, ServerConnection } from '@jupyterlab/services';
+import type { Contents, Drive } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 
-import { INotebookContent } from '@jupyterlab/nbformat';
+import type { INotebookContent } from '@jupyterlab/nbformat';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
 import { FILE, MIME } from './tokens';
 

--- a/packages/services/src/contents/drivecontents.ts
+++ b/packages/services/src/contents/drivecontents.ts
@@ -1,6 +1,7 @@
 import { PathExt } from '@jupyterlab/coreutils';
-import { Contents } from '@jupyterlab/services';
-import { BLOCK_SIZE, TDriveMethod, TDriveRequest, TDriveResponse } from './drivefs';
+import type { Contents } from '@jupyterlab/services';
+import type { TDriveMethod, TDriveRequest, TDriveResponse } from './drivefs';
+import { BLOCK_SIZE } from './drivefs';
 import { DIR_MODE, FILE_MODE } from './emscripten';
 
 export interface IDriveContentsProcessor {

--- a/packages/services/src/contents/drivefs.ts
+++ b/packages/services/src/contents/drivefs.ts
@@ -6,24 +6,21 @@
 // And from https://github.com/gzuidhof/starboard-notebook
 
 // LICENSE: https://github.com/gzuidhof/starboard-notebook/blob/cd8d3fc30af4bd29cdd8f6b8c207df8138f5d5dd/LICENSE
-import { Contents } from '@jupyterlab/services';
+import type { Contents } from '@jupyterlab/services';
 
 import { UUID } from '@lumino/coreutils';
 
-import {
+import type {
   FS,
   ERRNO_CODES,
   PATH,
-  DIR_MODE,
-  SEEK_CUR,
-  SEEK_END,
   IEmscriptenStream,
-  instanceOfStream,
   IEmscriptenStreamOps,
   IEmscriptenNodeOps,
   IEmscriptenFSNode,
   IStats,
 } from './emscripten';
+import { DIR_MODE, SEEK_CUR, SEEK_END, instanceOfStream } from './emscripten';
 
 export const DRIVE_SEPARATOR = ':';
 

--- a/packages/services/src/contents/tokens.ts
+++ b/packages/services/src/contents/tokens.ts
@@ -1,4 +1,4 @@
-import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { PageConfig } from '@jupyterlab/coreutils';
 import mime from 'mime';
 

--- a/packages/services/src/kernel/base.ts
+++ b/packages/services/src/kernel/base.ts
@@ -1,8 +1,9 @@
 import { KernelMessage } from '@jupyterlab/services';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
-import { IKernel } from './tokens';
+import type { IKernel } from './tokens';
 
 /**
  * A base kernel class handling basic kernel messaging.

--- a/packages/services/src/kernel/client.ts
+++ b/packages/services/src/kernel/client.ts
@@ -1,13 +1,10 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
+import type { IObservableMap } from '@jupyterlab/observables';
+import { ObservableMap } from '@jupyterlab/observables';
 
-import {
-  KernelAPI,
-  Kernel,
-  KernelMessage,
-  ServerConnection,
-} from '@jupyterlab/services';
+import type { Kernel } from '@jupyterlab/services';
+import { KernelAPI, KernelMessage, ServerConnection } from '@jupyterlab/services';
 
 import { deserialize, serialize } from '@jupyterlab/services/lib/kernel/serialize';
 
@@ -15,13 +12,16 @@ import { supportedKernelWebSocketProtocols } from '@jupyterlab/services/lib/kern
 
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
 import { Mutex } from 'async-mutex';
 
-import { Server as WebSocketServer, Client as WebSocketClient } from 'mock-socket';
+import type { Client as WebSocketClient } from 'mock-socket';
+import { Server as WebSocketServer } from 'mock-socket';
 
-import { FALLBACK_KERNEL, IKernel, IKernelSpecs } from './tokens';
+import type { IKernel, IKernelSpecs } from './tokens';
+import { FALLBACK_KERNEL } from './tokens';
 
 /**
  * Use the default kernel wire protocol.

--- a/packages/services/src/kernel/kernelspecclient.ts
+++ b/packages/services/src/kernel/kernelspecclient.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { KernelSpec, ServerConnection } from '@jupyterlab/services';
+import type { KernelSpec } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 
-import { IKernelSpecs } from './tokens';
+import type { IKernelSpecs } from './tokens';
 
 /**
  * Placeholder for the kernel specs.

--- a/packages/services/src/kernel/kernelspecs.ts
+++ b/packages/services/src/kernel/kernelspecs.ts
@@ -1,10 +1,12 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 
-import { KernelSpec } from '@jupyterlab/services';
+import type { KernelSpec } from '@jupyterlab/services';
 
-import { ISignal, Signal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
-import { FALLBACK_KERNEL, IKernel, IKernelSpecs } from './tokens';
+import type { IKernel, IKernelSpecs } from './tokens';
+import { FALLBACK_KERNEL } from './tokens';
 
 /**
  * A class to register in-browser kernel specs.

--- a/packages/services/src/kernel/tokens.ts
+++ b/packages/services/src/kernel/tokens.ts
@@ -3,17 +3,17 @@
 
 import type { Remote } from 'comlink';
 
-import { IObservableMap } from '@jupyterlab/observables';
+import type { IObservableMap } from '@jupyterlab/observables';
 
-import { Kernel, KernelMessage, KernelSpec } from '@jupyterlab/services';
+import type { Kernel, KernelMessage, KernelSpec } from '@jupyterlab/services';
 
 import { Token } from '@lumino/coreutils';
 
-import { IObservableDisposable } from '@lumino/disposable';
+import type { IObservableDisposable } from '@lumino/disposable';
 
-import { ISignal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
 
-import { KernelSpecs } from './kernelspecs';
+import type { KernelSpecs } from './kernelspecs';
 
 /**
  * The kernel name of last resort.

--- a/packages/services/src/nbconvert/exporters.ts
+++ b/packages/services/src/nbconvert/exporters.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Contents } from '@jupyterlab/services';
+import type { Contents } from '@jupyterlab/services';
 
-import { IExporter } from './tokens';
+import type { IExporter } from './tokens';
 
 /**
  * Base class for notebook exporters.

--- a/packages/services/src/nbconvert/manager.ts
+++ b/packages/services/src/nbconvert/manager.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Contents, NbConvert, NbConvertManager } from '@jupyterlab/services';
+import type { Contents, NbConvert } from '@jupyterlab/services';
+import { NbConvertManager } from '@jupyterlab/services';
 
-import { IExporter, INbConvertExporters } from './tokens';
+import type { IExporter, INbConvertExporters } from './tokens';
 
 /**
  * Options for creating a LiteNbConvertManager.

--- a/packages/services/src/nbconvert/tokens.ts
+++ b/packages/services/src/nbconvert/tokens.ts
@@ -3,7 +3,7 @@
 
 import { Token } from '@lumino/coreutils';
 
-import { Contents } from '@jupyterlab/services';
+import type { Contents } from '@jupyterlab/services';
 
 /**
  * The token for the exporter registry.

--- a/packages/services/src/session/client.ts
+++ b/packages/services/src/session/client.ts
@@ -1,14 +1,15 @@
-import { ServerConnection, Session } from '@jupyterlab/services';
+import type { Session } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
-import { LiteKernelClient } from '../kernel';
+import type { LiteKernelClient } from '../kernel';
 
 import { ArrayExt } from '@lumino/algorithm';
 
 import { UUID } from '@lumino/coreutils';
 
-import { ISessionAPIClient } from '@jupyterlab/services/lib/session/session';
+import type { ISessionAPIClient } from '@jupyterlab/services/lib/session/session';
 
 type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;

--- a/packages/services/src/settings/settings.ts
+++ b/packages/services/src/settings/settings.ts
@@ -1,8 +1,9 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { ServerConnection, Setting, SettingManager } from '@jupyterlab/services';
+import type { ServerConnection, Setting } from '@jupyterlab/services';
+import { SettingManager } from '@jupyterlab/services';
 
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 

--- a/ui-tests/test/renderers.spec.ts
+++ b/ui-tests/test/renderers.spec.ts
@@ -3,7 +3,8 @@
 
 import { test } from '@jupyterlab/galata';
 
-import { ConsoleMessage, expect } from '@playwright/test';
+import type { ConsoleMessage } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { firefoxWaitForApplication } from './utils';
 

--- a/ui-tests/test/utils.ts
+++ b/ui-tests/test/utils.ts
@@ -1,4 +1,4 @@
-import { IJupyterLabPageFixture } from '@jupyterlab/galata';
+import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
 
 const dirListingItemTextSelector = (name: string) =>
   `span.jp-DirListing-itemText > span:text-is("${name}")`;


### PR DESCRIPTION
## References

This can have the byproduct of reducing worker sizes if we are lucky (if only `import type` is required, we don't pull the JS code for the imported library)