### PR TITLE
Package removal note for 0.8.0 (kernel, contents, server, settings)

### DIFF
--- a/packages/contents/src/index.ts
+++ b/packages/contents/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 /**
- * @deprecated This package is deprecated. Please import from @jupyterlite/services instead.
+ * @deprecated This package is deprecated and will be removed in 0.8.0. Please import from @jupyterlite/services instead.
  *
  * This package now acts as a shim that re-exports contents-related components from
  * @jupyterlite/services for backward compatibility.

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 /**
- * @deprecated This package is deprecated. Please import from @jupyterlite/services instead.
+ * @deprecated This package is deprecated and will be removed in 0.8.0. Please import from @jupyterlite/services instead.
  *
  * This package now acts as a shim that re-exports kernel-related components from
  * @jupyterlite/services for backward compatibility.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 /**
- * @deprecated The `@jupyterlite/server` package is deprecated.
+ * @deprecated The `@jupyterlite/server` package is deprecated and will be removed in 0.8.0.
  * Please use `@jupyterlite/apputils` instead.
  *
  * This package now re-exports from `@jupyterlite/apputils` for backward compatibility.

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 /**
- * @deprecated This package is deprecated. Please import from @jupyterlite/services instead.
+ * @deprecated This package is deprecated and will be removed in 0.8.0. Please import from @jupyterlite/services instead.
  *
  * This package now acts as a shim that re-exports settings-related components from
  * @jupyterlite/services for backward compatibility.


### PR DESCRIPTION

## References

For https://github.com/jupyterlite/jupyterlite/issues/1779

This could be released in the next 0.7.x.

## Code changes

Improve deprecation notes for packages meant to be removed.

## User-facing changes

None

## Backwards-incompatible changes

None