### PR TITLE
Fix the plugin IDs of `@jupyterlite/apputils-extension`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -3,6 +3,33 @@
 This guide provides an overview of major (potentially breaking) changes and the steps to
 follow to update JupyterLite from one version to another.
 
+## `v0.8.0` to `v0.9.0`
+
+### Plugin IDs in `@jupyterlite/apputils-extension`
+
+The following plugins provided by the `@jupyterlite/apputils-extension` package were
+registered with a `@jupyterlite/application-extension:` prefix. They now use the
+`@jupyterlite/apputils-extension:` prefix, to match the package providing them:
+
+- `@jupyterlite/apputils-extension:licenses-client`
+- `@jupyterlite/apputils-extension:plugin-manager`
+- `@jupyterlite/apputils-extension:resolver`
+- `@jupyterlite/apputils-extension:translator-connector`
+- `@jupyterlite/apputils-extension:workspaces`
+
+If you were disabling or deferring any of these plugins in a custom `jupyter-lite.json`
+file, you will need to update the plugin IDs as follows:
+
+```diff
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+-   "disabledExtensions": ["@jupyterlite/application-extension:plugin-manager"]
++   "disabledExtensions": ["@jupyterlite/apputils-extension:plugin-manager"]
+  }
+}
+```
+
 ## `v0.7.0` to `v0.8.0`
 
 ### Extensions

--- a/packages/apputils-extension/src/index.tsx
+++ b/packages/apputils-extension/src/index.tsx
@@ -52,7 +52,7 @@ namespace CommandIDs {
  * The client for fetching licenses data.
  */
 const licensesClient: JupyterFrontEndPlugin<ILicensesClient> = {
-  id: '@jupyterlite/application-extension:licenses-client',
+  id: '@jupyterlite/apputils-extension:licenses-client',
   description: 'Provides the client for fetching license data.',
   autoStart: true,
   provides: ILicensesClient,
@@ -65,7 +65,7 @@ const licensesClient: JupyterFrontEndPlugin<ILicensesClient> = {
  * A plugin for managing the status of other plugins.
  */
 export const pluginManagerPlugin: JupyterFrontEndPlugin<IPluginManager> = {
-  id: '@jupyterlite/application-extension:plugin-manager',
+  id: '@jupyterlite/apputils-extension:plugin-manager',
   description: 'Plugin manager viewer',
   autoStart: true,
   optional: [JupyterLab.IInfo, ITranslator, ICommandPalette],
@@ -158,7 +158,7 @@ export const pluginManagerPlugin: JupyterFrontEndPlugin<IPluginManager> = {
  * The main translator connector plugin.
  */
 const translatorConnector: JupyterFrontEndPlugin<ITranslatorConnector> = {
-  id: '@jupyterlite/application-extension:translator-connector',
+  id: '@jupyterlite/apputils-extension:translator-connector',
   description: 'Provides the application translation connector.',
   autoStart: true,
   provides: ITranslatorConnector,
@@ -173,7 +173,7 @@ const translatorConnector: JupyterFrontEndPlugin<ITranslatorConnector> = {
  * This adds a dependency on `IWorkspaceRouter`
  */
 const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
-  id: '@jupyterlite/application-extension:resolver',
+  id: '@jupyterlite/apputils-extension:resolver',
   description: 'Provides the default window name resolver.',
   autoStart: true,
   provides: IWindowResolver,
@@ -218,7 +218,7 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
  * A custom plugin for workspace files and commands
  */
 const workspaces: JupyterFrontEndPlugin<IWorkspaceRouter> = {
-  id: '@jupyterlite/application-extension:workspaces',
+  id: '@jupyterlite/apputils-extension:workspaces',
   description: 'Handles workspace URL routing.',
   requires: [ILiteRouter],
   autoStart: true,


### PR DESCRIPTION

## References

As noticed in https://github.com/jupyterlab/jupyterlab/pull/19627#pullrequestreview-5178222861

## Code changes

- [x] Fix naming of some plugins
- [x] Mention in the 0.9.0 migration guide

## User-facing changes

Normally none, except if some of these plugins were explicitly referenced for example in `disabledExtensions`.

## Backwards-incompatible changes

None
