### PR TITLE
Fix schema paths on Windows

### DIFF
--- a/app/rspack.config.js
+++ b/app/rspack.config.js
@@ -267,7 +267,7 @@ class CompileSchemasPlugin {
       });
       const all = files.map((file) => {
         const schema = fs.readJSONSync(file);
-        const pluginFile = file.replace(`${schemaDir}/`, '');
+        const pluginFile = path.relative(schemaDir, file).split(path.sep).join('/');
         const basename = path.basename(pluginFile, '.json');
         const dirname = path.dirname(pluginFile);
         const packageJsonFile = path.resolve(schemaDir, dirname, 'package.json.orig');


### PR DESCRIPTION
## References

None.

## Code changes

Use a platform-aware relative path when generating schema plugin IDs, preventing Windows absolute paths from being written to `all.json`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Settings load correctly in JupyterLite apps built on Windows.

## Backwards-incompatible changes

None.
