### PR TITLE
Use URL fragments for sharing the REPL state

### DIFF
--- a/packages/repl-extension/src/index.ts
+++ b/packages/repl-extension/src/index.ts
@@ -132,8 +132,16 @@ const share: JupyterFrontEndPlugin<void> = {
         }
 
         const url = new URL(window.location.href);
+        // We share the state via the URL fragment rather than the query
+        // string. Fragments are not subject to the same length limits and
+        // are not stripped by some hosting platforms, such as Read The Docs.
+        // xref https://github.com/jupyterlite/jupyterlite/issues/1983.
+        const params = Private.parseHashParams(url.hash);
         SHAREABLE_PARAMETERS.forEach((parameter) => {
+          // clear params from query string
           url.searchParams.delete(parameter);
+          // clear params from fragment
+          params.delete(parameter);
         });
 
         const config = Private.getConsoleConfig(panel);
@@ -143,43 +151,45 @@ const share: JupyterFrontEndPlugin<void> = {
         const theme = themeManager?.theme?.trim() ?? '';
 
         if (!panel.toolbar.isDisposed) {
-          url.searchParams.set('toolbar', '1');
+          params.set('toolbar', '1');
         }
 
         if (kernelName) {
-          url.searchParams.set('kernel', kernelName);
+          params.set('kernel', kernelName);
         }
 
         if (theme) {
-          url.searchParams.set('theme', theme);
+          params.set('theme', theme);
         }
 
         if (config.promptCellPosition !== DEFAULT_REPL_CONFIG.promptCellPosition) {
-          url.searchParams.set('promptCellPosition', config.promptCellPosition);
+          params.set('promptCellPosition', config.promptCellPosition);
         }
 
         if (config.clearCellsOnExecute) {
-          url.searchParams.set('clearCellsOnExecute', '1');
+          params.set('clearCellsOnExecute', '1');
         }
 
         if (!config.clearCodeContentOnExecute) {
-          url.searchParams.set('clearCodeContentOnExecute', '0');
+          params.set('clearCodeContentOnExecute', '0');
         }
 
         if (config.hideCodeInput) {
-          url.searchParams.set('hideCodeInput', '1');
+          params.set('hideCodeInput', '1');
         }
 
         if (!config.showBanner) {
-          url.searchParams.set('showBanner', '0');
+          params.set('showBanner', '0');
         }
 
         if (promptCode !== '') {
-          url.searchParams.set('execute', '0');
+          params.set('execute', '0');
           promptCode.split('\n').forEach((line) => {
-            url.searchParams.append('code', line);
+            params.append('code', line);
           });
         }
+
+        url.hash = params.toString();
 
         window.history.replaceState(
           window.history.state,
@@ -252,8 +262,7 @@ const consolePlugin: JupyterFrontEndPlugin<void> = {
     }
     const { commands, started } = app;
 
-    const search = window.location.search;
-    const urlParams = new URLSearchParams(search);
+    const urlParams = Private.getShareableParams();
     const code = urlParams.getAll('code');
     const execute = urlParams.get('execute');
     const kernel = urlParams.get('kernel') || undefined;
@@ -392,6 +401,36 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
 export default plugins;
 
 namespace Private {
+  /**
+   * Parse a URL hash fragment as query-like parameters (`#key=value&...`)
+   * @param hash The URL hash fragment to parse.
+   * @returns A URLSearchParams object representing the parsed parameters.
+   */
+  export function parseHashParams(hash: string): URLSearchParams {
+    let fragment = hash.startsWith('#') ? hash.slice(1) : hash;
+    if (fragment.startsWith('?')) {
+      fragment = fragment.slice(1);
+    }
+    return new URLSearchParams(fragment);
+  }
+
+  /**
+   * Collect the shareable parameters from the current location.
+   *
+   * Sharing stores the REPL state in the URL fragment. Embedding configures the
+   * REPL through the documented query parameters. Read the fragment when it
+   * carries any shareable parameter, and the query string otherwise.
+   *
+   * @returns A URLSearchParams object containing the shareable parameters from the URL.
+   */
+  export function getShareableParams(): URLSearchParams {
+    const hashParams = parseHashParams(window.location.hash);
+    if (SHAREABLE_PARAMETERS.some((parameter) => hashParams.has(parameter))) {
+      return hashParams;
+    }
+    return new URLSearchParams(window.location.search);
+  }
+
   export function getConsoleConfig(panel: ConsolePanel): Required<CodeConsole.IConfig> {
     // JupyterLab exposes config updates but not a public getter.
     const config = ((panel.console as any)._config ?? {}) as CodeConsole.IConfig;

--- a/ui-tests/test/repl.spec.ts
+++ b/ui-tests/test/repl.spec.ts
@@ -97,17 +97,19 @@ test.describe('Share current REPL state', () => {
     await page.getByRole('button', { name: 'Copy a shareable link' }).click();
 
     const sharedUrl = new URL(page.url());
+    expect(sharedUrl.search).toBe('');
+    const sharedParams = new URLSearchParams(sharedUrl.hash.slice(1));
 
-    expect(sharedUrl.searchParams.get('toolbar')).toBe('1');
-    expect(sharedUrl.searchParams.get('kernel')).toBe('javascript');
-    expect(sharedUrl.searchParams.get('theme')).toBe('JupyterLab Dark');
-    expect(sharedUrl.searchParams.get('promptCellPosition')).toBe('left');
-    expect(sharedUrl.searchParams.get('clearCellsOnExecute')).toBe('1');
-    expect(sharedUrl.searchParams.get('clearCodeContentOnExecute')).toBe('0');
-    expect(sharedUrl.searchParams.get('hideCodeInput')).toBe('1');
-    expect(sharedUrl.searchParams.get('showBanner')).toBe('0');
-    expect(sharedUrl.searchParams.get('execute')).toBe('0');
-    expect(sharedUrl.searchParams.getAll('code')).toEqual([
+    expect(sharedParams.get('toolbar')).toBe('1');
+    expect(sharedParams.get('kernel')).toBe('javascript');
+    expect(sharedParams.get('theme')).toBe('JupyterLab Dark');
+    expect(sharedParams.get('promptCellPosition')).toBe('left');
+    expect(sharedParams.get('clearCellsOnExecute')).toBe('1');
+    expect(sharedParams.get('clearCodeContentOnExecute')).toBe('0');
+    expect(sharedParams.get('hideCodeInput')).toBe('1');
+    expect(sharedParams.get('showBanner')).toBe('0');
+    expect(sharedParams.get('execute')).toBe('0');
+    expect(sharedParams.getAll('code')).toEqual([
       'console.log("shared")',
       'console.log("state")',
     ]);
@@ -155,16 +157,18 @@ test.describe('Share current REPL state', () => {
     await page.getByRole('button', { name: 'Copy a shareable link' }).click();
 
     const sharedUrl = new URL(page.url());
+    expect(sharedUrl.search).toBe('');
+    const sharedParams = new URLSearchParams(sharedUrl.hash.slice(1));
 
-    expect(sharedUrl.searchParams.get('toolbar')).toBe('1');
-    expect(sharedUrl.searchParams.get('kernel')).toBe('javascript');
-    expect(sharedUrl.searchParams.get('execute')).toBe('0');
-    expect(sharedUrl.searchParams.getAll('code')).toEqual(['console.log("shared")']);
-    expect(sharedUrl.searchParams.has('promptCellPosition')).toBe(false);
-    expect(sharedUrl.searchParams.has('clearCellsOnExecute')).toBe(false);
-    expect(sharedUrl.searchParams.has('clearCodeContentOnExecute')).toBe(false);
-    expect(sharedUrl.searchParams.has('hideCodeInput')).toBe(false);
-    expect(sharedUrl.searchParams.has('showBanner')).toBe(false);
+    expect(sharedParams.get('toolbar')).toBe('1');
+    expect(sharedParams.get('kernel')).toBe('javascript');
+    expect(sharedParams.get('execute')).toBe('0');
+    expect(sharedParams.getAll('code')).toEqual(['console.log("shared")']);
+    expect(sharedParams.has('promptCellPosition')).toBe(false);
+    expect(sharedParams.has('clearCellsOnExecute')).toBe(false);
+    expect(sharedParams.has('clearCodeContentOnExecute')).toBe(false);
+    expect(sharedParams.has('hideCodeInput')).toBe(false);
+    expect(sharedParams.has('showBanner')).toBe(false);
   });
 
   test('Shows a single notification when copying the link multiple times', async ({
@@ -194,6 +198,13 @@ test.describe('Share current REPL state', () => {
 
     // the link is updated with the new prompt content
     await expect(page).toHaveURL(/extra/);
+
+    // re-sharing rewrites the fragment from the current state rather than
+    // stacking onto the previous one, so the code is not duplicated
+    const sharedParams = new URLSearchParams(new URL(page.url()).hash.slice(1));
+    expect(
+      sharedParams.getAll('code').filter((line) => line.includes('extra')),
+    ).toHaveLength(1);
 
     // the notifications should not stack up
     await expect(notifications).toHaveCount(1);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Closes #1983

## Code changes

<!-- Describe the code changes and how they address the issue. -->

I modified the "Share" button in the REPL to use URL fragments instead of URL parameters for sharing its state, as a means to circumvent truncation occurring due to length limits in browsers, as mentioned in https://github.com/jupyterlab/plugin-playground/issues/157 and https://github.com/jupyterlite/jupyterlite/pull/1972#discussion_r3434201440.

cc: @jtpio @krassowski

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

There are no visual changes, but users noticing the URL closely will note that the REPL is shared via URL fragments and not URL parameters.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->

None