### PR TITLE
Reject contents writes to missing directories

### DIFF
--- a/packages/services/src/contents/drive.ts
+++ b/packages/services/src/contents/drive.ts
@@ -356,6 +356,8 @@ export class BrowserStorageDrive implements Contents.IDrive {
     const type = options?.type ?? 'notebook';
     const created = new Date().toISOString();
 
+    await this._ensureDirectoryExists(path);
+
     let name: string | undefined = undefined;
 
     let file: IModel;
@@ -457,6 +459,7 @@ export class BrowserStorageDrive implements Contents.IDrive {
    */
   async copy(path: string, toDir: string): Promise<IModel> {
     let name = PathExt.basename(path);
+    await this._ensureDirectoryExists(toDir);
     toDir = toDir === '' ? '' : `${PathExt.removeSlash(toDir)}/`;
     // TODO: better handle naming collisions with existing files
     while (
@@ -608,6 +611,7 @@ export class BrowserStorageDrive implements Contents.IDrive {
     if (!file) {
       throw Error(`Could not find file with path ${path}`);
     }
+    await this._ensureParentDirectoryExists(newLocalPath);
     const modified = new Date().toISOString();
     const name = PathExt.basename(newLocalPath);
     const newFile = {
@@ -675,6 +679,7 @@ export class BrowserStorageDrive implements Contents.IDrive {
 
     // Otherwise fallback to our default drive implementation
     path = decodeURIComponent(path);
+    await this._ensureParentDirectoryExists(path);
 
     // process the file if coming from an upload
     const name = options.name ? options.name : PathExt.basename(path) ?? undefined;
@@ -1122,6 +1127,27 @@ export class BrowserStorageDrive implements Contents.IDrive {
     }
 
     return content;
+  }
+
+  /**
+   * Ensure that a directory path exists before creating children in it.
+   */
+  private async _ensureDirectoryExists(path: string): Promise<void> {
+    if (!path) {
+      return;
+    }
+
+    const model = await this.get(path).catch(() => null);
+    if (!model || model.type !== 'directory') {
+      throw Error(`Directory does not exist: ${path}`);
+    }
+  }
+
+  /**
+   * Ensure that the parent directory for a path exists.
+   */
+  private async _ensureParentDirectoryExists(path: string): Promise<void> {
+    await this._ensureDirectoryExists(PathExt.dirname(path));
   }
 
   /**

--- a/ui-tests/test/contents.spec.ts
+++ b/ui-tests/test/contents.spec.ts
@@ -170,6 +170,53 @@ test.describe('Contents Tests', () => {
     expect(await isDirectoryListedInBrowser({ page, name })).toBeFalsy();
   });
 
+  test('Creating a file in a missing directory should fail', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const contents = (window as any).galata.app.serviceManager.contents;
+      const missing = 'missing-directory';
+      const errors: Record<string, string> = {};
+
+      try {
+        await contents.newUntitled({
+          path: missing,
+          type: 'file',
+          ext: '.txt',
+        });
+      } catch (error) {
+        errors.newUntitled = (error as Error).message;
+      }
+
+      try {
+        await contents.save(`${missing}/file.txt`, {
+          type: 'file',
+          format: 'text',
+          content: 'hidden content',
+        });
+      } catch (error) {
+        errors.save = (error as Error).message;
+      }
+
+      const hiddenFileExists = await contents
+        .get(`${missing}/file.txt`)
+        .then(() => true)
+        .catch(() => false);
+
+      const root = await contents.get('', { content: true });
+      const missingDirectoryExists = root.content.some(
+        (item: any) => item.name === missing,
+      );
+
+      return { errors, hiddenFileExists, missingDirectoryExists };
+    });
+
+    expect(result.errors.newUntitled).toContain(
+      'Directory does not exist: missing-directory',
+    );
+    expect(result.errors.save).toContain('Directory does not exist: missing-directory');
+    expect(result.hiddenFileExists).toBe(false);
+    expect(result.missingDirectoryExists).toBe(false);
+  });
+
   test('Download a notebook', async ({ page }) => {
     const name = await page.notebook.createNew();
     if (!name) {


### PR DESCRIPTION
## References
Refs: 
https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/issues/23
https://github.com/jupyterlab/plugin-playground/issues/189#issuecomment-4313463320

## Code changes
This fixes JupyterLite content operations so files are not silently created under non-existent parent directories. newUntitled, save, copy, and rename. Now, validate that the target directory exists before writing, which prevents hidden browser-storage entries that the file browser cannot display.


## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->
