### PR TITLE
Update to pyodide-kernel 0.9.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ lint = [
 
 # An example downstream kernel
 pyodide-kernel = [
-    "jupyterlite-pyodide-kernel[lock] >=0.9.0a0; sys_platform != 'emscripten'",
+    "jupyterlite-pyodide-kernel[lock] >=0.9.0a1; sys_platform != 'emscripten'",
 ]
 
 ## Documentation build platform


### PR DESCRIPTION

## References

Mechanical bump to the new version.

## Code changes

- [x] Bump `jupyterlite-pyodide-kernel`

## User-facing changes

New Pyodide on the demo site.

## Backwards-incompatible changes

None
