### PR TITLE
Do not hard fail upon duplicated plugins

### DIFF
--- a/app/index.template.js
+++ b/app/index.template.js
@@ -156,7 +156,13 @@ export async function main() {
   const pluginRegistry = new PluginRegistry();
 
   // 2. Register the plugins
-  pluginRegistry.registerPlugins(pluginsToRegister);
+  for (const plugin of pluginsToRegister) {
+    try {
+      pluginRegistry.registerPlugin(plugin);
+    } catch(e) {
+      console.error(e);
+    }
+  }
 
   // 3. Get and resolve the service manager and connection status plugins
   const IServiceManager = require('@jupyterlab/services').IServiceManager;


### PR DESCRIPTION
Duplicated plugins would make the page go blank and never load.

## References

This issue was noticed in Notebook.link, where it's easy to install a package that is already provided by our custom lite build.

This was discussed in [#Ask anything > Opening a link hangs after «Finalizing setup»](https://notebook.zulipchat.com/#narrow/channel/545365-Ask-anything/topic/Opening.20a.20link.20hangs.20after.20.C2.ABFinalizing.20setup.C2.BB/with/584687689)

## Code changes

Log the error instead of showing a blank page.