### PR TITLE
docs: contents added after the build need contentsAllJsonFile set

### DIFF
--- a/app/jupyterlite.schema.v0.json
+++ b/app/jupyterlite.schema.v0.json
@@ -110,6 +110,14 @@
           "type": "string",
           "default": "JupyterLite Storage"
         },
+        "contentsAllJsonFile": {
+          "description": "name of the index file, relative to `api/contents/{dir}/`, listing the contents served from `files/`. Written by `jupyter lite build` when `files/` exists; set it (usually to `all.json`) when contents are added after the build, or no index is read",
+          "type": "string"
+        },
+        "workspacesAllJsonFile": {
+          "description": "name of the index file under `api/workspaces/` listing the workspaces served from the site. Written by `jupyter lite build` when workspaces exist; set it when workspaces are added after the build",
+          "type": "string"
+        },
         "workspacesStorageDrivers": {
           "description": "names of the localforage driver for workspaces, or `null` for the best available",
           "$ref": "#/definitions/localforage-driver-set"

--- a/docs/howto/configure/advanced/hard.md
+++ b/docs/howto/configure/advanced/hard.md
@@ -46,6 +46,8 @@ Open a browser:
 ```
 
 - Paste this JSON in `$YOUR_JUPYTERLITE/api/contents/all.json`
+- Set `"contentsAllJsonFile": "all.json"` under `jupyter-config-data` in
+  `$YOUR_JUPYTERLITE/jupyter-lite.json`; without it the index is never read
 - Copy your files in `$YOUR_JUPYTERLITE/files`
 - Repeat this for every subfolder `:(`
 

--- a/docs/howto/content/files.md
+++ b/docs/howto/content/files.md
@@ -20,13 +20,13 @@ Will be:
 - copied to the built site under `{output-dir}/files/`
   - may have timestamps changed if `--source-date-epoch` is provided.
 - indexed to provide `{output-dir}/api/contents/{subdir?}/all.json`
+- named in `jupyter-lite.json` as `contentsAllJsonFile`, which is what makes the
+  frontend read the index
 
 ```{note}
-If no contents are provided when building the JupyterLite website,
-the following error message might be logged in the browser console and can be safely ignored:
-
-    Failed to load resource: the server responded with a status of 404 (File not found) :8000/api/contents/all.json:1
-
+If contents are added after the build, set `contentsAllJsonFile` yourself. The build
+only writes it when `files/` exists at build time; without it no index is read, no
+request is made and the file browser is silently empty.
 ```
 
 ## Server Contents and Local Contents


### PR DESCRIPTION
## References

Fixes [#2041.](https://github.com/jupyterlite/jupyterlite/issues/2041)

## Code changes

Since 0.8, the frontend reads `api/contents/{dir}/all.json` only when `contentsAllJsonFile` is set in `jupyter-lite.json`, and `jupyter lite build` sets it only when `files/` exists at build time. A site that builds the app once and adds its notebooks afterwards now silently breaks; the key is not in the schema and neither how-to that explain writing `all.json` mentions it.

- `app/jupyterlite.schema.v0.json`: add `contentsAllJsonFile` and `workspacesAllJsonFile`. The frontend reads both and the build addons write both, but the schema did not list them.
- `docs/howto/configure/advanced/hard.md`: the hand-written `all.json` recipe now sets the key, without which that recipe has not worked since 0.8.
- `docs/howto/content/files.md`: say the build writes the key, and drop the note about a 404 that "can be safely ignored". 0.8 removed that request, so the 404 no longer occurs.


## User-facing changes

Documentation and schema only. The two keys now validate and autocomplete in `jupyter-lite.json`.

## Backwards-incompatible changes

None.