### PR TITLE
Fix directory recreation bug

### DIFF
--- a/packages/services/src/contents/drivecontents.ts
+++ b/packages/services/src/contents/drivecontents.ts
@@ -192,7 +192,13 @@ export class DriveContentsProcessor implements IDriveContentsProcessor {
   }
 
   async getattr(request: TDriveRequest<'getattr'>): Promise<TDriveResponse<'getattr'>> {
-    const model = await this.contentsManager.get(request.path);
+    let model: Contents.IModel;
+    try {
+      model = await this.contentsManager.get(request.path);
+    } catch {
+      return null;
+    }
+
     // create a default date for drives that send incomplete information
     // for nested foldes and files
     const defaultDate = new Date(0).toISOString();
@@ -205,7 +211,7 @@ export class DriveContentsProcessor implements IDriveContentsProcessor {
       rdev: 0,
       size: model.size || 0,
       blksize: BLOCK_SIZE,
-      blocks: Math.ceil(model.size || 0 / BLOCK_SIZE),
+      blocks: Math.ceil((model.size || 0) / BLOCK_SIZE),
       atime: model.last_modified || defaultDate, // TODO Get the proper atime?
       mtime: model.last_modified || defaultDate,
       ctime: model.created || defaultDate,

--- a/packages/services/src/contents/drivefs.ts
+++ b/packages/services/src/contents/drivefs.ts
@@ -101,7 +101,7 @@ type TDriveResponses = {
   getmode: number;
   lookup: DriveFS.ILookup;
   mknod: null;
-  getattr: IStats;
+  getattr: IStats | null;
   get: {
     /**
      * The returned file content
@@ -567,6 +567,10 @@ export abstract class ContentsAPI {
       path: this.normalizePath(path),
     });
 
+    if (!stats) {
+      throw new this.FS.ErrnoError(this.ERRNO_CODES['ENOENT']);
+    }
+
     // Emscripten 4.0.9+ (used by Pyodide 0.28+) requires all three timestamps
     // to be valid Date objects with .getTime() method (see https://github.com/emscripten-core/emscripten/pull/22998).
     // Fallback to epoch if any timestamp is missing/null/undefined.
@@ -677,6 +681,8 @@ export class DriveFS {
 
     this.node_ops = new DriveFSEmscriptenNodeOps(this);
     this.stream_ops = new DriveFSEmscriptenStreamOps(this);
+
+    this._hookMayCreate();
   }
 
   node_ops: IEmscriptenNodeOps;
@@ -733,6 +739,40 @@ export class DriveFS {
     parts.reverse();
 
     return this.PATH.join.apply(null, parts);
+  }
+
+  /**
+   * Wrap `FS.mayCreate` so that it does not report `EEXIST` for a path which
+   * has been deleted from the drive by another browsing context.
+   *
+   * Creating a path (`FS.mkdir`, `FS.mknod`) only consults the Emscripten node
+   * cache, so a node deleted from the file browser is still found there and
+   * makes the creation fail without any drive request being sent.
+   */
+  private _hookMayCreate(): void {
+    const FS = this.FS;
+    const { destroyNode, lookupNode, mayCreate } = FS;
+
+    if (!destroyNode || !lookupNode || !mayCreate) {
+      return;
+    }
+
+    FS.mayCreate = (dir: IEmscriptenFSNode, name: string): number => {
+      const errCode = mayCreate.call(FS, dir, name);
+
+      if (
+        errCode !== this.ERRNO_CODES['EEXIST'] ||
+        dir.node_ops !== this.node_ops ||
+        this.API.lookup(this.PATH.join2(this.realPath(dir), name)).ok
+      ) {
+        return errCode;
+      }
+
+      // The cached node no longer exists on the drive: forget about it so that
+      // the path can be created again.
+      destroyNode.call(FS, lookupNode.call(FS, dir, name));
+      return mayCreate.call(FS, dir, name);
+    };
   }
 }
 

--- a/packages/services/src/contents/drivefs.ts
+++ b/packages/services/src/contents/drivefs.ts
@@ -742,12 +742,8 @@ export class DriveFS {
   }
 
   /**
-   * Wrap `FS.mayCreate` so that it does not report `EEXIST` for a path which
-   * has been deleted from the drive by another browsing context.
-   *
-   * Creating a path (`FS.mkdir`, `FS.mknod`) only consults the Emscripten node
-   * cache, so a node deleted from the file browser is still found there and
-   * makes the creation fail without any drive request being sent.
+   * Wrap `FS.mayCreate` to delete stale cached nodes when recreating a path
+   * deleted externally (e.g. from the UI file browser).
    */
   private _hookMayCreate(): void {
     const FS = this.FS;
@@ -768,8 +764,7 @@ export class DriveFS {
         return errCode;
       }
 
-      // The cached node no longer exists on the drive: forget about it so that
-      // the path can be created again.
+      // destroy stale node and retry creation
       destroyNode.call(FS, lookupNode.call(FS, dir, name));
       return mayCreate.call(FS, dir, name);
     };

--- a/packages/services/src/contents/emscripten.ts
+++ b/packages/services/src/contents/emscripten.ts
@@ -142,6 +142,20 @@ export type FS = EmscriptenFS & {
     mode: number,
     dev: number,
   ) => IEmscriptenFSNode;
+  /**
+   * Remove a node from the FS.nameTable cache
+   */
+  destroyNode?: (node: IEmscriptenFSNode) => void;
+
+  /**
+   * Look a child node up, in the node cache first and then through node_ops
+   */
+  lookupNode?: (parent: IEmscriptenFSNode, name: string) => IEmscriptenFSNode;
+
+  /**
+   * Return the error code preventing name from being created in dir or 0.
+   */
+  mayCreate?: (dir: IEmscriptenFSNode, name: string) => number;
 };
 
 /**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ lint = [
 
 # An example downstream kernel
 pyodide-kernel = [
-    "jupyterlite-pyodide-kernel @ https://jupyterlite-pyodide-kernel--338.org.readthedocs.build/en/338/_static/jupyterlite_pyodide_kernel-0.9.0a1-py3-none-any.whl ; sys_platform != 'emscripten'",
+    "jupyterlite-pyodide-kernel[lock] @ https://jupyterlite-pyodide-kernel--338.org.readthedocs.build/en/338/_static/jupyterlite_pyodide_kernel-0.9.0a1-py3-none-any.whl ; sys_platform != 'emscripten'",
 ]
 
 ## Documentation build platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ lint = [
 
 # An example downstream kernel
 pyodide-kernel = [
-    "jupyterlite-pyodide-kernel[lock] >=0.9.0a1; sys_platform != 'emscripten'",
+    "jupyterlite-pyodide-kernel @ https://jupyterlite-pyodide-kernel--338.org.readthedocs.build/en/338/_static/jupyterlite_pyodide_kernel-0.9.0a1-py3-none-any.whl ; sys_platform != 'emscripten'",
 ]
 
 ## Documentation build platform

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -8,8 +8,11 @@ import { test } from '@jupyterlab/galata';
 import { expect } from '@playwright/test';
 
 import {
+  deleteItem,
   firefoxWaitForApplication,
+  isDirectoryListedInBrowser,
   notebooksWaitForApplication,
+  refreshFilebrowser,
   uploadFiles,
 } from './utils';
 
@@ -566,6 +569,39 @@ test.describe('Kernels', () => {
     // Expect all cells to have cleared execution status
     const idleCells = page.locator('.jp-InputArea-prompt >> text="[ ]:"');
     expect(idleCells).toHaveCount(5);
+  });
+
+  test('Recreate a directory in the kernel after deletion in the file browser', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+
+    await page.goto('lab/index.html');
+    await page.notebook.createNew();
+
+    const dirName = 'test_dir';
+
+    // Create a directory via Python
+    await page.notebook.setCell(
+      0,
+      'code',
+      `import os\nos.mkdir("${dirName}")\nprint("created")`,
+    );
+    await page.notebook.run();
+    let output = await page.notebook.getCellTextOutput(0);
+    expect(output?.[0]?.trim()).toBe('created');
+
+    // Delete the directory in the file browser UI
+    await refreshFilebrowser({ page });
+    await deleteItem({ page, name: dirName });
+    await refreshFilebrowser({ page });
+    expect(await isDirectoryListedInBrowser({ page, name: dirName })).toBeFalsy();
+
+    // Recreate the directory via Python (should succeed without EEXIST)
+    await page.notebook.addCell('code', `os.mkdir("${dirName}")\nprint("recreated")`);
+    await page.notebook.runCell(1);
+    output = await page.notebook.getCellTextOutput(1);
+    expect(output?.[0]?.trim()).toBe('recreated');
   });
 });
 

--- a/ui-tests/test/kernels.spec.ts
+++ b/ui-tests/test/kernels.spec.ts
@@ -577,7 +577,7 @@ test.describe('Kernels', () => {
     test.setTimeout(120000);
 
     await page.goto('lab/index.html');
-    await page.notebook.createNew();
+    await page.notebook.open('empty.ipynb');
 
     const dirName = 'test_dir';
 


### PR DESCRIPTION
## References

This fixes an issue where if you create a directory from the terminal (using cockle/jupyterlite-terminal), then delete it through the file browser UI, trying to recreate it in the terminal throws an error and causes the shell to hang indefinitely.
A very similar bug happens when using a Python notebook instead of the terminal to create directories.
This PR has two separate fixes for both cases.

## Code changes

- **`DriveFS._hookMayCreate`**: Wrapped Emscripten's internal `FS.mayCreate` to intercept `EEXIST` errors on `DriveFS` mounts. If Emscripten's in-memory node cache (`FS.nameTable`) reports `EEXIST` even though the path no longer exists on the drive, this stale node is purged via `FS.destroyNode` and creation is retried.
- **`DriveContentsProcessor.getattr`**: Wrapped the logic in a `try...catch` block to catch missing path rejections from `contentsManager.get` to return `null` instead of an unhandled Promise rejection (which is what previously caused the terminal to hang indefinitely). 
  Also fixed an operator precedence bug for the `blocks` calculation:
  - Before: `blocks: Math.ceil(model.size || 0 / BLOCK_SIZE)` (evaluated as `model.size || 0` since `/` has higher precedence than `||`)
  - After: `blocks: Math.ceil((model.size || 0) / BLOCK_SIZE)`
- **`ContentsAPI.getattr`**: Updated to throw POSIX `ENOENT` when the drive responds with `null`.
- **`emscripten.ts`**: Added typed definitions for Emscripten's internal `destroyNode`, `lookupNode`, and `mayCreate` methods on `FS`.

## User-facing changes

Users can now recreate directories in kernels (for example using Pyodide and `os.mkdir()` in a Python notebook) or cockle terminal sessions without running into `FileExistsError: [Errno 20] File exists` after having deleted the directory from the JupyterLite UI file browser.

## Backwards-incompatible changes

None.

## Screencast

[Screencast From 2026-09-01 18-11-27.webm](https://github.com/user-attachments/assets/0a21dc3d-c58d-4d10-97fb-7fda12bdc071)

