### PR TITLE
Drive: Match JupyterLab behavior in `rename` +  force renaming when the request comes from the kernel or terminal

### DIFF
--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -618,7 +618,7 @@ export class BrowserStorageDrive implements Contents.IDrive {
     const storage = await this.storage;
     const alreadyExists =
       (await storage.getItem(newLocalPath)) !== null ||
-      (await this._getServerContents(path)) !== null;
+      (await this._getServerContents(newLocalPath)) !== null;
 
     if (alreadyExists) {
       // Hacky but JupyterLab assumes an HTTP error

--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -616,7 +616,9 @@ export class BrowserStorageDrive implements Contents.IDrive {
     const name = PathExt.basename(newLocalPath);
 
     const storage = await this.storage;
-    const alreadyExists = (await storage.getItem(newLocalPath)) !== null;
+    const alreadyExists =
+      (await storage.getItem(newLocalPath)) !== null ||
+      (await this._getServerContents(path)) !== null;
 
     if (alreadyExists) {
       // Hacky but JupyterLab assumes an HTTP error

--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -614,13 +614,23 @@ export class BrowserStorageDrive implements Contents.IDrive {
     await this._ensureParentDirectoryExists(newLocalPath);
     const modified = new Date().toISOString();
     const name = PathExt.basename(newLocalPath);
+
+    const storage = await this.storage;
+    const alreadyExists = (await storage.getItem(newLocalPath)) !== null;
+
+    if (alreadyExists) {
+      // Hacky but JupyterLab assumes an HTTP error
+      const err = new Error(`Path ${newLocalPath} already exists.`);
+      (err as any).response = { status: 409 };
+      throw err;
+    }
+
     const newFile = {
       ...file,
       name,
       path: newLocalPath,
       last_modified: modified,
     };
-    const storage = await this.storage;
     await storage.setItem(newLocalPath, newFile);
     // remove the old file
     await storage.removeItem(path);

--- a/packages/services/src/contents/drivecontents.ts
+++ b/packages/services/src/contents/drivecontents.ts
@@ -144,7 +144,8 @@ export class DriveContentsProcessor implements IDriveContentsProcessor {
   }
 
   async rename(request: TDriveRequest<'rename'>): Promise<TDriveResponse<'rename'>> {
-    await this.contentsManager.rename(request.path, request.data.newPath);
+    // We do not call rename on the contents manager, since rename is supposed to fail if the target exists
+    await this.contentsManager.overwrite(request.path, request.data.newPath);
     return null;
   }
 

--- a/packages/services/src/contents/drivecontents.ts
+++ b/packages/services/src/contents/drivecontents.ts
@@ -144,8 +144,13 @@ export class DriveContentsProcessor implements IDriveContentsProcessor {
   }
 
   async rename(request: TDriveRequest<'rename'>): Promise<TDriveResponse<'rename'>> {
-    // We do not call rename on the contents manager, since rename is supposed to fail if the target exists
-    await this.contentsManager.overwrite(request.path, request.data.newPath);
+    if (this.contentsManager.overwrite) {
+      // We do not call rename on the contents manager, since rename is supposed to fail if the target exists
+      await this.contentsManager.overwrite(request.path, request.data.newPath);
+    } else {
+      // Fallback to using rename
+      await this.contentsManager.rename(request.path, request.data.newPath);
+    }
     return null;
   }
 

--- a/ui-tests/contents/file-rename.ipynb
+++ b/ui-tests/contents/file-rename.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a35c343-490d-49c6-961a-b47367d15024",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "source": [
+    "# All the following cells should print Ok. If they don't we have a problem.\n",
+    "import os\n",
+    "\n",
+    "print(\"Ok\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18f796e5-b5e1-4980-a2f3-03cb57be7749",
+   "metadata": {
+    "trusted": true
+   },
+   "outputs": [],
+   "source": [
+    "# Writing a simple text file\n",
+    "filename1 = \"example1.txt\"\n",
+    "filename2 = \"example2.txt\"\n",
+    "content1 = \"Hello there\"\n",
+    "content2 = \"Salut ici\"\n",
+    "\n",
+    "with open(filename1, \"w\") as fobj:\n",
+    "    fobj.write(content1)\n",
+    "with open(filename2, \"w\") as fobj:\n",
+    "    fobj.write(content2)\n",
+    "\n",
+    "# Rename is forced even if the target exists\n",
+    "os.rename(filename1, filename2)\n",
+    "\n",
+    "with open(filename2, \"r\") as fobj:\n",
+    "    content = fobj.read()\n",
+    "\n",
+    "assert content == content1\n",
+    "\n",
+    "print(\"Ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (Pyodide)",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "python",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/test/service-worker.spec.ts
+++ b/ui-tests/test/service-worker.spec.ts
@@ -138,6 +138,23 @@ test.describe('Service Worker Tests', () => {
     });
   });
 
+  test('rename on the file system', async ({ page }) => {
+    const notebook = 'file-rename.ipynb';
+
+    await page.menu.clickMenuItem('Settings>Autosave Documents');
+
+    await page.notebook.open(notebook);
+
+    await page.notebook.runCellByCell({
+      onAfterCellRun: async (cellIndex: number) => {
+        const output = await page.notebook.getCellTextOutput(cellIndex);
+
+        expect(output).toBeTruthy();
+        expect(output![0]).toContain('Ok');
+      },
+    });
+  });
+
   test('State read on the file system', async ({ page }) => {
     const notebook = 'file-attr-read.ipynb';
 


### PR DESCRIPTION
Context in https://github.com/jupyterlab/jupyterlab/pull/18681

This PR makes the drive behave like JupyterLab when trying to rename a file into a filename that already exists. Meaning `rename` can now fail. For kernels and terminals, renames should be forced (`mv` does not fail when the target exists, nor `os.rename` in Python)

https://github.com/user-attachments/assets/747f5a81-da70-4ee8-8390-82e2400f39b2



TODO in this PR:
- [x] wait for https://github.com/jupyterlab/jupyterlab/pull/18681 merged and released
- [x] then update jupyterlab version
- [x] use `overwrite` when processing emscripten drive `mv` request
- [x] `IDrive`'s rename should fail properly if the target exists, to match jupyterlab's behavior