### PR TITLE
Read a fetched file's Last-Modified as GMT, not local time

### DIFF
--- a/py/jupyterlite-core/jupyterlite_core/addons/base.py
+++ b/py/jupyterlite-core/jupyterlite_core/addons/base.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import tarfile
 import tempfile
-import time
 import zipfile
 from collections.abc import Generator
 from pathlib import Path
@@ -114,8 +113,13 @@ class BaseAddon(LoggingConfigurable):
                 with tmp_dest.open("wb") as fd:
                     shutil.copyfileobj(response, fd)
                 last_modified = response.headers.get("Last-Modified")
-                if last_modified:
-                    epoch_time = time.mktime(email.utils.parsedate(last_modified))
+                # ``Last-Modified`` carries its own time zone, so it needs the
+                # time-zone-aware pair: ``parsedate`` drops the offset and
+                # ``mktime`` would then read the result as local time. It also
+                # returns ``None`` for a header it cannot parse.
+                parsed = email.utils.parsedate_tz(last_modified) if last_modified else None
+                if parsed is not None:
+                    epoch_time = email.utils.mktime_tz(parsed)
                     os.utime(tmp_dest, (epoch_time, epoch_time))
             shutil.copy2(tmp_dest, dest)
 

--- a/py/jupyterlite-core/jupyterlite_core/tests/test_fetch.py
+++ b/py/jupyterlite-core/jupyterlite_core/tests/test_fetch.py
@@ -1,0 +1,92 @@
+"""tests for fetching remote files"""
+
+import io
+import os
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from jupyterlite_core.addons.base import BaseAddon
+from jupyterlite_core.manager import LiteManager
+
+# Wed, 01 Jan 2020 00:00:00 GMT
+A_LAST_MODIFIED = "Wed, 01 Jan 2020 00:00:00 GMT"
+A_LAST_MODIFIED_EPOCH = 1577836800
+
+# time zones east and west of UTC, so a local-time reading of a GMT header
+# lands on either side of the right answer
+SOME_TIME_ZONES = ["UTC", "America/Toronto", "Australia/Sydney"]
+
+NOT_A_DATE = "the beginning of time"
+
+
+class _FakeResponse(io.BytesIO):
+    def __init__(self, headers):
+        super().__init__(b"hello")
+        self.headers = headers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+@pytest.fixture
+def an_addon(an_empty_lite_dir):
+    return BaseAddon(manager=LiteManager(lite_dir=an_empty_lite_dir))
+
+
+def _fetch(monkeypatch, an_addon, tmp_path, headers, tz):
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req: _FakeResponse(headers))
+    monkeypatch.setenv("TZ", tz)
+    time.tzset()
+    dest = Path(tmp_path) / tz.replace("/", "_") / "a-file.tgz"
+    an_addon.fetch_one("https://example.com/a-file.tgz", dest)
+    return dest
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs POSIX tzset")
+@pytest.mark.parametrize("tz", SOME_TIME_ZONES)
+def test_fetch_one_last_modified(monkeypatch, an_addon, tmp_path, tz):
+    """``Last-Modified`` should give the same mtime whatever the machine's time zone."""
+    dest = _fetch(monkeypatch, an_addon, tmp_path, {"Last-Modified": A_LAST_MODIFIED}, tz)
+    assert dest.exists()
+    assert dest.stat().st_mtime == A_LAST_MODIFIED_EPOCH
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs POSIX tzset")
+def test_fetch_one_last_modified_with_offset(monkeypatch, an_addon, tmp_path):
+    """A header may carry an offset other than GMT."""
+    dest = _fetch(
+        monkeypatch,
+        an_addon,
+        tmp_path,
+        {"Last-Modified": "Tue, 31 Dec 2019 19:00:00 -0500"},
+        "UTC",
+    )
+    assert dest.stat().st_mtime == A_LAST_MODIFIED_EPOCH
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="needs POSIX tzset")
+@pytest.mark.parametrize("headers", [{}, {"Last-Modified": NOT_A_DATE}])
+def test_fetch_one_without_usable_last_modified(monkeypatch, an_addon, tmp_path, headers):
+    """A missing or unparsable header leaves the file alone instead of failing."""
+    before = time.time()
+    dest = _fetch(monkeypatch, an_addon, tmp_path, headers, "UTC")
+    assert dest.read_bytes() == b"hello"
+    assert dest.stat().st_mtime >= before - 60
+
+
+@pytest.fixture(autouse=True)
+def _restore_tz():
+    tz = os.environ.get("TZ")
+    yield
+    if tz is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = tz
+    if hasattr(time, "tzset"):
+        time.tzset()


### PR DESCRIPTION
## References

No existing issue — found while reading `BaseAddon`. Introduced by `7d69610`, "use `Last-Modified`
if available when fetching" (2021-11-07), unchanged since.

## Code changes

`base.py:118` paired `email.utils.parsedate`, which **discards** the header's time zone, with
`time.mktime`, which reads a `struct_time` as **local** time. So the mtime written onto a fetched
file is off by the build machine's UTC offset. Measured here for
`Last-Modified: Wed, 01 Jan 2020 00:00:00 GMT` (true epoch `1577836800`):

```
TZ=UTC                mktime = 1577836800    delta      0 s
TZ=America/Toronto    mktime = 1577854800    delta +18000 s
TZ=Australia/Sydney   mktime = 1577797200    delta -39600 s
TZ=Europe/Paris       mktime = 1577833200    delta  -3600 s
```

`TZ=UTC` is exactly right, which is why CI never sees this — GitHub runners are UTC.

Second defect in the same three lines: `parsedate` returns `None` for a header it cannot read, and
`time.mktime(None)` raises `TypeError: Tuple or struct_time argument required`, which aborts the
build rather than skipping the timestamp.

`parsedate_tz` / `mktime_tz` is the time-zone-aware stdlib pair: it returns a UTC epoch, honours an
explicit non-GMT offset, and returns `None` instead of raising. Reachable through
`FederatedExtensionAddon.resolve_one_extension`, which calls `fetch_one` for any
`federated_extensions` entry given as an `http(s)://` URL.

`fetch_one` had no tests, which is why neither defect was visible; the new `test_fetch.py` pins the
mtime across three time zones, one explicit-offset header, and the missing/unparsable cases.

## Measurements

`pytest jupyterlite_core/tests/test_fetch.py -q`, source marker asserted and printed before each
run:

* patched: **6 passed**
* mutant A, revert `base.py` only: **4 failed / 2 passed**. The two that pass are the `UTC` case and
  the no-header case, i.e. the test is discriminating rather than trivially failing.
* mutant B, the naive fix (`calendar.timegm(email.utils.parsedate(...))`, time zone only):
  **2 failed / 4 passed** — the explicit-offset header and the unparsable header still fail.

Wider suite, same command and env both times: on the modules that run without a built app archive
(`test_extend_addon.py`, `test_meta.py`) `main` here is **3 failed / 2 passed** and this branch is
the same 3 failures, plus `test_fetch.py`, at **3 failed / 8 passed**. Those 3 are pre-existing on
an unmodified checkout — `RuntimeError: No app archive found`, because I have not run `jlpm build`.
The rest of the Python suite needs that archive and was **not** run; neither were the UI tests. I am
not claiming CI is green — nothing has run upstream yet.

`ruff` 0.16.0 (the version pinned in `.pre-commit-config.yaml`) `check` and `format --check` both
pass. `import time` is now unused in `base.py` and was removed.

## User-facing changes

None visible in the UI. A fetched extension archive now carries the mtime the server reported.

## Backwards-incompatible changes

None.

---

Written with AI assistance (Claude); the measurements above were run locally on this branch.
