### PR TITLE
Fix getattr's size

### DIFF
--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -551,7 +551,7 @@ export class BrowserStorageDrive implements Contents.IDrive {
     } else {
       return {
         ...model,
-        size: 0,
+        size: model.size ?? 0,
         format: options?.format ?? model.format,
         content: null,
       };

--- a/ui-tests/contents/file-attr-read.ipynb
+++ b/ui-tests/contents/file-attr-read.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a35c343-490d-49c6-961a-b47367d15024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All the following cells should print Ok. If they don't we have a problem.\n",
+    "import os\n",
+    "\n",
+    "file_path = \"file-attr-read.ipynb\"\n",
+    "assert os.path.getsize(file_path) == 862\n",
+    "\n",
+    "print(\"Ok\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/test/service-worker.spec.ts
+++ b/ui-tests/test/service-worker.spec.ts
@@ -137,4 +137,19 @@ test.describe('Service Worker Tests', () => {
       },
     });
   });
+
+  test('State read on the file system', async ({ page }) => {
+    const notebook = 'file-attr-read.ipynb';
+
+    await page.notebook.open(notebook);
+
+    await page.notebook.runCellByCell({
+      onAfterCellRun: async (cellIndex: number) => {
+        const output = await page.notebook.getCellTextOutput(cellIndex);
+
+        expect(output).toBeTruthy();
+        expect(output![0]).toContain('Ok');
+      },
+    });
+  });
 });


### PR DESCRIPTION
## References

Fix #1941 `getattr` (stat) requests make use of `contentManager.get(file)`, not `contentManager.get(file, {content: true})`, because we don't need the content of the file. In that case the drive was returning `0` even though we do know the size of the file in the database.

## Code changes

Return the size