### PR TITLE
Fix Notebooks download for drives that give Notebooks in base64 format

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -362,8 +362,12 @@ const downloadPlugin: JupyterFrontEndPlugin<void> = {
         model.format === 'json' ||
         model.mimetype === 'text/json'
       ) {
+        let filecontent = model.content;
+        if (model.format === 'base64') {
+          filecontent = JSON.parse(atob(model.content));
+        }
         const mime = model.mimetype ?? 'text/json';
-        const content = JSON.stringify(model.content, null, 2);
+        const content = JSON.stringify(filecontent, null, 2);
         element.href = `data:${mime};charset=utf-8,${encodeURIComponent(content)}`;
       } else if (model.format === 'text' || model.mimetype === 'text/plain') {
         const mime = model.mimetype ?? 'text/plain';


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

The Notebook.link drive gives Notebooks as base64 unless it's specifically requested to provide JSON format.

This PR makes the download feature take that into `format` into account instead of assuming json format