### PR TITLE
Fix kernel shut down

### DIFF
--- a/examples/python.ipynb
+++ b/examples/python.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Python kernel backed by Pyodide\n",
     "\n",
-    "![](https://raw.githubusercontent.com/pyodide/pyodide/master/docs/_static/img/pyodide-logo.png)"
+    "![](https://raw.githubusercontent.com/pyodide/pyodide/main/docs/_static/img/pyodide-logo-light.svg)"
    ]
   },
   {

--- a/packages/apputils-extension/src/kernelstatus.tsx
+++ b/packages/apputils-extension/src/kernelstatus.tsx
@@ -3,14 +3,13 @@
 
 import type { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 
+import type { ISessionContext } from '@jupyterlab/apputils';
 import { IToolbarWidgetRegistry, ReactWidget } from '@jupyterlab/apputils';
 
 import type { NotebookPanel } from '@jupyterlab/notebook';
 
 import type { ILogOutputModel } from '@jupyterlab/logconsole';
 import { ILoggerRegistry } from '@jupyterlab/logconsole';
-
-import type { Kernel } from '@jupyterlab/services';
 
 import type { ISignal } from '@lumino/signaling';
 import { Signal } from '@lumino/signaling';
@@ -23,34 +22,45 @@ import { ITranslator, nullTranslator } from '@jupyterlab/translation';
  */
 export class KernelStatus {
   /**
-   * Current execution status of the kernel.
+   * Current display status of the kernel.
    */
-  get status(): Kernel.Status {
+  get status(): ISessionContext.KernelDisplayStatus {
     return this._status;
   }
 
   /**
-   * Signal emitted when the kernel status changes.
+   * Whether the session currently has no kernel (e.g. after a shutdown).
+   *
+   * This is tracked separately from the status because a session reports the
+   * 'unknown' status both while a kernel is starting up (a kernel is present
+   * but has not reported its status yet) and when there is no kernel at all.
    */
-  get statusChanged(): ISignal<this, Kernel.Status> {
-    return this._statusChanged;
+  get hasNoKernel(): boolean {
+    return this._hasNoKernel;
   }
 
   /**
-   * Set the current execution status.
-   *
-   * @param status - The new status
+   * Signal emitted when the status or kernel presence changes.
    */
-  setStatus(status: Kernel.Status): void {
-    if (this._status === status) {
+  get changed(): ISignal<this, void> {
+    return this._changed;
+  }
+
+  /**
+   * Set the current display status and whether a kernel is present.
+   */
+  setStatus(status: ISessionContext.KernelDisplayStatus, hasNoKernel: boolean): void {
+    if (this._status === status && this._hasNoKernel === hasNoKernel) {
       return;
     }
     this._status = status;
-    this._statusChanged.emit(status);
+    this._hasNoKernel = hasNoKernel;
+    this._changed.emit();
   }
 
-  private _status: Kernel.Status = 'idle';
-  private _statusChanged = new Signal<this, Kernel.Status>(this);
+  private _status: ISessionContext.KernelDisplayStatus = 'unknown';
+  private _hasNoKernel = true;
+  private _changed = new Signal<this, void>(this);
 }
 
 /**
@@ -61,26 +71,28 @@ function KernelStatusComponent(props: {
   onClick?: () => void;
   translator: ITranslator;
 }): JSX.Element {
-  const [status, setStatus] = useState<Kernel.Status>(props.model.status);
+  const [, forceUpdate] = useState({});
   const trans = props.translator.load('jupyterlite');
   useEffect(() => {
-    const onChange = (_: any, newStatus: Kernel.Status) => {
-      setStatus(newStatus);
+    const onChange = () => {
+      forceUpdate({});
     };
 
-    props.model.statusChanged.connect(onChange);
+    props.model.changed.connect(onChange);
 
     return () => {
-      props.model.statusChanged.disconnect(onChange);
+      props.model.changed.disconnect(onChange);
     };
   }, [props.model]);
 
+  const status = props.model.status;
   const isError = status === 'dead';
   const isIdle = status === 'idle';
-  // 'unknown' is reported when there is no kernel (e.g. after shutting it down).
-  // It must not be treated as a busy/loading state, otherwise the spinner would
-  // keep spinning forever even though nothing is happening.
-  const isBusy = !isError && !isIdle && status !== 'unknown';
+  // Show the loading spinner while a kernel is present (or starting up) and not
+  // yet idle or dead. When there is no kernel (e.g. after a shutdown) show
+  // nothing: the display status is also 'unknown' in that case, so it cannot be
+  // distinguished by the status alone, hence relying on `hasNoKernel`.
+  const isBusy = !props.model.hasNoKernel && !isError && !isIdle;
 
   // Return the appropriate icon and text based on status
   return (
@@ -250,10 +262,21 @@ export const kernelStatusPlugin: JupyterFrontEndPlugin<void> = {
 
           const sessionContext = panel.sessionContext;
 
-          // Update status when kernel status changes
-          sessionContext.statusChanged.connect((_, status) => {
-            kernelStatus.setStatus(status as Kernel.Status);
-          });
+          // Reflect the session's display status together with whether a kernel
+          // is present. The display status is recomputed on any signal that can
+          // affect it (mirroring the execution indicator), and `hasNoKernel`
+          // tells a starting kernel (spinner) apart from no kernel (no spinner),
+          // since both report the 'unknown' status.
+          const updateStatus = () => {
+            kernelStatus.setStatus(
+              sessionContext.kernelDisplayStatus,
+              sessionContext.hasNoKernel,
+            );
+          };
+          sessionContext.statusChanged.connect(updateStatus);
+          sessionContext.connectionStatusChanged.connect(updateStatus);
+          sessionContext.kernelChanged.connect(updateStatus);
+          updateStatus();
 
           if (loggerRegistry) {
             const path = panel.context.path;
@@ -268,10 +291,10 @@ export const kernelStatusPlugin: JupyterFrontEndPlugin<void> = {
                 const level = latestMessage.level;
                 // rely on kernels properly reporting a critical state
                 if (level === 'critical') {
-                  kernelStatus.setStatus('dead');
+                  kernelStatus.setStatus('dead', sessionContext.hasNoKernel);
                 } else if (level !== 'metadata') {
                   // if new messages are logged, set the status back to busy
-                  kernelStatus.setStatus('busy');
+                  kernelStatus.setStatus('busy', sessionContext.hasNoKernel);
                 }
               }
             });

--- a/packages/apputils-extension/src/kernelstatus.tsx
+++ b/packages/apputils-extension/src/kernelstatus.tsx
@@ -86,13 +86,17 @@ function KernelStatusComponent(props: {
   }, [props.model]);
 
   const status = props.model.status;
-  const isError = status === 'dead';
-  const isIdle = status === 'idle';
+  // When there is no kernel (e.g. after a shutdown) show a neutral, muted icon
+  // rather than the spinner, the idle checkmark or the error cross. The display
+  // status is also 'unknown' in that case, so it cannot be distinguished by the
+  // status alone, hence relying on `hasNoKernel`. This takes precedence over the
+  // other states so the indicator never reserves an empty, icon-less gap.
+  const isNoKernel = props.model.hasNoKernel;
+  const isError = !isNoKernel && status === 'dead';
+  const isIdle = !isNoKernel && status === 'idle';
   // Show the loading spinner while a kernel is present (or starting up) and not
-  // yet idle or dead. When there is no kernel (e.g. after a shutdown) show
-  // nothing: the display status is also 'unknown' in that case, so it cannot be
-  // distinguished by the status alone, hence relying on `hasNoKernel`.
-  const isBusy = !props.model.hasNoKernel && !isError && !isIdle;
+  // yet idle or dead.
+  const isBusy = !isNoKernel && !isError && !isIdle;
 
   // Return the appropriate icon and text based on status
   return (
@@ -103,6 +107,18 @@ function KernelStatusComponent(props: {
       title={trans.__('Click to open kernel logs')}
     >
       <div className="jp-KernelStatus-icon-container">
+        {isNoKernel && (
+          <div className="jp-KernelStatus-none">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+                stroke="currentColor"
+                strokeWidth="2"
+              />
+            </svg>
+          </div>
+        )}
+
         {isBusy && (
           <div className="jp-KernelStatus-spinner">
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/apputils-extension/src/kernelstatus.tsx
+++ b/packages/apputils-extension/src/kernelstatus.tsx
@@ -77,7 +77,10 @@ function KernelStatusComponent(props: {
 
   const isError = status === 'dead';
   const isIdle = status === 'idle';
-  const isBusy = !isError && !isIdle;
+  // 'unknown' is reported when there is no kernel (e.g. after shutting it down).
+  // It must not be treated as a busy/loading state, otherwise the spinner would
+  // keep spinning forever even though nothing is happening.
+  const isBusy = !isError && !isIdle && status !== 'unknown';
 
   // Return the appropriate icon and text based on status
   return (

--- a/packages/apputils-extension/src/kernelstatus.tsx
+++ b/packages/apputils-extension/src/kernelstatus.tsx
@@ -6,6 +6,8 @@ import type { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/applica
 import type { ISessionContext } from '@jupyterlab/apputils';
 import { IToolbarWidgetRegistry, ReactWidget } from '@jupyterlab/apputils';
 
+import { circleEmptyIcon } from '@jupyterlab/ui-components';
+
 import type { NotebookPanel } from '@jupyterlab/notebook';
 
 import type { ILogOutputModel } from '@jupyterlab/logconsole';
@@ -109,13 +111,11 @@ function KernelStatusComponent(props: {
       <div className="jp-KernelStatus-icon-container">
         {isNoKernel && (
           <div className="jp-KernelStatus-none">
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path
-                d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
-                stroke="currentColor"
-                strokeWidth="2"
-              />
-            </svg>
+            {/* Reuse JupyterLab's empty-circle icon: it already renders a muted,
+                theme-aware ring (via its `jp-icon3` class) for this neutral,
+                inactive state. `tag={null}` returns the bare <svg>, matching the
+                structure of the sibling state icons. */}
+            <circleEmptyIcon.react tag={null} />
           </div>
         )}
 

--- a/packages/apputils-extension/style/base.css
+++ b/packages/apputils-extension/style/base.css
@@ -19,6 +19,7 @@
 .jp-KernelStatus-spinner,
 .jp-KernelStatus-success,
 .jp-KernelStatus-error,
+.jp-KernelStatus-none,
 .jp-KernelStatus svg {
   width: 16px;
   height: 16px;
@@ -56,6 +57,13 @@
 /* Error state */
 .jp-KernelStatus-error {
   color: var(--jp-error-color1);
+}
+
+/* No kernel state (e.g. after a shutdown): a neutral, muted circle that is
+   quieter than the vivid idle/error states but still clearly an intentional
+   indicator rather than an empty gap */
+.jp-KernelStatus-none {
+  color: var(--jp-ui-font-color2);
 }
 
 /* Busy state */

--- a/packages/apputils-extension/style/base.css
+++ b/packages/apputils-extension/style/base.css
@@ -59,12 +59,9 @@
   color: var(--jp-error-color1);
 }
 
-/* No kernel state (e.g. after a shutdown): a neutral, muted circle that is
-   quieter than the vivid idle/error states but still clearly an intentional
-   indicator rather than an empty gap */
-.jp-KernelStatus-none {
-  color: var(--jp-ui-font-color2);
-}
+/* No kernel state (e.g. after a shutdown) uses JupyterLab's circleEmptyIcon,
+   which is already a muted, theme-aware ring (via its `jp-icon3` class), so no
+   color override is needed here. */
 
 /* Busy state */
 .jp-KernelStatus-busy {

--- a/packages/services/src/kernel/client.ts
+++ b/packages/services/src/kernel/client.ts
@@ -335,6 +335,21 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
     try {
       kernel.dispose();
       await this.startNew({ id, name, location });
+    } catch (error) {
+      // The kernel could not be re-created, so the removal suppressed above
+      // turns out to be a real termination. Clear the flag before re-emitting
+      // the removal so consumers do not skip it as a restart. Only re-emit if
+      // the kernel is indeed gone (dispose itself may have failed instead).
+      this._restarting.delete(kernelId);
+      if (!this._kernels.has(kernelId)) {
+        this._changed.emit({
+          type: 'remove',
+          key: kernelId,
+          oldValue: kernel,
+          newValue: undefined,
+        });
+      }
+      throw error;
     } finally {
       this._restarting.delete(kernelId);
     }

--- a/packages/services/src/kernel/client.ts
+++ b/packages/services/src/kernel/client.ts
@@ -328,8 +328,25 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
       throw Error(`Kernel ${kernelId} does not exist`);
     }
     const { id, name, location } = kernel;
-    kernel.dispose();
-    await this.startNew({ id, name, location });
+    // Flag the kernel as restarting so consumers of the `changed` signal (e.g.
+    // the session client) do not treat the upcoming removal as a termination
+    // while the kernel is being disposed and re-created with the same id.
+    this._restarting.add(kernelId);
+    try {
+      kernel.dispose();
+      await this.startNew({ id, name, location });
+    } finally {
+      this._restarting.delete(kernelId);
+    }
+  }
+
+  /**
+   * Whether a kernel is currently restarting.
+   *
+   * @param id The kernel id.
+   */
+  isRestarting(id: string): boolean {
+    return this._restarting.has(id);
   }
 
   /**
@@ -423,6 +440,7 @@ export class LiteKernelClient implements Kernel.IKernelAPIClient {
   }
 
   private _kernels = new ObservableMap<IKernel>();
+  private _restarting = new Set<string>();
   private _clients = new ObservableMap<WebSocketClient>();
   private _mutexMap = new Map<string, Mutex>();
   private _kernelClients = new ObservableMap<Set<string>>();

--- a/packages/services/src/session/client.ts
+++ b/packages/services/src/session/client.ts
@@ -27,39 +27,21 @@ export class LiteSessionClient implements ISessionAPIClient {
   constructor(options: LiteSessionClient.IOptions) {
     this._kernelClient = options.kernelClient;
     this._serverSettings = options.serverSettings ?? ServerConnection.makeSettings();
-    // Listen for kernel removals
+    // Clean up sessions whose kernel went away without an explicit session
+    // shutdown (e.g. the kernel was shut down on its own or crashed). Kernel
+    // restarts are skipped: the kernel client flags them while the kernel is
+    // being re-created, so the session is kept alive.
     this._kernelClient.changed.connect((_, args) => {
-      switch (args.type) {
-        case 'remove': {
-          const kernelId = args.oldValue?.id;
-          if (!kernelId) {
-            return;
-          }
-          // find the session associated with the kernel
-          const session = this._sessions.find((s) => s.kernel?.id === kernelId);
-          if (!session) {
-            return;
-          }
-          // Track the kernel ID for restart detection
-          this._pendingRestarts.add(kernelId);
-          setTimeout(async () => {
-            // If after a short delay the kernel hasn't been re-added, it was terminated
-            if (this._pendingRestarts.has(kernelId)) {
-              this._pendingRestarts.delete(kernelId);
-              await this.shutdown(session.id);
-            }
-          }, 100);
-          break;
-        }
-        case 'add': {
-          // If this was a restart, remove it from pending
-          const kernelId = args.newValue?.id;
-          if (!kernelId) {
-            return;
-          }
-          this._pendingRestarts.delete(kernelId);
-          break;
-        }
+      if (args.type !== 'remove') {
+        return;
+      }
+      const kernelId = args.oldValue?.id;
+      if (!kernelId || this._kernelClient.isRestarting(kernelId)) {
+        return;
+      }
+      const session = this._sessions.find((s) => s.kernel?.id === kernelId);
+      if (session) {
+        ArrayExt.removeFirstOf(this._sessions, session);
       }
     });
   }
@@ -223,10 +205,13 @@ export class LiteSessionClient implements ISessionAPIClient {
       throw Error(`Session ${id} not found`);
     }
     const kernelId = session.kernel?.id;
+    // Remove the session before shutting down its kernel so the resulting
+    // kernel removal is not mistaken for an externally terminated kernel (which
+    // would otherwise trigger a second, redundant cleanup of this session).
+    ArrayExt.removeFirstOf(this._sessions, session);
     if (kernelId) {
       await this._kernelClient.shutdown(kernelId);
     }
-    ArrayExt.removeFirstOf(this._sessions, session);
   }
 
   /**
@@ -252,7 +237,6 @@ export class LiteSessionClient implements ISessionAPIClient {
   private _kernelClient: LiteKernelClient;
   private _serverSettings: ServerConnection.ISettings;
   private _sessions: Session.IModel[] = [];
-  private _pendingRestarts = new Set<string>();
 }
 
 /**

--- a/packages/services/src/session/client.ts
+++ b/packages/services/src/session/client.ts
@@ -114,12 +114,6 @@ export class LiteSessionClient implements ISessionAPIClient {
         if (newKernel) {
           patched.kernel = newKernel;
         }
-
-        // clean up the session on kernel shutdown
-        void this._handleKernelShutdown({
-          kernelId: newKernel.id,
-          sessionId: session.id,
-        });
       }
     }
 
@@ -188,9 +182,6 @@ export class LiteSessionClient implements ISessionAPIClient {
     };
     this._sessions.push(session);
 
-    // clean up the session on kernel shutdown
-    void this._handleKernelShutdown({ kernelId: id, sessionId: session.id });
-
     return session;
   }
 
@@ -219,19 +210,6 @@ export class LiteSessionClient implements ISessionAPIClient {
    */
   async shutdownAll(): Promise<void> {
     await Promise.all(this._sessions.map((s) => this.shutdown(s.id)));
-  }
-
-  /**
-   * Handle kernel shutdown
-   */
-  private async _handleKernelShutdown({
-    kernelId,
-    sessionId,
-  }: {
-    kernelId: string;
-    sessionId: string;
-  }): Promise<void> {
-    // No need to handle kernel shutdown here anymore since we're using the changed signal
   }
 
   private _kernelClient: LiteKernelClient;

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -115,6 +115,9 @@ test.describe('Kernels', () => {
     expect(
       pageErrors.filter((message) => /Session .* not found/.test(message)),
     ).toEqual([]);
+
+    // the kernel status indicator should not keep spinning once the kernel is gone
+    await expect(page.locator('.jp-KernelStatus-spinner')).toHaveCount(0);
   });
 
   test('Multiple kernel restarts', async ({ page }) => {

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -118,6 +118,13 @@ test.describe('Kernels', () => {
 
     // the kernel status indicator should not keep spinning once the kernel is gone
     await expect(page.locator('.jp-KernelStatus-spinner')).toHaveCount(0);
+
+    // instead it shows the neutral "no kernel" icon, and neither the idle
+    // checkmark nor the error cross (which would reserve a misleading state),
+    // so the indicator never leaves an empty, icon-less gap
+    await expect(page.locator('.jp-KernelStatus-none')).toBeVisible();
+    await expect(page.locator('.jp-KernelStatus-success')).toHaveCount(0);
+    await expect(page.locator('.jp-KernelStatus-error')).toHaveCount(0);
   });
 
   // regression test: the kernel status indicator must show the spinner while a

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -120,6 +120,30 @@ test.describe('Kernels', () => {
     await expect(page.locator('.jp-KernelStatus-spinner')).toHaveCount(0);
   });
 
+  // regression test: the kernel status indicator must show the spinner while a
+  // kernel is starting up, then the idle checkmark once it is ready.
+  // https://github.com/jupyterlite/jupyterlite/issues/1990
+  test('Kernel status indicator spins while a kernel is starting', async ({ page }) => {
+    // this test can sometimes take longer to run as it uses the Pyodide kernel
+    test.setTimeout(120000);
+
+    await page.goto('lab/index.html');
+
+    // open a notebook backed by the Pyodide kernel: it takes a while to start,
+    // so the status indicator shows the loading spinner while it is starting up
+    // (opening does not wait for the kernel to be ready)
+    await page.notebook.open('stdin.ipynb');
+
+    await expect(page.locator('.jp-KernelStatus-spinner')).toBeVisible({
+      timeout: 30000,
+    });
+
+    // once the kernel is ready the spinner is replaced by the idle checkmark
+    await expect(page.locator('.jp-KernelStatus-success')).toBeVisible({
+      timeout: 90000,
+    });
+  });
+
   test('Multiple kernel restarts', async ({ page }) => {
     // Common selectors
     const runningKernelsTab = page.getByTitle('Running Terminals and Kernels').first();

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -82,6 +82,41 @@ test.describe('Kernels', () => {
     expect(output![0]).toBe('4');
   });
 
+  // regression test for https://github.com/jupyterlite/jupyterlite/issues/1990
+  test('Shut Down Kernel from the menu does not raise', async ({ page }) => {
+    // this test can sometimes take longer to run as it uses the Pyodide kernel
+    test.setTimeout(120000);
+
+    // collect uncaught errors and unhandled promise rejections raised in the page
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('lab/index.html');
+    const name = await page.notebook.createNew();
+    if (!name) {
+      throw new Error('Notebook name is undefined');
+    }
+
+    // make sure the kernel is up and running before shutting it down
+    await page.notebook.setCell(0, 'code', '1 + 1');
+    await page.notebook.run();
+    expect((await page.notebook.getCellTextOutput(0))![0]).toBe('2');
+
+    // shut down the kernel via the menu command
+    await page.menu.clickMenuItem('Kernel>Shut Down Kernel');
+
+    // wait until the kernel is gone from the running sessions panel
+    await page.getByTitle('Running Terminals and Kernels').first().click();
+    await expect(page.locator('.jp-RunningSessions-item.jp-mod-kernel')).toHaveCount(0);
+
+    // give any deferred error a chance to surface before asserting
+    await page.waitForTimeout(500);
+
+    expect(
+      pageErrors.filter((message) => /Session .* not found/.test(message)),
+    ).toEqual([]);
+  });
+
   test('Multiple kernel restarts', async ({ page }) => {
     // Common selectors
     const runningKernelsTab = page.getByTitle('Running Terminals and Kernels').first();


### PR DESCRIPTION

## References

Fixes https://github.com/jupyterlite/jupyterlite/issues/1990

## Code changes

- [x] Add test
- [x] Fix shutting down kernel
- [x] Fix kernel status indicator spinning when there is no kernel

## User-facing changes

Shutting down kernel should complete.

## Backwards-incompatible changes

None