### PR TITLE
Implement ContentProviderRegistry

### DIFF
--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -59,6 +59,10 @@ export class BrowserStorageDrive implements Contents.IDrive {
     this.initialize().catch(console.warn);
   }
 
+  /**
+   * Content provider registry.
+   * @experimental
+   */
   readonly contentProviderRegistry: ContentProviderRegistry;
 
   /**


### PR DESCRIPTION
## References

Alternative to https://github.com/jupyterlite/jupyterlite/pull/1745 that will not require some nasty hacks to extract part of the drive implementation in some "default content provider".

Depends on https://github.com/jupyterlab/jupyterlab/pull/18169

Closes #1745