### PR TITLE
Fix service worker heartbeat bind so that it is called repeatedly

### DIFF
--- a/packages/apputils/src/service-worker-manager.ts
+++ b/packages/apputils/src/service-worker-manager.ts
@@ -29,6 +29,11 @@ const VERSION = PageConfig.getOption('appVersion');
 const SW_PING_ENDPOINT = '/api/service-worker-heartbeat';
 
 /**
+ * Time in milliseconds between heartbeat pings.
+ */
+const HEARTBEAT_MS = 20000;
+
+/**
  * A class that manages the ServiceWorker registration and communication,
  * used for accessing the file system.
  */
@@ -125,7 +130,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
         console.info('Registering new JupyterLite ServiceWorker', workerUrl);
         registration = await serviceWorker.register(workerUrl);
         // eslint-disable-next-line no-console
-        console.info('JupyterLite ServiceWorker was sucessfully registered');
+        console.info('JupyterLite ServiceWorker was successfully registered');
       } catch (err: any) {
         console.warn(err);
         console.warn(
@@ -140,7 +145,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
       this._ready.reject(void 0);
     } else {
       this._ready.resolve(void 0);
-      setTimeout(this._pingServiceWorker, 20000);
+      setTimeout(this._pingServiceWorker.bind(this), HEARTBEAT_MS);
     }
   }
 
@@ -174,7 +179,7 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     const response = await fetch(SW_PING_ENDPOINT);
     const text = await response.text();
     if (text === 'ok') {
-      setTimeout(this._pingServiceWorker, 20000);
+      setTimeout(this._pingServiceWorker.bind(this), HEARTBEAT_MS);
     }
   }
 


### PR DESCRIPTION
## References

Bug found whilst investigating service worker registration (#1939). Service worker heartbeat is only ever sent once whereas is should be sent repeatedly.

## Code changes

The callback `this._pingServiceWorker` is now bound correctly using `this._pingServiceWorker.bind(this)`. Also moved the time between heartbeat pings to be specified once in new `const HEARTBEAT_MS`. These are the same fixes as in jupyterlite/cockle#316.

Also fixed a typo.

## User-facing changes

None. Those who watch the browser network tab will now see more than one heartbeat request, as 20 second intervals.

## Backwards-incompatible changes

None.