### PR TITLE
Replace loading indicator with JupyterLab splash-style spinner

### DIFF
--- a/app/index.template.html
+++ b/app/index.template.html
@@ -49,73 +49,175 @@
         color: #fff;
       }
 
+      /*
+       * Loading indicator that mirrors JupyterLab's splash screen visual
+       * design for a clean transition. The SVG, orbit dimensions, planet
+       * sizes, and planet colors below are adapted from:
+       * https://github.com/jupyterlab/jupyterlab/blob/main/packages/apputils-extension/style/splash.css
+       */
+
       #jupyterlite-loading-indicator {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        text-align: center;
         z-index: 1000;
-        opacity: 0; /* Hidden by default */
+        position: fixed;
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
         transition: opacity 0.5s ease-out;
-        display: none; /* Hidden by default */
+        display: none;
+        background-color: white;
+      }
+
+      body.jp-mod-dark #jupyterlite-loading-indicator {
+        background-color: #212121;
       }
 
       #jupyterlite-loading-indicator.hidden {
-        animation: fadeOut 0.5s ease-out forwards;
+        animation: jupyterlite-fade-out 0.5s ease-out forwards;
         pointer-events: none;
       }
 
-      /* Show the indicator when needed */
       #jupyterlite-loading-indicator:not(.hidden) {
         opacity: 1;
         display: block;
       }
 
-      .jupyterlite-loading-indicator-spinner {
-        width: 60px;
-        height: 60px;
-        margin: 0 auto 20px;
-        border: 6px solid rgba(0, 0, 0, 0.1);
-        border-top: 6px solid #FFDC00; /* Bright yellow color */
-        border-radius: 50%;
-        animation: jupyter-spin 1s linear infinite;
+      #jupyterlite-galaxy {
+        position: relative;
+        width: 100%;
+        height: 100%;
       }
 
-      body.jp-mod-dark .jupyterlite-loading-indicator-spinner {
-        border: 6px solid rgba(255, 255, 255, 0.1);
-        border-top: 6px solid #FFDC00;
+      #jupyterlite-main-logo {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        z-index: 1;
+      }
+
+      #jupyterlite-main-logo svg {
+        width: 100px;
+        height: auto;
+      }
+
+      .jupyterlite-moon {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        border-radius: 50%;
+      }
+
+      #jupyterlite-moon1 {
+        width: 200px;
+        height: 140px;
+        margin-top: -53px;
+        margin-left: -54px;
+        animation: jupyterlite-orbit 2s linear infinite;
+      }
+
+      #jupyterlite-moon2 {
+        width: 132px;
+        height: 180px;
+        margin-top: -66px;
+        margin-left: -85px;
+        animation: jupyterlite-orbit 2.5s linear infinite reverse;
+      }
+
+      #jupyterlite-moon3 {
+        width: 220px;
+        height: 166px;
+        margin-top: -96px;
+        margin-left: -50px;
+        animation: jupyterlite-orbit 3s linear infinite;
+      }
+
+      .jupyterlite-planet {
+        border-radius: 50%;
+      }
+
+      #jupyterlite-moon1 .jupyterlite-planet {
+        width: 12px;
+        height: 12px;
+      }
+
+      #jupyterlite-moon2 .jupyterlite-planet {
+        width: 16px;
+        height: 16px;
+        float: right;
+      }
+
+      #jupyterlite-moon3 .jupyterlite-planet {
+        width: 20px;
+        height: 20px;
+      }
+
+      /* Light theme planet colors */
+      #jupyterlite-moon1 .jupyterlite-planet {
+        background-color: #6f7070;
+      }
+
+      #jupyterlite-moon2 .jupyterlite-planet {
+        background-color: #767677;
+      }
+
+      #jupyterlite-moon3 .jupyterlite-planet {
+        background-color: #989798;
+      }
+
+      /* Dark theme planet colors */
+      body.jp-mod-dark #jupyterlite-moon1 .jupyterlite-planet,
+      body.jp-mod-dark #jupyterlite-moon2 .jupyterlite-planet,
+      body.jp-mod-dark #jupyterlite-moon3 .jupyterlite-planet {
+        background-color: white;
+      }
+
+      @keyframes jupyterlite-orbit {
+        0%   { transform: rotateZ(0deg); }
+        100% { transform: rotateZ(-720deg); }
+      }
+
+      @keyframes jupyterlite-fade-out {
+        0%   { opacity: 1; }
+        100% { opacity: 0; }
       }
 
       .jupyterlite-loading-indicator-text {
+        position: absolute;
+        bottom: 20%;
+        left: 50%;
+        transform: translateX(-50%);
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
         font-size: 16px;
-      }
-
-      /* Adjust text color based on theme */
-      body.jp-mod-light .jupyterlite-loading-indicator-text {
-        color: #000000;
+        color: #616161;
       }
 
       body.jp-mod-dark .jupyterlite-loading-indicator-text {
-        color: #ffffff;
-      }
-
-      @keyframes jupyter-spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
-      }
-
-      @keyframes fadeOut {
-        0% { opacity: 1; }
-        100% { opacity: 0; }
+        color: #bdbdbd;
       }
     </style>
   </head>
   {{#unless (ispage name 'tree')}}
   <body class="jp-ThemedContainer" data-notebook="{{ name }}">
     <div id="jupyterlite-loading-indicator" class="hidden">
-      <div class="jupyterlite-loading-indicator-spinner"></div>
+      <div id="jupyterlite-galaxy">
+        <div id="jupyterlite-main-logo">
+          <!-- Jupyter planet logo from @jupyterlab/ui-components jupyter-favicon.svg -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="152" height="165" viewBox="0 0 152 165">
+            <path fill="#F37726" class="jp-jupyter-icon-color" d="M76.021 140.163c-32.64 0-61.145-11.927-75.942-29.58 5.51 15.84 15.781 29.567 29.39 39.278a80.17 80.17 0 0 0 46.57 14.929 80.17 80.17 0 0 0 46.57-14.929c13.61-9.711 23.88-23.437 29.391-39.278-14.833 17.653-43.338 29.58-75.979 29.58m-.005-114.832c32.64 0 61.146 11.927 75.943 29.58a80.9 80.9 0 0 0-29.391-39.278A80.16 80.16 0 0 0 75.998.705a80.16 80.16 0 0 0-46.57 14.928A80.9 80.9 0 0 0 .038 54.912c14.832-17.617 43.338-29.58 75.978-29.58" />
+          </svg>
+        </div>
+        <div id="jupyterlite-moon1" class="jupyterlite-moon">
+          <div class="jupyterlite-planet"></div>
+        </div>
+        <div id="jupyterlite-moon2" class="jupyterlite-moon">
+          <div class="jupyterlite-planet"></div>
+        </div>
+        <div id="jupyterlite-moon3" class="jupyterlite-moon">
+          <div class="jupyterlite-planet"></div>
+        </div>
+      </div>
       <div class="jupyterlite-loading-indicator-text">Loading JupyterLite...</div>
     </div>
     <noscript>

--- a/ui-tests/test/page.spec.ts
+++ b/ui-tests/test/page.spec.ts
@@ -21,7 +21,7 @@ test.describe('Page Tests', () => {
     const loadingIndicator = page.locator('#jupyterlite-loading-indicator');
     await loadingIndicator.waitFor({ state: 'visible' });
 
-    await expect(loadingIndicator.getByText('Loading JupyterLite...')).toBeVisible();
+    await expect(loadingIndicator.locator('#jupyterlite-main-logo')).toBeVisible();
     await loadingIndicator.waitFor({ state: 'hidden' });
 
     expect(await loadingIndicator.isVisible()).toBeFalsy();


### PR DESCRIPTION
## Summary
- Replaces the old yellow circle spinner in the JupyterLite loading indicator with the Jupyter planet logo and orbiting moons, matching the JupyterLab splash screen design
- The SVG icon, orbit dimensions, and planet colors are adapted from the upstream JupyterLab splash so the two look identical and the transition between them is invisible
- The loading indicator now fills the full viewport (like the JupyterLab splash) and retains the "Loading JupyterLite..." label

[Screencast From 2026-05-27 16-21-21.webm](https://github.com/user-attachments/assets/1fa435b5-d512-499b-9353-56ae89a2a6ef)