### PR TITLE
Send the service worker heartbeat under the base URL

### DIFF
--- a/packages/apputils/src/service-worker-manager.ts
+++ b/packages/apputils/src/service-worker-manager.ts
@@ -25,8 +25,14 @@ const VERSION = PageConfig.getOption('appVersion');
 
 /**
  * Used to keep the service worker alive
+ *
+ * Must be under the base URL, otherwise the request falls outside of the scope of
+ * the service worker and is never intercepted by it.
  */
-const SW_PING_ENDPOINT = '/api/service-worker-heartbeat';
+const SW_PING_ENDPOINT = URLExt.join(
+  PageConfig.getBaseUrl(),
+  'api/service-worker-heartbeat',
+);
 
 /**
  * Time in milliseconds between heartbeat pings.
@@ -180,6 +186,11 @@ export class ServiceWorkerManager implements IServiceWorkerManager {
     const text = await response.text();
     if (text === 'ok') {
       setTimeout(this._pingServiceWorker.bind(this), HEARTBEAT_MS);
+    } else {
+      console.warn(
+        `JupyterLite ServiceWorker heartbeat was not answered by ${SW_PING_ENDPOINT}, ` +
+          'it may be terminated by the browser when idle',
+      );
     }
   }
 

--- a/packages/apputils/src/service-worker.ts
+++ b/packages/apputils/src/service-worker.ts
@@ -47,7 +47,7 @@ async function onFetch(event: FetchEvent): Promise<void> {
   const { request } = event;
 
   const url = new URL(event.request.url);
-  if (url.pathname === '/api/service-worker-heartbeat') {
+  if (isHeartbeat(url)) {
     event.respondWith(new Response('ok'));
     return;
   }
@@ -108,6 +108,19 @@ async function refetch(request: Request): Promise<Response> {
   const fromServer = await fetch(request);
   await updateCache(request, fromServer);
   return fromServer;
+}
+
+/**
+ * Whether a given URL is a heartbeat ping from the main thread
+ *
+ * The pathname is prefixed with the base URL, which is not known here, so only
+ * match on its suffix.
+ */
+function isHeartbeat(url: URL): boolean {
+  return (
+    url.origin === location.origin &&
+    url.pathname.endsWith('/api/service-worker-heartbeat')
+  );
 }
 
 /**

--- a/ui-tests/test/service-worker-base-url.spec.ts
+++ b/ui-tests/test/service-worker-base-url.spec.ts
@@ -1,0 +1,38 @@
+// Copyright (c) JupyterLite Contributors
+// Distributed under the terms of the Modified BSD License.
+
+import { expect, test } from '@playwright/test';
+
+/**
+ * The heartbeat keeping the service worker alive must be sent under the base URL,
+ * otherwise it falls outside of the scope of the service worker, is never
+ * intercepted by it, and the browser is free to terminate it when idle.
+ *
+ * This uses the server serving the whole `ui-tests` directory, so that the app is
+ * deployed under a base URL which is not the root of the origin, as is the case
+ * for example on GitHub Pages project sites.
+ */
+const ORIGIN = 'http://localhost:8001';
+const BASE_URL = `${ORIGIN}/ui-tests-app/`;
+
+test.use({
+  baseURL: ORIGIN,
+});
+
+test.describe('Service Worker heartbeat under a base URL', () => {
+  test('is answered by the service worker', async ({ page }) => {
+    await page.goto(`${BASE_URL}lab/index.html`);
+
+    // the heartbeat is only sent once the service worker controls the page
+    await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+
+    const response = await page.waitForResponse(
+      (response) => response.url().includes('/api/service-worker-heartbeat'),
+      // the first heartbeat is sent one interval after registration
+      { timeout: 60000 },
+    );
+
+    expect(response.url()).toEqual(`${BASE_URL}api/service-worker-heartbeat`);
+    expect(await response.text()).toEqual('ok');
+  });
+});


### PR DESCRIPTION
The heartbeat keeping the service worker alive is sent to the root-absolute path
`/api/service-worker-heartbeat`, ignoring the base URL. On any deployment that is not at the
root of its origin — a GitHub Pages project site, for example — that request falls outside of
the scope of the service worker, is never intercepted by it, and is answered by the server
with a 404. The reply is then not `ok`, so the ping is never rescheduled: the keep-alive stops
after the very first interval and the browser is free to terminate the service worker when idle.

## References

There is no existing issue for this; it was found while debugging kernels hanging at
*Connecting* on a JupyterLite deployment served from a GitHub Pages project site
(https://github.com/lfortran/lfortran/issues/12476). Happy to open a separate issue first if
you prefer that order.

Related, but deliberately not addressed here: under `jupyterlite-xeus`, a page that is not
cross-origin isolated proxies every kernel filesystem syscall through a synchronous
`XMLHttpRequest` to the service worker, so a terminated service worker is fatal to kernel
startup rather than merely slow. This PR only restores the keep-alive that is meant to prevent
that termination.

## Code changes

- `packages/apputils/src/service-worker-manager.ts`: build `SW_PING_ENDPOINT` with
  `URLExt.join(PageConfig.getBaseUrl(), 'api/service-worker-heartbeat')` so the ping stays
  within the scope of the service worker.
- `packages/apputils/src/service-worker.ts`: match the heartbeat on the suffix of the pathname
  (and on the origin), as `shouldBroadcast` already does for the drive and stdin endpoints,
  since the base URL is not known inside the worker.
- `packages/apputils/src/service-worker-manager.ts`: `console.warn` when a heartbeat goes
  unanswered, so that a future regression here fails visibly instead of silently disabling the
  keep-alive.
- `ui-tests/test/service-worker-base-url.spec.ts`: new test loading the app from the server
  that serves the whole `ui-tests` directory, where it is deployed under `/ui-tests-app/`
  rather than at the root. It waits for the service worker to control the page, catches the
  first heartbeat, and asserts both that it was sent under the base URL and that the response
  body is `ok` — only the service worker can produce `ok`, as the static server 404s that path.

Verified against a locally built site, both ways:

- without the change, the test fails with
  `Received: ".../api/service-worker-heartbeat"` against
  `Expected: ".../ui-tests-app/api/service-worker-heartbeat"`;
- with the change, it passes in ~21s (one heartbeat interval).

## User-facing changes

On deployments served from a sub-path, the service worker now keeps receiving its heartbeat
and is no longer terminated by the browser while idle. Features that depend on it — contents
synced with the kernel filesystem, and stdin for kernels using the service worker — stop
failing after the app has been idle for a while. Deployments at the root of their origin are
unaffected. No visual changes.

## Backwards-incompatible changes

None. `SW_PING_ENDPOINT` is module-private, and the service worker still answers the previous
root-absolute path where it is in scope, so an older client served by a newer service worker
keeps working.