### PR TITLE
Added interrupt_mode handling to LiteKernelClient.interrupt.

### DIFF
--- a/packages/services/src/kernel/client.ts
+++ b/packages/services/src/kernel/client.ts
@@ -8,6 +8,7 @@ import { KernelAPI, KernelMessage, ServerConnection } from '@jupyterlab/services
 
 import { deserialize, serialize } from '@jupyterlab/services/lib/kernel/serialize';
 
+import type { IInterruptRequestMsg } from '@jupyterlab/services/lib/kernel/messages';
 import { supportedKernelWebSocketProtocols } from '@jupyterlab/services/lib/kernel/messages';
 
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
@@ -343,15 +344,28 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
 
     // Wait for kernel to be ready
     await kernel.ready;
+    kernel;
+    const interrupt_mode =
+      this._kernelspecs.specs?.kernelspecs[kernel.name]?.interrupt_mode ?? 'signal';
 
-    // Cancel execution of following cells
-    const mutex = this._mutexMap.get(kernelId);
-    if (!mutex) {
-      console.warn('No mutex to cancel');
-      return;
+    if (interrupt_mode === 'message') {
+      const msg = KernelMessage.createMessage<IInterruptRequestMsg>({
+        msgType: 'interrupt_request',
+        channel: 'control',
+        content: {},
+        session: '',
+      });
+      await kernel.handleMessage(msg);
+    } else {
+      // Cancel execution of following cells
+      const mutex = this._mutexMap.get(kernelId);
+      if (!mutex) {
+        console.warn('No mutex to cancel');
+        return;
+      }
+      this._cancelReason.set(mutex, 'interrupt');
+      mutex.cancel();
     }
-    this._cancelReason.set(mutex, 'interrupt');
-    mutex.cancel();
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References
- #459

Related:
- https://github.com/jupyterlab/jupyterlab/pull/18307
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
A kernel developer should now be able to specify 'interrupt_mode' as  'message' or 'signal' (default)  in the spec when they register the kernel.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

```js
    kernelspecs.register({
      spec: {
        name: config.name,
        display_name: config.display_name,
        language: config.language,
        argv: [],
        resources: {
          'logo-32x32': config.logo,
          'logo-64x64': config.logo
        },
        interrupt_mode: 'message'
      },
```

For an interrupt mode 'message' a message is sent to the kernel where the plugin is responsible for handling the interrupt.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
