### PR TITLE
Remove pin on `pytest-cov`

### DIFF
--- a/py/jupyterlite-core/pyproject.toml
+++ b/py/jupyterlite-core/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "ansi2html",
     "diffoscope; sys_platform == 'linux'",
     "pytest-console-scripts",
-    "pytest-cov",
+    "pytest-cov>=7",
     "pytest-html",
     "pytest-xdist",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ test = [
     "jupyterlab_server>=2.8.1,<3",
     "pytest>=7",
     "pytest-console-scripts>=1.4.0",
-    "pytest-cov",
+    "pytest-cov>=7",
     "pytest-html",
     "pytest-xdist",
 ]


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1732
Closes https://github.com/jupyterlite/jupyterlite/pull/1727

## Code changes

- [x] Remove the pin `pytest-cov`
- [x] Adapt config to the new version

## User-facing changes

None

## Backwards-incompatible changes

None