### PR TITLE
Document piplite wheel flag examples

### DIFF
--- a/docs/howto/pyodide/wheels.md
+++ b/docs/howto/pyodide/wheels.md
@@ -16,6 +16,41 @@ Extra wheels that can be installed via `piplite` in a running kernel can be adde
 the `--piplite-wheels` CLI flag or `PipliteAddon/piplite_urls` config value, or simply
 left in-place in `lite_dir/pypi`.
 
+Pass one `--piplite-wheels` flag for each wheel you want to ship. For example, to add
+a single local wheel:
+
+```bash
+jupyter lite build \
+  --piplite-wheels dist/example_package-0.1.0-py3-none-any.whl
+```
+
+To add more than one wheel, repeat the flag:
+
+```bash
+jupyter lite build \
+  --piplite-wheels dist/example_package-0.1.0-py3-none-any.whl \
+  --piplite-wheels dist/example_dependency-0.2.0-py3-none-any.whl
+```
+
+The same values can be supplied in `jupyter_lite_config.json` with
+`PipliteAddon.piplite_urls`:
+
+```json
+{
+  "PipliteAddon": {
+    "piplite_urls": [
+      "dist/example_package-0.1.0-py3-none-any.whl",
+      "dist/example_dependency-0.2.0-py3-none-any.whl"
+    ]
+  }
+}
+```
+
+`PipliteAddon.piplite_urls` expects a list of values. If a build fails with an error
+that says the trait expected a tuple but received a string, make sure each wheel path is
+provided either as a repeated `--piplite-wheels` flag or as an item in the
+`piplite_urls` list.
+
 These will be:
 
 - downloaded to the local cache


### PR DESCRIPTION
## Summary

- Add examples for passing a single wheel with `--piplite-wheels`
- Clarify that multiple wheels should be passed by repeating the flag
- Show the equivalent `PipliteAddon.piplite_urls` JSON configuration
- Add a short troubleshooting note for the string-vs-list/tuple error described in #1563

Closes #1563.

## Validation

- `git diff --check`
- Checked fenced code blocks are balanced in `docs/howto/pyodide/wheels.md`
- `python -m sphinx.cmd.build -b html docs docs/_build/html -W --keep-going` reached the changed page but did not complete in this local checkout because generated docs assets/package imports are missing (`../dist`, `../build/docs-app`, generated API docs, and `jupyterlite_core` import setup). No warning was reported for the changed page.